### PR TITLE
S1-9: Signal handling

### DIFF
--- a/src/signals.ts
+++ b/src/signals.ts
@@ -1,0 +1,104 @@
+// Signal handling — graceful shutdown on SIGINT/SIGTERM
+// See SPEC.md DD13: advisory lock release on all exit paths
+
+type CleanupFn = () => void | Promise<void>;
+
+export class ShutdownManager {
+  private shuttingDown = false;
+  private cleanupCallbacks: CleanupFn[] = [];
+  private signalReceived: "SIGINT" | "SIGTERM" | null = null;
+  private quiet = false;
+
+  /**
+   * Register SIGINT and SIGTERM handlers on the process.
+   * Call this once at startup, before any database operations.
+   *
+   * @param options.quiet — suppress "Shutting down..." message
+   * @param options.process_ — process object (for testing)
+   */
+  register(options?: {
+    quiet?: boolean;
+    process_?: NodeJS.Process;
+  }): void {
+    const proc = options?.process_ ?? process;
+    this.quiet = options?.quiet ?? false;
+
+    const handler = (signal: "SIGINT" | "SIGTERM") => {
+      if (this.shuttingDown) {
+        // Second signal — force exit immediately
+        proc.exit(signal === "SIGINT" ? 130 : 143);
+        return; // unreachable, but satisfies control flow
+      }
+
+      this.shuttingDown = true;
+      this.signalReceived = signal;
+
+      if (!this.quiet) {
+        // Write directly to stderr to avoid buffering issues during shutdown
+        proc.stderr.write("Shutting down...\n");
+      }
+
+      const exitCode = signal === "SIGINT" ? 130 : 143;
+
+      this.runCleanup()
+        .catch(() => {
+          // Cleanup errors should not prevent exit.
+          // The safety net (PG disconnects on process exit) handles
+          // anything we miss here.
+        })
+        .finally(() => {
+          proc.exit(exitCode);
+        });
+    };
+
+    proc.on("SIGINT", () => handler("SIGINT"));
+    proc.on("SIGTERM", () => handler("SIGTERM"));
+  }
+
+  /**
+   * Register a cleanup callback to run during graceful shutdown.
+   * Callbacks run in registration order. Each callback should be
+   * short-lived and async-safe (no user interaction, no long waits).
+   *
+   * Typical uses:
+   *   - Roll back in-flight transaction
+   *   - Release advisory lock (pg_advisory_unlock)
+   *   - Close database connection
+   */
+  onShutdown(fn: CleanupFn): void {
+    this.cleanupCallbacks.push(fn);
+  }
+
+  /**
+   * Returns true once the first signal has been received and shutdown
+   * is in progress. Long-running operations should check this to
+   * bail out early.
+   */
+  isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
+
+  /**
+   * Run all registered cleanup callbacks sequentially.
+   * Errors in individual callbacks are caught so that subsequent
+   * callbacks still run.
+   */
+  private async runCleanup(): Promise<void> {
+    for (const fn of this.cleanupCallbacks) {
+      try {
+        await fn();
+      } catch {
+        // Swallow — best-effort cleanup. PG disconnect is the safety net.
+      }
+    }
+  }
+}
+
+/**
+ * Singleton instance for the application. Import and use directly:
+ *
+ *   import { shutdownManager } from "./signals";
+ *   shutdownManager.register();
+ *   shutdownManager.onShutdown(async () => { await db.end(); });
+ */
+export const shutdownManager = new ShutdownManager();

