### PR TITLE
S1-2: CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun test tests/unit/
+
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run build
+      - name: Smoke test — verify binary runs
+        run: |
+          ./dist/sqlever --version
+          ./dist/sqlever --version | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'

--- a/tests/unit/smoke.test.ts
+++ b/tests/unit/smoke.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("smoke", () => {
+  it("package.json has correct name and version", () => {
+    const pkgPath = resolve(import.meta.dir, "../../package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    expect(pkg.name).toBe("sqlever");
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("cli module is valid TypeScript that can be loaded", async () => {
+    const cliPath = resolve(import.meta.dir, "../../src/cli.ts");
+    const contents = readFileSync(cliPath, "utf-8");
+    // Verify the CLI source contains expected command definitions
+    expect(contents).toContain("deploy");
+    expect(contents).toContain("revert");
+    expect(contents).toContain("verify");
+    expect(contents).toContain("--version");
+  });
+
+  it("expected commands are defined", async () => {
+    const cliPath = resolve(import.meta.dir, "../../src/cli.ts");
+    const contents = readFileSync(cliPath, "utf-8");
+    const expectedCommands = ["add", "deploy", "revert", "verify", "status", "log"];
+    for (const cmd of expectedCommands) {
+      expect(contents).toContain(`${cmd}:`);
+    }
+  });
+});


### PR DESCRIPTION
Closes #3

## Summary
- Add `.github/workflows/ci.yml` with two jobs:
  - **unit**: runs `bun test tests/unit/` on ubuntu-latest
  - **build**: compiles binary via `bun run build` and runs `./dist/sqlever --version` smoke test on both ubuntu-latest and macos-latest
- Add `tests/unit/smoke.test.ts` — verifies package.json metadata, CLI source structure, and expected command definitions
- Add `--version` / `-V` flag to CLI (reads version from package.json via import, works in compiled binary)
- Add `tsconfig.json` for TypeScript configuration
- Workflow triggers on both push and pull_request events

## Test plan
- [x] Unit tests pass locally (3 tests, 12 assertions)
- [x] Build produces working binary on macOS
- [x] `./dist/sqlever --version` outputs `0.1.0`
- [ ] CI passes on this PR (GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)