### PR TITLE
S1-4: Output module

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -1,0 +1,155 @@
+// src/output.ts — Shared output helpers for sqlever CLI
+//
+// All CLI output flows through this module so that --quiet, --verbose,
+// and --format flags are respected consistently.
+
+export type OutputFormat = "text" | "json";
+
+export interface OutputConfig {
+  format: OutputFormat;
+  quiet: boolean;
+  verbose: boolean;
+}
+
+let config: OutputConfig = {
+  format: "text",
+  quiet: false,
+  verbose: false,
+};
+
+/** Replace the global output config. */
+export function setConfig(next: Partial<OutputConfig>): void {
+  config = { ...config, ...next };
+}
+
+/** Return a copy of the current config (useful for tests). */
+export function getConfig(): OutputConfig {
+  return { ...config };
+}
+
+/** Reset config to defaults (useful for tests). */
+export function resetConfig(): void {
+  config = { format: "text", quiet: false, verbose: false };
+}
+
+// ---------------------------------------------------------------------------
+// Core output functions
+// ---------------------------------------------------------------------------
+
+/** Print an informational message to stdout. Suppressed by --quiet. */
+export function info(msg: string): void {
+  if (config.quiet) return;
+  process.stdout.write(msg + "\n");
+}
+
+/** Print an error message to stderr. Always shown. */
+export function error(msg: string): void {
+  process.stderr.write(msg + "\n");
+}
+
+/** Print a verbose/debug message to stderr. Only shown with --verbose. */
+export function verbose(msg: string): void {
+  if (!config.verbose) return;
+  process.stderr.write(msg + "\n");
+}
+
+/** Print structured data as JSON to stdout. Intended for --format json. */
+export function json(data: unknown): void {
+  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Table output
+// ---------------------------------------------------------------------------
+
+/**
+ * Print an aligned text table to stdout.
+ *
+ * @param rows  - Array of objects (each row) or array of arrays.
+ * @param headers - Column headers. When rows are objects, headers also
+ *                  serve as the keys to extract from each row.
+ *
+ * Respects --quiet (suppressed) and --format json (emits JSON instead).
+ */
+export function table(
+  rows: Record<string, unknown>[] | string[][],
+  headers: string[],
+): void {
+  // In JSON mode, emit structured data instead of a text table.
+  if (config.format === "json") {
+    const structured = rows.map((row) => {
+      if (Array.isArray(row)) {
+        const obj: Record<string, unknown> = {};
+        headers.forEach((h, i) => {
+          obj[h] = row[i] ?? null;
+        });
+        return obj;
+      }
+      return row;
+    });
+    json(structured);
+    return;
+  }
+
+  if (config.quiet) return;
+
+  // Normalize rows to string arrays.
+  const stringRows: string[][] = rows.map((row) => {
+    if (Array.isArray(row)) return row.map(String);
+    return headers.map((h) => String(row[h] ?? ""));
+  });
+
+  // Compute column widths.
+  const widths = headers.map((h) => h.length);
+  for (const row of stringRows) {
+    for (let i = 0; i < headers.length; i++) {
+      const cell = row[i] ?? "";
+      if (cell.length > widths[i]) {
+        widths[i] = cell.length;
+      }
+    }
+  }
+
+  const pad = (s: string, w: number) => s + " ".repeat(Math.max(0, w - s.length));
+
+  // Header line.
+  const headerLine = headers.map((h, i) => pad(h, widths[i])).join("  ");
+  process.stdout.write(headerLine + "\n");
+
+  // Separator line.
+  const separator = widths.map((w) => "-".repeat(w)).join("  ");
+  process.stdout.write(separator + "\n");
+
+  // Data lines.
+  for (const row of stringRows) {
+    const line = headers.map((_, i) => pad(row[i] ?? "", widths[i])).join("  ");
+    process.stdout.write(line + "\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// URI masking
+// ---------------------------------------------------------------------------
+
+/**
+ * Mask passwords in database connection URIs.
+ *
+ * Handles schemes like:
+ *   postgresql://user:secret@host/db  ->  postgresql://user:***@host/db
+ *   db:pg://user:secret@host/db       ->  db:pg://user:***@host/db
+ *   postgres://host/db                ->  postgres://host/db  (no password)
+ *
+ * The regex matches:
+ *   (scheme://)(user):(password)(@host...)
+ * and replaces the password portion with ***.
+ */
+export function maskUri(uri: string): string {
+  // Match scheme (including compound schemes like "db:pg"), then "://",
+  // then "user:password@" where password is everything between the first
+  // colon after :// and the LAST @ sign before the host (to handle
+  // passwords containing @).
+  return uri.replace(
+    /^([a-zA-Z][a-zA-Z0-9+.:~-]*:\/\/)([^:@/]+):(.+)@(?=[^@]*$)/,
+    "$1$2:***@",
+  );
+}

--- a/tests/unit/output.test.ts
+++ b/tests/unit/output.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import {
+  setConfig,
+  getConfig,
+  resetConfig,
+  info,
+  error,
+  verbose,
+  json,
+  table,
+  maskUri,
+} from "../../src/output";
+
+// ---------------------------------------------------------------------------
+// Helpers — capture stdout / stderr writes
+// ---------------------------------------------------------------------------
+
+function captureWrites() {
+  let stdout = "";
+  let stderr = "";
+
+  const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+    (chunk: string | Uint8Array) => {
+      stdout += String(chunk);
+      return true;
+    },
+  );
+
+  const stderrSpy = spyOn(process.stderr, "write").mockImplementation(
+    (chunk: string | Uint8Array) => {
+      stderr += String(chunk);
+      return true;
+    },
+  );
+
+  return {
+    get stdout() {
+      return stdout;
+    },
+    get stderr() {
+      return stderr;
+    },
+    restore() {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("output module", () => {
+  beforeEach(() => resetConfig());
+
+  describe("setConfig / getConfig / resetConfig", () => {
+    it("returns default config after reset", () => {
+      expect(getConfig()).toEqual({
+        format: "text",
+        quiet: false,
+        verbose: false,
+      });
+    });
+
+    it("merges partial config", () => {
+      setConfig({ quiet: true });
+      expect(getConfig()).toEqual({
+        format: "text",
+        quiet: true,
+        verbose: false,
+      });
+    });
+
+    it("overrides full config", () => {
+      setConfig({ format: "json", quiet: true, verbose: true });
+      expect(getConfig()).toEqual({
+        format: "json",
+        quiet: true,
+        verbose: true,
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // info()
+  // -----------------------------------------------------------------------
+
+  describe("info()", () => {
+    it("writes to stdout", () => {
+      const cap = captureWrites();
+      try {
+        info("hello");
+        expect(cap.stdout).toBe("hello\n");
+        expect(cap.stderr).toBe("");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("is suppressed in quiet mode", () => {
+      setConfig({ quiet: true });
+      const cap = captureWrites();
+      try {
+        info("should not appear");
+        expect(cap.stdout).toBe("");
+      } finally {
+        cap.restore();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // error()
+  // -----------------------------------------------------------------------
+
+  describe("error()", () => {
+    it("writes to stderr", () => {
+      const cap = captureWrites();
+      try {
+        error("oops");
+        expect(cap.stderr).toBe("oops\n");
+        expect(cap.stdout).toBe("");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("is shown even in quiet mode", () => {
+      setConfig({ quiet: true });
+      const cap = captureWrites();
+      try {
+        error("still visible");
+        expect(cap.stderr).toBe("still visible\n");
+      } finally {
+        cap.restore();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // verbose()
+  // -----------------------------------------------------------------------
+
+  describe("verbose()", () => {
+    it("is suppressed by default", () => {
+      const cap = captureWrites();
+      try {
+        verbose("debug info");
+        expect(cap.stderr).toBe("");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("writes to stderr when verbose is enabled", () => {
+      setConfig({ verbose: true });
+      const cap = captureWrites();
+      try {
+        verbose("debug info");
+        expect(cap.stderr).toBe("debug info\n");
+      } finally {
+        cap.restore();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // json()
+  // -----------------------------------------------------------------------
+
+  describe("json()", () => {
+    it("outputs pretty-printed JSON to stdout", () => {
+      const cap = captureWrites();
+      try {
+        json({ key: "value", n: 42 });
+        const parsed = JSON.parse(cap.stdout);
+        expect(parsed).toEqual({ key: "value", n: 42 });
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("handles arrays", () => {
+      const cap = captureWrites();
+      try {
+        json([1, 2, 3]);
+        expect(JSON.parse(cap.stdout)).toEqual([1, 2, 3]);
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("handles null", () => {
+      const cap = captureWrites();
+      try {
+        json(null);
+        expect(cap.stdout).toBe("null\n");
+      } finally {
+        cap.restore();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // table()
+  // -----------------------------------------------------------------------
+
+  describe("table()", () => {
+    it("prints aligned columns with object rows", () => {
+      const cap = captureWrites();
+      try {
+        table(
+          [
+            { name: "Alice", age: 30 },
+            { name: "Bob", age: 7 },
+          ],
+          ["name", "age"],
+        );
+        const lines = cap.stdout.split("\n");
+        expect(lines[0]).toBe("name   age");
+        expect(lines[1]).toBe("-----  ---");
+        expect(lines[2]).toBe("Alice  30 ");
+        expect(lines[3]).toBe("Bob    7  ");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("prints aligned columns with array rows", () => {
+      const cap = captureWrites();
+      try {
+        table(
+          [
+            ["Alice", "30"],
+            ["Bob", "7"],
+          ],
+          ["name", "age"],
+        );
+        const lines = cap.stdout.split("\n");
+        expect(lines[0]).toBe("name   age");
+        expect(lines[1]).toBe("-----  ---");
+        expect(lines[2]).toBe("Alice  30 ");
+        expect(lines[3]).toBe("Bob    7  ");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("handles wide data that exceeds header width", () => {
+      const cap = captureWrites();
+      try {
+        table(
+          [{ id: "1", description: "A very long description here" }],
+          ["id", "description"],
+        );
+        const lines = cap.stdout.split("\n");
+        // "description" is 11 chars, data is 28 chars — data wins.
+        expect(lines[0]).toBe("id  description                 ");
+        expect(lines[2]).toBe("1   A very long description here");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("is suppressed in quiet mode", () => {
+      setConfig({ quiet: true });
+      const cap = captureWrites();
+      try {
+        table([{ a: 1 }], ["a"]);
+        expect(cap.stdout).toBe("");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("outputs JSON in json format mode", () => {
+      setConfig({ format: "json" });
+      const cap = captureWrites();
+      try {
+        table(
+          [
+            { name: "Alice", age: 30 },
+            { name: "Bob", age: 7 },
+          ],
+          ["name", "age"],
+        );
+        const parsed = JSON.parse(cap.stdout);
+        expect(parsed).toEqual([
+          { name: "Alice", age: 30 },
+          { name: "Bob", age: 7 },
+        ]);
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("converts array rows to objects in json format mode", () => {
+      setConfig({ format: "json" });
+      const cap = captureWrites();
+      try {
+        table(
+          [
+            ["Alice", "30"],
+            ["Bob", "7"],
+          ],
+          ["name", "age"],
+        );
+        const parsed = JSON.parse(cap.stdout);
+        expect(parsed).toEqual([
+          { name: "Alice", age: "30" },
+          { name: "Bob", age: "7" },
+        ]);
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("handles empty rows", () => {
+      const cap = captureWrites();
+      try {
+        table([], ["name", "age"]);
+        const lines = cap.stdout.split("\n");
+        expect(lines[0]).toBe("name  age");
+        expect(lines[1]).toBe("----  ---");
+        expect(lines.length).toBe(3); // header + separator + trailing newline
+      } finally {
+        cap.restore();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // maskUri()
+  // -----------------------------------------------------------------------
+
+  describe("maskUri()", () => {
+    it("masks password in postgresql:// URI", () => {
+      expect(maskUri("postgresql://user:secret@host/db")).toBe(
+        "postgresql://user:***@host/db",
+      );
+    });
+
+    it("masks password in postgres:// URI", () => {
+      expect(maskUri("postgres://admin:p4$$w0rd@db.example.com:5432/mydb")).toBe(
+        "postgres://admin:***@db.example.com:5432/mydb",
+      );
+    });
+
+    it("masks password in db:pg:// URI", () => {
+      expect(maskUri("db:pg://user:secret@host/db")).toBe(
+        "db:pg://user:***@host/db",
+      );
+    });
+
+    it("preserves URI without password", () => {
+      expect(maskUri("postgresql://host/db")).toBe("postgresql://host/db");
+    });
+
+    it("preserves URI with user but no password", () => {
+      expect(maskUri("postgresql://user@host/db")).toBe(
+        "postgresql://user@host/db",
+      );
+    });
+
+    it("handles password with special characters", () => {
+      expect(maskUri("postgresql://user:p@ss:word!@host/db")).toBe(
+        "postgresql://user:***@host/db",
+      );
+    });
+
+    it("handles non-URI strings (passthrough)", () => {
+      expect(maskUri("/var/run/postgres")).toBe("/var/run/postgres");
+    });
+
+    it("handles empty string", () => {
+      expect(maskUri("")).toBe("");
+    });
+
+    it("masks password in URI with port", () => {
+      expect(maskUri("postgresql://user:secret@host:5432/db")).toBe(
+        "postgresql://user:***@host:5432/db",
+      );
+    });
+
+    it("masks password in URI with query params", () => {
+      expect(
+        maskUri("postgresql://user:secret@host/db?sslmode=require"),
+      ).toBe("postgresql://user:***@host/db?sslmode=require");
+    });
+  });
+});


### PR DESCRIPTION
Closes #5

## Summary
- Add `src/output.ts` with shared output helpers: `info()`, `error()`, `verbose()`, `json()`, `table()`, `maskUri()`
- `OutputConfig` type controls behavior via `setConfig()` — respects `--quiet`, `--verbose`, and `--format json` flags
- `table()` renders aligned text columns in text mode, emits structured JSON in json mode
- `maskUri()` replaces passwords in connection URIs (handles `postgresql://`, `db:pg://`, passwords with special chars including `@`)
- Comprehensive unit tests (29 tests) covering all modes and edge cases

## Test plan
- [x] `bun test` — 29 tests pass, 40 assertions
- [x] Quiet mode suppresses `info()` and `table()` output
- [x] Verbose mode enables `verbose()` output to stderr
- [x] JSON format mode emits structured data from `table()`
- [x] `error()` always writes to stderr regardless of flags
- [x] URI masking handles: standard URIs, compound schemes (`db:pg://`), passwords with `@`, URIs without password, non-URI strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)