--- a/tests/unit/signals.test.ts
+++ b/tests/unit/signals.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+import { ShutdownManager } from "../../src/signals";
+import { EventEmitter } from "events";
+
+/**
+ * Create a mock process object that supports signal listeners and
+ * tracks exit() calls and stderr writes, without affecting the real
+ * process.
+ */
+function createMockProcess() {
+  const emitter = new EventEmitter();
+  const exits: number[] = [];
+  const stderrWrites: string[] = [];
+
+  const mock = Object.assign(emitter, {
+    exit: (code: number) => {
+      exits.push(code);
+    },
+    stderr: {
+      write: (msg: string) => {
+        stderrWrites.push(msg);
+        return true;
+      },
+    },
+  }) as unknown as NodeJS.Process;
+
+  return { mock, exits, stderrWrites };
+}
+
+describe("ShutdownManager", () => {
+  let manager: ShutdownManager;
+
+  beforeEach(() => {
+    manager = new ShutdownManager();
+  });
+
+  it("isShuttingDown() returns false initially", () => {
+    expect(manager.isShuttingDown()).toBe(false);
+  });
+
+  it("registers SIGINT and SIGTERM handlers", () => {
+    const { mock } = createMockProcess();
+    manager.register({ process_: mock });
+
+    expect(mock.listenerCount("SIGINT")).toBe(1);
+    expect(mock.listenerCount("SIGTERM")).toBe(1);
+  });
+
+  it("sets shutting-down flag on first SIGINT", async () => {
+    const { mock } = createMockProcess();
+    manager.register({ process_: mock });
+
+    mock.emit("SIGINT");
+
+    // Allow microtask (cleanup promise) to settle
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(manager.isShuttingDown()).toBe(true);
+  });
+
+  it("exits with code 130 on SIGINT", async () => {
+    const { mock, exits } = createMockProcess();
+    manager.register({ process_: mock });
+
+    mock.emit("SIGINT");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(exits).toContain(130);
+  });
+
+  it("exits with code 143 on SIGTERM", async () => {
+    const { mock, exits } = createMockProcess();
+    manager.register({ process_: mock });
+
+    mock.emit("SIGTERM");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(exits).toContain(143);
+  });
+
+  it("prints 'Shutting down...' on first signal", async () => {
+    const { mock, stderrWrites } = createMockProcess();
+    manager.register({ process_: mock });
+
+    mock.emit("SIGINT");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(stderrWrites).toContain("Shutting down...\n");
+  });
+
+  it("suppresses message in quiet mode", async () => {
+    const { mock, stderrWrites } = createMockProcess();
+    manager.register({ quiet: true, process_: mock });
+
+    mock.emit("SIGINT");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(stderrWrites).toHaveLength(0);
+  });
+
+  it("runs cleanup callbacks on shutdown", async () => {
+    const { mock } = createMockProcess();
+    const called: string[] = [];
+
+    manager.register({ process_: mock });
+    manager.onShutdown(() => {
+      called.push("first");
+    });
+    manager.onShutdown(async () => {
+      called.push("second");
+    });
+
+    mock.emit("SIGTERM");
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(called).toEqual(["first", "second"]);
+  });
+
+  it("continues cleanup when a callback throws", async () => {
+    const { mock, exits } = createMockProcess();
+    const called: string[] = [];
+
+    manager.register({ process_: mock });
+    manager.onShutdown(() => {
+      called.push("before-error");
+    });
+    manager.onShutdown(() => {
+      throw new Error("cleanup failed");
+    });
+    manager.onShutdown(() => {
+      called.push("after-error");
+    });
+
+    mock.emit("SIGINT");
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(called).toEqual(["before-error", "after-error"]);
+    expect(exits).toContain(130);
+  });
+
+  it("force-exits on second signal (double Ctrl+C)", async () => {
+    const { mock, exits } = createMockProcess();
+
+    // Register a slow cleanup so the first signal is still processing
+    manager.register({ process_: mock });
+    manager.onShutdown(
+      () => new Promise((r) => setTimeout(r, 500)),
+    );
+
+    // First signal — starts cleanup
+    mock.emit("SIGINT");
+    // Give just enough time for the flag to be set but cleanup is still running
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(manager.isShuttingDown()).toBe(true);
+    // First signal hasn't exited yet (cleanup is still running)
+    expect(exits).toHaveLength(0);
+
+    // Second signal — force exit
+    mock.emit("SIGINT");
+
+    // The second signal triggers synchronous exit(130)
+    expect(exits).toEqual([130]);
+  });
+
+  it("force-exits with 143 on double SIGTERM", async () => {
+    const { mock, exits } = createMockProcess();
+
+    manager.register({ process_: mock });
+    manager.onShutdown(
+      () => new Promise((r) => setTimeout(r, 500)),
+    );
+
+    mock.emit("SIGTERM");
+    await new Promise((r) => setTimeout(r, 10));
+
+    mock.emit("SIGTERM");
+
+    expect(exits).toEqual([143]);
+  });
+
+  it("can register callbacks before register()", () => {
+    const { mock } = createMockProcess();
+    const called: string[] = [];
+
+    // Register callback before calling register()
+    manager.onShutdown(() => {
+      called.push("early");
+    });
+
+    manager.register({ process_: mock });
+
+    mock.emit("SIGINT");
+    // Use a longer timeout to allow async cleanup
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(called).toEqual(["early"]);
+        resolve();
+      }, 50);
+    });
+  });
+});


### PR DESCRIPTION
Closes #10

## Summary
- Add `src/signals.ts` with `ShutdownManager` class for graceful shutdown on SIGINT/SIGTERM
- First signal: sets shutting-down flag, prints "Shutting down..." (unless quiet mode), runs registered cleanup callbacks in order, exits with POSIX code (130 for SIGINT, 143 for SIGTERM)
- Second signal: force-exits immediately with the appropriate code
- Cleanup callbacks are async-safe — errors in individual callbacks are caught so subsequent callbacks still run
- Exports a singleton `shutdownManager` for application-wide use
- Independent module — no dependencies on other project modules

## Test plan
- [x] `isShuttingDown()` returns false initially
- [x] Registers SIGINT and SIGTERM handlers on the process
- [x] Sets shutting-down flag on first signal
- [x] Exits with code 130 on SIGINT, 143 on SIGTERM
- [x] Prints "Shutting down..." on first signal
- [x] Suppresses message in quiet mode
- [x] Runs cleanup callbacks in registration order
- [x] Continues cleanup when a callback throws
- [x] Force-exits on second signal (double Ctrl+C / double SIGTERM)
- [x] Callbacks registered before `register()` still run
- [x] All 12 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)