### PR TITLE
S1-8: Validate libpg-query WASM parser with bun build --compile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "sqlever",
       "dependencies": {
+        "libpg-query": "^17.7.3",
         "pg": "^8.11.0",
       },
       "devDependencies": {
@@ -13,9 +14,13 @@
     },
   },
   "packages": {
+    "@pgsql/types": ["@pgsql/types@17.6.2", "", {}, "sha512-1UtbELdbqNdyOShhrVfSz3a1gDi0s9XXiQemx+6QqtsrXe62a6zOGU+vjb2GRfG5jeEokI1zBBcfD42enRv0Rw=="],
+
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "libpg-query": ["libpg-query@17.7.3", "", { "dependencies": { "@pgsql/types": "^17.6.2" } }, "sha512-lHKBvoWRsXt/9bJxpAeFxkLu0CA6tELusqy3o1z6/DwGXSETxhKJDaNlNdrNV8msvXDLBhpg/4RE/fKKs5rYFA=="],
 
     "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bun-types": "latest"
   },
   "dependencies": {
+    "libpg-query": "^17.7.3",
     "pg": "^8.11.0"
   }
 }

--- a/tests/compile-test.ts
+++ b/tests/compile-test.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+/**
+ * Standalone script for testing bun build --compile with libpg-query.
+ * This file is compiled into a single binary and executed to verify
+ * the WASM parser works in the compiled output.
+ */
+import { parse, parseSync, loadModule } from "libpg-query";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+
+async function main() {
+  console.log("=== bun build --compile parser test ===\n");
+
+  // 1. Load WASM module
+  console.log("1. Loading WASM module...");
+  const loadStart = performance.now();
+  await loadModule();
+  console.log(`   OK (${(performance.now() - loadStart).toFixed(1)}ms)\n`);
+
+  // 2. Parse simple SQL
+  console.log("2. Parsing simple SELECT...");
+  const result1 = await parse("SELECT 1 + 2 AS answer");
+  console.log(`   Statements: ${result1.stmts.length}`);
+  console.log(
+    `   Type: ${Object.keys(result1.stmts[0].stmt)[0]}`
+  );
+  console.log("   OK\n");
+
+  // 3. Parse multi-statement SQL
+  console.log("3. Parsing multi-statement SQL...");
+  const multiSql = `
+    CREATE TABLE test (id int PRIMARY KEY, name text);
+    INSERT INTO test (id, name) VALUES (1, 'hello');
+    SELECT * FROM test;
+    DROP TABLE test;
+  `;
+  const result2 = await parse(multiSql);
+  console.log(`   Statements: ${result2.stmts.length}`);
+  const types = result2.stmts.map(
+    (s: any) => Object.keys(s.stmt)[0]
+  );
+  console.log(`   Types: ${types.join(", ")}`);
+  console.log("   OK\n");
+
+  // 4. Parse dollar-quoted function
+  console.log("4. Parsing dollar-quoted CREATE FUNCTION...");
+  const funcSql = `
+    CREATE FUNCTION greet(name text) RETURNS text AS $$
+    BEGIN
+      RETURN 'Hello, ' || name || '!';
+    END;
+    $$ LANGUAGE plpgsql;
+  `;
+  const result3 = await parse(funcSql);
+  console.log(`   Statements: ${result3.stmts.length}`);
+  console.log(
+    `   Type: ${Object.keys(result3.stmts[0].stmt)[0]}`
+  );
+  console.log("   OK\n");
+
+  // 5. parseSync test
+  console.log("5. Testing parseSync...");
+  const result4 = parseSync("SELECT now()");
+  console.log(`   Statements: ${result4.stmts.length}`);
+  console.log("   OK\n");
+
+  // 6. Error handling
+  console.log("6. Testing error handling on invalid SQL...");
+  try {
+    await parse("SELCT 1");
+    console.log("   FAIL: should have thrown");
+    process.exit(1);
+  } catch (e: any) {
+    console.log(`   Caught expected error: ${e.message.substring(0, 60)}...`);
+    console.log("   OK\n");
+  }
+
+  // 7. Benchmark with inline large SQL
+  console.log("7. Benchmark: generating and parsing large SQL...");
+  const stmts: string[] = [];
+  for (let i = 0; i < 100; i++) {
+    stmts.push(`CREATE TABLE t${i} (id int PRIMARY KEY, name text, val numeric DEFAULT ${i});`);
+    stmts.push(`CREATE INDEX idx_t${i}_name ON t${i} (name);`);
+  }
+  const largeSql = stmts.join("\n");
+
+  const times: number[] = [];
+  for (let i = 0; i < 5; i++) {
+    const start = performance.now();
+    const r = await parse(largeSql);
+    times.push(performance.now() - start);
+  }
+  times.sort((a, b) => a - b);
+  const median = times[Math.floor(times.length / 2)];
+  console.log(`   SQL length: ${largeSql.length} chars, ${largeSql.split("\n").length} lines`);
+  console.log(`   Median parse time: ${median.toFixed(2)}ms`);
+  console.log(`   ${median < 200 ? "PASS" : "FAIL"}: ${median < 200 ? "< 200ms target met" : "> 200ms target exceeded"}`);
+  console.log("   OK\n");
+
+  console.log("=== ALL TESTS PASSED ===");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});

--- a/tests/fixtures/edge-cases.sql
+++ b/tests/fixtures/edge-cases.sql
@@ -1,0 +1,126 @@
+-- Edge case SQL fixture for parser spike testing
+-- Tests: multi-statement, dollar-quoting, CREATE FUNCTION, comments, various DDL/DML
+
+-- 1. Simple DDL
+CREATE TABLE users (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    email text NOT NULL UNIQUE,
+    display_name text,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 2. Multi-column index
+CREATE INDEX idx_users_email ON users (email);
+
+-- 3. Another table with FK
+CREATE TABLE posts (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    author_id bigint NOT NULL REFERENCES users(id),
+    title text NOT NULL,
+    body text,
+    published_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 4. Block comment
+/* This is a block comment
+   spanning multiple lines
+   with special characters: '; DROP TABLE users; --
+*/
+
+-- 5. Dollar-quoted string in a function
+CREATE FUNCTION update_modified_column()
+RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 6. Named dollar-quoting
+CREATE FUNCTION complex_function(p_input text)
+RETURNS text AS $fn_body$
+DECLARE
+    v_result text;
+BEGIN
+    -- This is a comment inside a function body
+    v_result := 'Hello, ' || p_input || '!';
+
+    /* Block comment inside function */
+    IF v_result IS NULL THEN
+        v_result := 'default';
+    END IF;
+
+    RETURN v_result;
+END;
+$fn_body$ LANGUAGE plpgsql VOLATILE;
+
+-- 7. CREATE TRIGGER
+CREATE TRIGGER set_updated_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW
+    EXECUTE FUNCTION update_modified_column();
+
+-- 8. ALTER TABLE with multiple subcommands
+ALTER TABLE posts
+    ADD COLUMN updated_at timestamptz,
+    ADD COLUMN slug text;
+
+-- 9. INSERT with multiple rows
+INSERT INTO users (email, display_name) VALUES
+    ('alice@example.com', 'Alice'),
+    ('bob@example.com', 'Bob');
+
+-- 10. CTE (WITH clause)
+WITH active_users AS (
+    SELECT id, email FROM users WHERE created_at > now() - interval '30 days'
+)
+SELECT u.email, count(p.id) AS post_count
+FROM active_users u
+LEFT JOIN posts p ON p.author_id = u.id
+GROUP BY u.email;
+
+-- 11. View creation
+CREATE VIEW recent_posts AS
+SELECT p.id, p.title, u.display_name AS author_name, p.published_at
+FROM posts p
+JOIN users u ON u.id = p.author_id
+WHERE p.published_at > now() - interval '7 days';
+
+-- 12. DO block (anonymous code block)
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'uuid-ossp') THEN
+        CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    END IF;
+END;
+$$;
+
+-- 13. Volatile default (table rewrite on older PG)
+ALTER TABLE users ADD COLUMN uuid uuid DEFAULT gen_random_uuid();
+
+-- 14. GRANT/REVOKE
+GRANT SELECT ON users TO readonly_role;
+REVOKE INSERT ON users FROM public;
+
+-- 15. Complex query with subquery and window function
+SELECT
+    email,
+    display_name,
+    created_at,
+    ROW_NUMBER() OVER (ORDER BY created_at DESC) AS signup_order
+FROM users
+WHERE email LIKE '%@example.com'
+ORDER BY created_at DESC
+LIMIT 10;
+
+-- 16. CREATE TYPE (enum)
+CREATE TYPE post_status AS ENUM ('draft', 'published', 'archived');
+
+-- 17. ALTER TABLE with NOT NULL on existing column (dangerous!)
+ALTER TABLE posts ALTER COLUMN title SET NOT NULL;
+
+-- 18. CREATE INDEX CONCURRENTLY (non-transactional DDL)
+CREATE INDEX CONCURRENTLY idx_posts_published
+ON posts (published_at)
+WHERE published_at IS NOT NULL;

--- a/tests/fixtures/gen-large-fixture.ts
+++ b/tests/fixtures/gen-large-fixture.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+// Generates a ~1000-line SQL fixture for benchmarking parser performance.
+
+const lines: string[] = [];
+
+lines.push("-- Auto-generated 1000-line SQL fixture for benchmark testing");
+lines.push("");
+
+// Generate 50 tables (each ~8 lines = 400 lines)
+for (let i = 1; i <= 50; i++) {
+  lines.push(`CREATE TABLE bench_table_${i} (`);
+  lines.push(`    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,`);
+  lines.push(`    name text NOT NULL,`);
+  lines.push(`    value numeric(12, 2) DEFAULT 0,`);
+  lines.push(`    status text DEFAULT 'active',`);
+  lines.push(`    created_at timestamptz NOT NULL DEFAULT now(),`);
+  lines.push(`    updated_at timestamptz`);
+  lines.push(`);`);
+  lines.push("");
+}
+
+// Generate 50 indexes (50 lines)
+for (let i = 1; i <= 50; i++) {
+  lines.push(`CREATE INDEX idx_bench_table_${i}_name ON bench_table_${i} (name);`);
+}
+lines.push("");
+
+// Generate 20 functions with dollar-quoting (each ~12 lines = 240 lines)
+for (let i = 1; i <= 20; i++) {
+  lines.push(`CREATE OR REPLACE FUNCTION bench_func_${i}(p_id bigint)`);
+  lines.push(`RETURNS void AS $$`);
+  lines.push(`BEGIN`);
+  lines.push(`    UPDATE bench_table_${i} SET updated_at = now() WHERE id = p_id;`);
+  lines.push(`    IF NOT FOUND THEN`);
+  lines.push(`        RAISE NOTICE 'Record % not found in bench_table_${i}', p_id;`);
+  lines.push(`    END IF;`);
+  lines.push(`END;`);
+  lines.push(`$$ LANGUAGE plpgsql;`);
+  lines.push("");
+}
+
+// Generate 20 views with joins (each ~6 lines = 120 lines)
+for (let i = 1; i <= 20; i++) {
+  const j = i + 1 <= 50 ? i + 1 : 1;
+  lines.push(`CREATE VIEW bench_view_${i} AS`);
+  lines.push(`SELECT a.id, a.name, b.value, a.created_at`);
+  lines.push(`FROM bench_table_${i} a`);
+  lines.push(`JOIN bench_table_${j} b ON b.id = a.id`);
+  lines.push(`WHERE a.status = 'active';`);
+  lines.push("");
+}
+
+// Generate 30 ALTER TABLE statements (60 lines)
+for (let i = 1; i <= 30; i++) {
+  lines.push(`ALTER TABLE bench_table_${i} ADD COLUMN extra_col_${i} text;`);
+  lines.push(`ALTER TABLE bench_table_${i} ADD COLUMN score_${i} integer DEFAULT 0;`);
+}
+lines.push("");
+
+// Generate INSERT statements (80 lines)
+for (let i = 1; i <= 20; i++) {
+  lines.push(`INSERT INTO bench_table_${i} (name, value, status) VALUES`);
+  lines.push(`    ('item_a', ${i * 10}.50, 'active'),`);
+  lines.push(`    ('item_b', ${i * 20}.75, 'inactive'),`);
+  lines.push(`    ('item_c', ${i * 30}.00, 'active');`);
+}
+lines.push("");
+
+// Generate GRANT statements (50 lines)
+for (let i = 1; i <= 50; i++) {
+  lines.push(`GRANT SELECT ON bench_table_${i} TO readonly_role;`);
+}
+lines.push("");
+
+// Footer comment
+lines.push(`-- End of generated fixture (${lines.length + 1} lines)`);
+
+const content = lines.join("\n") + "\n";
+const path = new URL("./large-benchmark.sql", import.meta.url).pathname;
+await Bun.write(path, content);
+console.log(`Generated ${path} with ${lines.length} lines`);

--- a/tests/fixtures/large-benchmark.sql
+++ b/tests/fixtures/large-benchmark.sql
@@ -1,0 +1,1017 @@
+-- Auto-generated 1000-line SQL fixture for benchmark testing
+
+CREATE TABLE bench_table_1 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_2 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_3 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_4 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_5 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_6 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_7 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_8 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_9 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_10 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_11 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_12 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_13 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_14 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_15 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_16 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_17 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_18 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_19 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_20 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_21 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_22 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_23 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_24 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_25 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_26 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_27 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_28 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_29 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_30 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_31 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_32 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_33 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_34 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_35 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_36 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_37 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_38 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_39 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_40 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_41 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_42 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_43 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_44 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_45 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_46 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_47 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_48 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_49 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE TABLE bench_table_50 (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    value numeric(12, 2) DEFAULT 0,
+    status text DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz
+);
+
+CREATE INDEX idx_bench_table_1_name ON bench_table_1 (name);
+CREATE INDEX idx_bench_table_2_name ON bench_table_2 (name);
+CREATE INDEX idx_bench_table_3_name ON bench_table_3 (name);
+CREATE INDEX idx_bench_table_4_name ON bench_table_4 (name);
+CREATE INDEX idx_bench_table_5_name ON bench_table_5 (name);
+CREATE INDEX idx_bench_table_6_name ON bench_table_6 (name);
+CREATE INDEX idx_bench_table_7_name ON bench_table_7 (name);
+CREATE INDEX idx_bench_table_8_name ON bench_table_8 (name);
+CREATE INDEX idx_bench_table_9_name ON bench_table_9 (name);
+CREATE INDEX idx_bench_table_10_name ON bench_table_10 (name);
+CREATE INDEX idx_bench_table_11_name ON bench_table_11 (name);
+CREATE INDEX idx_bench_table_12_name ON bench_table_12 (name);
+CREATE INDEX idx_bench_table_13_name ON bench_table_13 (name);
+CREATE INDEX idx_bench_table_14_name ON bench_table_14 (name);
+CREATE INDEX idx_bench_table_15_name ON bench_table_15 (name);
+CREATE INDEX idx_bench_table_16_name ON bench_table_16 (name);
+CREATE INDEX idx_bench_table_17_name ON bench_table_17 (name);
+CREATE INDEX idx_bench_table_18_name ON bench_table_18 (name);
+CREATE INDEX idx_bench_table_19_name ON bench_table_19 (name);
+CREATE INDEX idx_bench_table_20_name ON bench_table_20 (name);
+CREATE INDEX idx_bench_table_21_name ON bench_table_21 (name);
+CREATE INDEX idx_bench_table_22_name ON bench_table_22 (name);
+CREATE INDEX idx_bench_table_23_name ON bench_table_23 (name);
+CREATE INDEX idx_bench_table_24_name ON bench_table_24 (name);
+CREATE INDEX idx_bench_table_25_name ON bench_table_25 (name);
+CREATE INDEX idx_bench_table_26_name ON bench_table_26 (name);
+CREATE INDEX idx_bench_table_27_name ON bench_table_27 (name);
+CREATE INDEX idx_bench_table_28_name ON bench_table_28 (name);
+CREATE INDEX idx_bench_table_29_name ON bench_table_29 (name);
+CREATE INDEX idx_bench_table_30_name ON bench_table_30 (name);
+CREATE INDEX idx_bench_table_31_name ON bench_table_31 (name);
+CREATE INDEX idx_bench_table_32_name ON bench_table_32 (name);
+CREATE INDEX idx_bench_table_33_name ON bench_table_33 (name);
+CREATE INDEX idx_bench_table_34_name ON bench_table_34 (name);
+CREATE INDEX idx_bench_table_35_name ON bench_table_35 (name);
+CREATE INDEX idx_bench_table_36_name ON bench_table_36 (name);
+CREATE INDEX idx_bench_table_37_name ON bench_table_37 (name);
+CREATE INDEX idx_bench_table_38_name ON bench_table_38 (name);
+CREATE INDEX idx_bench_table_39_name ON bench_table_39 (name);
+CREATE INDEX idx_bench_table_40_name ON bench_table_40 (name);
+CREATE INDEX idx_bench_table_41_name ON bench_table_41 (name);
+CREATE INDEX idx_bench_table_42_name ON bench_table_42 (name);
+CREATE INDEX idx_bench_table_43_name ON bench_table_43 (name);
+CREATE INDEX idx_bench_table_44_name ON bench_table_44 (name);
+CREATE INDEX idx_bench_table_45_name ON bench_table_45 (name);
+CREATE INDEX idx_bench_table_46_name ON bench_table_46 (name);
+CREATE INDEX idx_bench_table_47_name ON bench_table_47 (name);
+CREATE INDEX idx_bench_table_48_name ON bench_table_48 (name);
+CREATE INDEX idx_bench_table_49_name ON bench_table_49 (name);
+CREATE INDEX idx_bench_table_50_name ON bench_table_50 (name);
+
+CREATE OR REPLACE FUNCTION bench_func_1(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_1 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_1', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_2(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_2 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_2', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_3(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_3 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_3', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_4(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_4 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_4', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_5(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_5 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_5', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_6(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_6 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_6', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_7(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_7 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_7', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_8(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_8 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_8', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_9(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_9 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_9', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_10(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_10 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_10', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_11(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_11 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_11', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_12(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_12 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_12', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_13(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_13 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_13', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_14(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_14 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_14', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_15(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_15 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_15', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_16(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_16 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_16', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_17(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_17 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_17', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_18(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_18 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_18', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_19(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_19 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_19', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bench_func_20(p_id bigint)
+RETURNS void AS $$
+BEGIN
+    UPDATE bench_table_20 SET updated_at = now() WHERE id = p_id;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Record % not found in bench_table_20', p_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE VIEW bench_view_1 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_1 a
+JOIN bench_table_2 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_2 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_2 a
+JOIN bench_table_3 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_3 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_3 a
+JOIN bench_table_4 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_4 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_4 a
+JOIN bench_table_5 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_5 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_5 a
+JOIN bench_table_6 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_6 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_6 a
+JOIN bench_table_7 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_7 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_7 a
+JOIN bench_table_8 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_8 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_8 a
+JOIN bench_table_9 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_9 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_9 a
+JOIN bench_table_10 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_10 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_10 a
+JOIN bench_table_11 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_11 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_11 a
+JOIN bench_table_12 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_12 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_12 a
+JOIN bench_table_13 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_13 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_13 a
+JOIN bench_table_14 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_14 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_14 a
+JOIN bench_table_15 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_15 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_15 a
+JOIN bench_table_16 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_16 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_16 a
+JOIN bench_table_17 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_17 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_17 a
+JOIN bench_table_18 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_18 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_18 a
+JOIN bench_table_19 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_19 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_19 a
+JOIN bench_table_20 b ON b.id = a.id
+WHERE a.status = 'active';
+
+CREATE VIEW bench_view_20 AS
+SELECT a.id, a.name, b.value, a.created_at
+FROM bench_table_20 a
+JOIN bench_table_21 b ON b.id = a.id
+WHERE a.status = 'active';
+
+ALTER TABLE bench_table_1 ADD COLUMN extra_col_1 text;
+ALTER TABLE bench_table_1 ADD COLUMN score_1 integer DEFAULT 0;
+ALTER TABLE bench_table_2 ADD COLUMN extra_col_2 text;
+ALTER TABLE bench_table_2 ADD COLUMN score_2 integer DEFAULT 0;
+ALTER TABLE bench_table_3 ADD COLUMN extra_col_3 text;
+ALTER TABLE bench_table_3 ADD COLUMN score_3 integer DEFAULT 0;
+ALTER TABLE bench_table_4 ADD COLUMN extra_col_4 text;
+ALTER TABLE bench_table_4 ADD COLUMN score_4 integer DEFAULT 0;
+ALTER TABLE bench_table_5 ADD COLUMN extra_col_5 text;
+ALTER TABLE bench_table_5 ADD COLUMN score_5 integer DEFAULT 0;
+ALTER TABLE bench_table_6 ADD COLUMN extra_col_6 text;
+ALTER TABLE bench_table_6 ADD COLUMN score_6 integer DEFAULT 0;
+ALTER TABLE bench_table_7 ADD COLUMN extra_col_7 text;
+ALTER TABLE bench_table_7 ADD COLUMN score_7 integer DEFAULT 0;
+ALTER TABLE bench_table_8 ADD COLUMN extra_col_8 text;
+ALTER TABLE bench_table_8 ADD COLUMN score_8 integer DEFAULT 0;
+ALTER TABLE bench_table_9 ADD COLUMN extra_col_9 text;
+ALTER TABLE bench_table_9 ADD COLUMN score_9 integer DEFAULT 0;
+ALTER TABLE bench_table_10 ADD COLUMN extra_col_10 text;
+ALTER TABLE bench_table_10 ADD COLUMN score_10 integer DEFAULT 0;
+ALTER TABLE bench_table_11 ADD COLUMN extra_col_11 text;
+ALTER TABLE bench_table_11 ADD COLUMN score_11 integer DEFAULT 0;
+ALTER TABLE bench_table_12 ADD COLUMN extra_col_12 text;
+ALTER TABLE bench_table_12 ADD COLUMN score_12 integer DEFAULT 0;
+ALTER TABLE bench_table_13 ADD COLUMN extra_col_13 text;
+ALTER TABLE bench_table_13 ADD COLUMN score_13 integer DEFAULT 0;
+ALTER TABLE bench_table_14 ADD COLUMN extra_col_14 text;
+ALTER TABLE bench_table_14 ADD COLUMN score_14 integer DEFAULT 0;
+ALTER TABLE bench_table_15 ADD COLUMN extra_col_15 text;
+ALTER TABLE bench_table_15 ADD COLUMN score_15 integer DEFAULT 0;
+ALTER TABLE bench_table_16 ADD COLUMN extra_col_16 text;
+ALTER TABLE bench_table_16 ADD COLUMN score_16 integer DEFAULT 0;
+ALTER TABLE bench_table_17 ADD COLUMN extra_col_17 text;
+ALTER TABLE bench_table_17 ADD COLUMN score_17 integer DEFAULT 0;
+ALTER TABLE bench_table_18 ADD COLUMN extra_col_18 text;
+ALTER TABLE bench_table_18 ADD COLUMN score_18 integer DEFAULT 0;
+ALTER TABLE bench_table_19 ADD COLUMN extra_col_19 text;
+ALTER TABLE bench_table_19 ADD COLUMN score_19 integer DEFAULT 0;
+ALTER TABLE bench_table_20 ADD COLUMN extra_col_20 text;
+ALTER TABLE bench_table_20 ADD COLUMN score_20 integer DEFAULT 0;
+ALTER TABLE bench_table_21 ADD COLUMN extra_col_21 text;
+ALTER TABLE bench_table_21 ADD COLUMN score_21 integer DEFAULT 0;
+ALTER TABLE bench_table_22 ADD COLUMN extra_col_22 text;
+ALTER TABLE bench_table_22 ADD COLUMN score_22 integer DEFAULT 0;
+ALTER TABLE bench_table_23 ADD COLUMN extra_col_23 text;
+ALTER TABLE bench_table_23 ADD COLUMN score_23 integer DEFAULT 0;
+ALTER TABLE bench_table_24 ADD COLUMN extra_col_24 text;
+ALTER TABLE bench_table_24 ADD COLUMN score_24 integer DEFAULT 0;
+ALTER TABLE bench_table_25 ADD COLUMN extra_col_25 text;
+ALTER TABLE bench_table_25 ADD COLUMN score_25 integer DEFAULT 0;
+ALTER TABLE bench_table_26 ADD COLUMN extra_col_26 text;
+ALTER TABLE bench_table_26 ADD COLUMN score_26 integer DEFAULT 0;
+ALTER TABLE bench_table_27 ADD COLUMN extra_col_27 text;
+ALTER TABLE bench_table_27 ADD COLUMN score_27 integer DEFAULT 0;
+ALTER TABLE bench_table_28 ADD COLUMN extra_col_28 text;
+ALTER TABLE bench_table_28 ADD COLUMN score_28 integer DEFAULT 0;
+ALTER TABLE bench_table_29 ADD COLUMN extra_col_29 text;
+ALTER TABLE bench_table_29 ADD COLUMN score_29 integer DEFAULT 0;
+ALTER TABLE bench_table_30 ADD COLUMN extra_col_30 text;
+ALTER TABLE bench_table_30 ADD COLUMN score_30 integer DEFAULT 0;
+
+INSERT INTO bench_table_1 (name, value, status) VALUES
+    ('item_a', 10.50, 'active'),
+    ('item_b', 20.75, 'inactive'),
+    ('item_c', 30.00, 'active');
+INSERT INTO bench_table_2 (name, value, status) VALUES
+    ('item_a', 20.50, 'active'),
+    ('item_b', 40.75, 'inactive'),
+    ('item_c', 60.00, 'active');
+INSERT INTO bench_table_3 (name, value, status) VALUES
+    ('item_a', 30.50, 'active'),
+    ('item_b', 60.75, 'inactive'),
+    ('item_c', 90.00, 'active');
+INSERT INTO bench_table_4 (name, value, status) VALUES
+    ('item_a', 40.50, 'active'),
+    ('item_b', 80.75, 'inactive'),
+    ('item_c', 120.00, 'active');
+INSERT INTO bench_table_5 (name, value, status) VALUES
+    ('item_a', 50.50, 'active'),
+    ('item_b', 100.75, 'inactive'),
+    ('item_c', 150.00, 'active');
+INSERT INTO bench_table_6 (name, value, status) VALUES
+    ('item_a', 60.50, 'active'),
+    ('item_b', 120.75, 'inactive'),
+    ('item_c', 180.00, 'active');
+INSERT INTO bench_table_7 (name, value, status) VALUES
+    ('item_a', 70.50, 'active'),
+    ('item_b', 140.75, 'inactive'),
+    ('item_c', 210.00, 'active');
+INSERT INTO bench_table_8 (name, value, status) VALUES
+    ('item_a', 80.50, 'active'),
+    ('item_b', 160.75, 'inactive'),
+    ('item_c', 240.00, 'active');
+INSERT INTO bench_table_9 (name, value, status) VALUES
+    ('item_a', 90.50, 'active'),
+    ('item_b', 180.75, 'inactive'),
+    ('item_c', 270.00, 'active');
+INSERT INTO bench_table_10 (name, value, status) VALUES
+    ('item_a', 100.50, 'active'),
+    ('item_b', 200.75, 'inactive'),
+    ('item_c', 300.00, 'active');
+INSERT INTO bench_table_11 (name, value, status) VALUES
+    ('item_a', 110.50, 'active'),
+    ('item_b', 220.75, 'inactive'),
+    ('item_c', 330.00, 'active');
+INSERT INTO bench_table_12 (name, value, status) VALUES
+    ('item_a', 120.50, 'active'),
+    ('item_b', 240.75, 'inactive'),
+    ('item_c', 360.00, 'active');
+INSERT INTO bench_table_13 (name, value, status) VALUES
+    ('item_a', 130.50, 'active'),
+    ('item_b', 260.75, 'inactive'),
+    ('item_c', 390.00, 'active');
+INSERT INTO bench_table_14 (name, value, status) VALUES
+    ('item_a', 140.50, 'active'),
+    ('item_b', 280.75, 'inactive'),
+    ('item_c', 420.00, 'active');
+INSERT INTO bench_table_15 (name, value, status) VALUES
+    ('item_a', 150.50, 'active'),
+    ('item_b', 300.75, 'inactive'),
+    ('item_c', 450.00, 'active');
+INSERT INTO bench_table_16 (name, value, status) VALUES
+    ('item_a', 160.50, 'active'),
+    ('item_b', 320.75, 'inactive'),
+    ('item_c', 480.00, 'active');
+INSERT INTO bench_table_17 (name, value, status) VALUES
+    ('item_a', 170.50, 'active'),
+    ('item_b', 340.75, 'inactive'),
+    ('item_c', 510.00, 'active');
+INSERT INTO bench_table_18 (name, value, status) VALUES
+    ('item_a', 180.50, 'active'),
+    ('item_b', 360.75, 'inactive'),
+    ('item_c', 540.00, 'active');
+INSERT INTO bench_table_19 (name, value, status) VALUES
+    ('item_a', 190.50, 'active'),
+    ('item_b', 380.75, 'inactive'),
+    ('item_c', 570.00, 'active');
+INSERT INTO bench_table_20 (name, value, status) VALUES
+    ('item_a', 200.50, 'active'),
+    ('item_b', 400.75, 'inactive'),
+    ('item_c', 600.00, 'active');
+
+GRANT SELECT ON bench_table_1 TO readonly_role;
+GRANT SELECT ON bench_table_2 TO readonly_role;
+GRANT SELECT ON bench_table_3 TO readonly_role;
+GRANT SELECT ON bench_table_4 TO readonly_role;
+GRANT SELECT ON bench_table_5 TO readonly_role;
+GRANT SELECT ON bench_table_6 TO readonly_role;
+GRANT SELECT ON bench_table_7 TO readonly_role;
+GRANT SELECT ON bench_table_8 TO readonly_role;
+GRANT SELECT ON bench_table_9 TO readonly_role;
+GRANT SELECT ON bench_table_10 TO readonly_role;
+GRANT SELECT ON bench_table_11 TO readonly_role;
+GRANT SELECT ON bench_table_12 TO readonly_role;
+GRANT SELECT ON bench_table_13 TO readonly_role;
+GRANT SELECT ON bench_table_14 TO readonly_role;
+GRANT SELECT ON bench_table_15 TO readonly_role;
+GRANT SELECT ON bench_table_16 TO readonly_role;
+GRANT SELECT ON bench_table_17 TO readonly_role;
+GRANT SELECT ON bench_table_18 TO readonly_role;
+GRANT SELECT ON bench_table_19 TO readonly_role;
+GRANT SELECT ON bench_table_20 TO readonly_role;
+GRANT SELECT ON bench_table_21 TO readonly_role;
+GRANT SELECT ON bench_table_22 TO readonly_role;
+GRANT SELECT ON bench_table_23 TO readonly_role;
+GRANT SELECT ON bench_table_24 TO readonly_role;
+GRANT SELECT ON bench_table_25 TO readonly_role;
+GRANT SELECT ON bench_table_26 TO readonly_role;
+GRANT SELECT ON bench_table_27 TO readonly_role;
+GRANT SELECT ON bench_table_28 TO readonly_role;
+GRANT SELECT ON bench_table_29 TO readonly_role;
+GRANT SELECT ON bench_table_30 TO readonly_role;
+GRANT SELECT ON bench_table_31 TO readonly_role;
+GRANT SELECT ON bench_table_32 TO readonly_role;
+GRANT SELECT ON bench_table_33 TO readonly_role;
+GRANT SELECT ON bench_table_34 TO readonly_role;
+GRANT SELECT ON bench_table_35 TO readonly_role;
+GRANT SELECT ON bench_table_36 TO readonly_role;
+GRANT SELECT ON bench_table_37 TO readonly_role;
+GRANT SELECT ON bench_table_38 TO readonly_role;
+GRANT SELECT ON bench_table_39 TO readonly_role;
+GRANT SELECT ON bench_table_40 TO readonly_role;
+GRANT SELECT ON bench_table_41 TO readonly_role;
+GRANT SELECT ON bench_table_42 TO readonly_role;
+GRANT SELECT ON bench_table_43 TO readonly_role;
+GRANT SELECT ON bench_table_44 TO readonly_role;
+GRANT SELECT ON bench_table_45 TO readonly_role;
+GRANT SELECT ON bench_table_46 TO readonly_role;
+GRANT SELECT ON bench_table_47 TO readonly_role;
+GRANT SELECT ON bench_table_48 TO readonly_role;
+GRANT SELECT ON bench_table_49 TO readonly_role;
+GRANT SELECT ON bench_table_50 TO readonly_role;
+
+-- End of generated fixture (1017 lines)

--- a/tests/unit/parser-spike.test.ts
+++ b/tests/unit/parser-spike.test.ts
@@ -1,0 +1,555 @@
+/**
+ * S1-8: Validation spike — pgsql-parser + bun build --compile
+ *
+ * This test validates that `libpg-query` (via `pgsql-parser`) can parse
+ * PostgreSQL SQL into AST nodes and works with Bun's runtime and compiled
+ * binary output.
+ *
+ * Key findings will be documented inline as comments.
+ */
+import { describe, test, expect, beforeAll } from "bun:test";
+import { parse, parseSync, loadModule } from "libpg-query";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const FIXTURES_DIR = join(import.meta.dir, "..", "fixtures");
+
+describe("libpg-query WASM parser spike", () => {
+  // Load the WASM module once before all tests
+  beforeAll(async () => {
+    await loadModule();
+  });
+
+  describe("basic parsing", () => {
+    test("parses a simple SELECT", async () => {
+      const result = await parse("SELECT 1");
+      expect(result).toBeDefined();
+      expect(result.stmts).toBeArray();
+      expect(result.stmts).toHaveLength(1);
+      expect(result.stmts[0].stmt).toHaveProperty("SelectStmt");
+    });
+
+    test("parseSync works without await", () => {
+      const result = parseSync("SELECT 1 + 2");
+      expect(result).toBeDefined();
+      expect(result.stmts).toBeArray();
+      expect(result.stmts).toHaveLength(1);
+    });
+
+    test("parses CREATE TABLE and extracts table name", async () => {
+      const sql = `CREATE TABLE users (
+        id bigint PRIMARY KEY,
+        email text NOT NULL
+      )`;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+
+      const stmt = result.stmts[0].stmt;
+      expect(stmt).toHaveProperty("CreateStmt");
+
+      const createStmt = stmt.CreateStmt;
+      const relname = createStmt.relation.relname;
+      expect(relname).toBe("users");
+    });
+
+    test("parses ALTER TABLE and identifies subcommands", async () => {
+      const sql = "ALTER TABLE posts ADD COLUMN slug text";
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+
+      const stmt = result.stmts[0].stmt;
+      expect(stmt).toHaveProperty("AlterTableStmt");
+
+      const alterStmt = stmt.AlterTableStmt;
+      expect(alterStmt.relation.relname).toBe("posts");
+      expect(alterStmt.cmds).toBeArray();
+      expect(alterStmt.cmds.length).toBeGreaterThan(0);
+    });
+
+    test("parses CREATE INDEX", async () => {
+      const sql = "CREATE INDEX idx_users_email ON users (email)";
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+
+      const stmt = result.stmts[0].stmt;
+      expect(stmt).toHaveProperty("IndexStmt");
+      expect(stmt.IndexStmt.idxname).toBe("idx_users_email");
+      expect(stmt.IndexStmt.relation.relname).toBe("users");
+    });
+
+    test("parses CREATE INDEX CONCURRENTLY", async () => {
+      const sql =
+        "CREATE INDEX CONCURRENTLY idx_foo ON bar (baz) WHERE baz IS NOT NULL";
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+
+      const stmt = result.stmts[0].stmt;
+      expect(stmt).toHaveProperty("IndexStmt");
+      expect(stmt.IndexStmt.concurrent).toBe(true);
+    });
+  });
+
+  describe("multi-statement parsing", () => {
+    test("parses multiple statements separated by semicolons", async () => {
+      const sql = `
+        CREATE TABLE a (id int);
+        CREATE TABLE b (id int);
+        CREATE TABLE c (id int);
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(3);
+
+      for (const entry of result.stmts) {
+        expect(entry.stmt).toHaveProperty("CreateStmt");
+      }
+    });
+
+    test("provides statement locations (byte offsets)", async () => {
+      const sql = "SELECT 1; SELECT 2; SELECT 3;";
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(3);
+
+      // First statement: stmt_location is omitted (protobuf zero-value),
+      // meaning offset 0. We normalize with `?? 0`.
+      expect(result.stmts[0].stmt_location ?? 0).toBe(0);
+
+      // Subsequent statements have positive offsets
+      expect(result.stmts[1].stmt_location).toBeGreaterThan(0);
+      expect(result.stmts[2].stmt_location).toBeGreaterThan(
+        result.stmts[1].stmt_location,
+      );
+    });
+
+    test("provides statement lengths", async () => {
+      const sql = "SELECT 1; SELECT 2; SELECT 3;";
+      const result = await parse(sql);
+
+      // All statements should have positive lengths
+      expect(result.stmts[0].stmt_len).toBeGreaterThan(0);
+      expect(result.stmts[1].stmt_len).toBeGreaterThan(0);
+      expect(result.stmts[2].stmt_len).toBeGreaterThan(0);
+    });
+  });
+
+  describe("dollar-quoted strings", () => {
+    test("parses basic dollar-quoted function", async () => {
+      const sql = `
+        CREATE FUNCTION hello()
+        RETURNS text AS $$
+        BEGIN
+          RETURN 'hello world';
+        END;
+        $$ LANGUAGE plpgsql;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+
+      const stmt = result.stmts[0].stmt;
+      expect(stmt).toHaveProperty("CreateFunctionStmt");
+    });
+
+    test("parses named dollar-quoted function", async () => {
+      const sql = `
+        CREATE FUNCTION greet(name text)
+        RETURNS text AS $fn$
+        BEGIN
+          RETURN 'Hello, ' || name;
+        END;
+        $fn$ LANGUAGE plpgsql;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+      expect(result.stmts[0].stmt).toHaveProperty("CreateFunctionStmt");
+    });
+
+    test("parses function with nested single quotes inside dollar-quoting", async () => {
+      const sql = `
+        CREATE FUNCTION test_quotes()
+        RETURNS void AS $$
+        BEGIN
+          RAISE NOTICE 'It''s working with ''quotes''!';
+        END;
+        $$ LANGUAGE plpgsql;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+    });
+
+    test("parses DO block with dollar-quoting", async () => {
+      const sql = `
+        DO $$
+        BEGIN
+          IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'uuid-ossp') THEN
+            CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+          END IF;
+        END;
+        $$;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+      expect(result.stmts[0].stmt).toHaveProperty("DoStmt");
+    });
+  });
+
+  describe("CREATE FUNCTION bodies", () => {
+    test("extracts function name and return type", async () => {
+      const sql = `
+        CREATE FUNCTION calculate_total(p_order_id bigint)
+        RETURNS numeric AS $$
+        BEGIN
+          RETURN (SELECT sum(amount) FROM order_items WHERE order_id = p_order_id);
+        END;
+        $$ LANGUAGE plpgsql STABLE;
+      `;
+      const result = await parse(sql);
+      const stmt = result.stmts[0].stmt.CreateFunctionStmt;
+      expect(stmt.funcname).toBeArray();
+
+      // Function name is in the last element
+      const funcName = stmt.funcname[stmt.funcname.length - 1];
+      expect(funcName.String?.sval || funcName.str).toBeDefined();
+    });
+
+    test("parses trigger function", async () => {
+      const sql = `
+        CREATE FUNCTION update_modified_column()
+        RETURNS trigger AS $$
+        BEGIN
+          NEW.updated_at = now();
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+      expect(result.stmts[0].stmt).toHaveProperty("CreateFunctionStmt");
+    });
+
+    test("parses CREATE OR REPLACE FUNCTION", async () => {
+      const sql = `
+        CREATE OR REPLACE FUNCTION my_func()
+        RETURNS void AS $$
+        BEGIN
+          NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+      `;
+      const result = await parse(sql);
+      const stmt = result.stmts[0].stmt.CreateFunctionStmt;
+      expect(stmt.replace).toBe(true);
+    });
+  });
+
+  describe("comments handling", () => {
+    test("parses SQL with single-line comments", async () => {
+      const sql = `
+        -- This is a comment
+        SELECT 1; -- inline comment
+        -- Another comment
+        SELECT 2;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(2);
+    });
+
+    test("parses SQL with block comments", async () => {
+      const sql = `
+        /* Block comment */
+        SELECT 1;
+        /* Multi-line
+           block comment
+           with special chars: '; DROP TABLE users; -- */
+        SELECT 2;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(2);
+    });
+
+    test("parses SQL with nested block comments", async () => {
+      const sql = `
+        /* Outer /* inner */ outer still */
+        SELECT 1;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+    });
+  });
+
+  describe("edge case SQL types", () => {
+    test("parses GRANT/REVOKE", async () => {
+      const sql = `
+        GRANT SELECT ON users TO readonly_role;
+        REVOKE INSERT ON users FROM public;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(2);
+      expect(result.stmts[0].stmt).toHaveProperty("GrantStmt");
+      expect(result.stmts[1].stmt).toHaveProperty("GrantStmt"); // REVOKE uses GrantStmt with is_grant=false
+    });
+
+    test("parses CREATE TYPE (enum)", async () => {
+      const sql = "CREATE TYPE status AS ENUM ('draft', 'published', 'archived')";
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+      expect(result.stmts[0].stmt).toHaveProperty("CreateEnumStmt");
+    });
+
+    test("parses CREATE VIEW", async () => {
+      const sql = `
+        CREATE VIEW active_users AS
+        SELECT id, email FROM users WHERE status = 'active';
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+      expect(result.stmts[0].stmt).toHaveProperty("ViewStmt");
+    });
+
+    test("parses CTE (WITH clause)", async () => {
+      const sql = `
+        WITH recent AS (
+          SELECT id FROM users WHERE created_at > now() - interval '1 day'
+        )
+        SELECT * FROM recent;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+      const selectStmt = result.stmts[0].stmt.SelectStmt;
+      expect(selectStmt.withClause).toBeDefined();
+    });
+
+    test("parses window functions", async () => {
+      const sql = `
+        SELECT id, ROW_NUMBER() OVER (ORDER BY id) AS rn
+        FROM users;
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+    });
+
+    test("parses CREATE TRIGGER", async () => {
+      const sql = `
+        CREATE TRIGGER set_updated
+        BEFORE UPDATE ON users
+        FOR EACH ROW
+        EXECUTE FUNCTION update_modified_column();
+      `;
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+      expect(result.stmts[0].stmt).toHaveProperty("CreateTrigStmt");
+    });
+
+    test("parses CREATE EXTENSION", async () => {
+      const sql = 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"';
+      const result = await parse(sql);
+      expect(result.stmts).toHaveLength(1);
+      expect(result.stmts[0].stmt).toHaveProperty("CreateExtensionStmt");
+    });
+  });
+
+  describe("error handling", () => {
+    test("throws on invalid SQL", async () => {
+      await expect(parse("SELCT 1")).rejects.toThrow();
+    });
+
+    test("throws on incomplete statement", async () => {
+      await expect(parse("CREATE TABLE")).rejects.toThrow();
+    });
+
+    test("error includes position information", async () => {
+      try {
+        await parse("SELECT FROM WHERE");
+        expect(true).toBe(false); // should not reach here
+      } catch (e: any) {
+        expect(e.message).toBeDefined();
+        // The error should indicate something about the syntax
+        expect(e.message.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("fixture file parsing", () => {
+    test("parses edge-cases.sql fixture", async () => {
+      const sql = readFileSync(join(FIXTURES_DIR, "edge-cases.sql"), "utf-8");
+      const result = await parse(sql);
+
+      // The fixture has 18 distinct SQL statements
+      expect(result.stmts.length).toBe(18);
+
+      // Verify we can identify statement types
+      const stmtTypes = result.stmts.map((s: any) => Object.keys(s.stmt)[0]);
+      expect(stmtTypes).toContain("CreateStmt"); // CREATE TABLE
+      expect(stmtTypes).toContain("IndexStmt"); // CREATE INDEX
+      expect(stmtTypes).toContain("CreateFunctionStmt"); // CREATE FUNCTION
+      expect(stmtTypes).toContain("CreateTrigStmt"); // CREATE TRIGGER
+      expect(stmtTypes).toContain("AlterTableStmt"); // ALTER TABLE
+      expect(stmtTypes).toContain("InsertStmt"); // INSERT
+      expect(stmtTypes).toContain("SelectStmt"); // SELECT with CTE
+      expect(stmtTypes).toContain("ViewStmt"); // CREATE VIEW
+      expect(stmtTypes).toContain("DoStmt"); // DO block
+      expect(stmtTypes).toContain("GrantStmt"); // GRANT/REVOKE
+      expect(stmtTypes).toContain("CreateEnumStmt"); // CREATE TYPE ENUM
+    });
+
+    test("provides byte offsets for all statements in fixture", async () => {
+      const sql = readFileSync(join(FIXTURES_DIR, "edge-cases.sql"), "utf-8");
+      const result = await parse(sql);
+
+      // Every statement should have a location
+      // Note: stmt_location is omitted (undefined) for the first statement
+      // when it starts at byte 0 (protobuf zero-value omission).
+      for (let i = 0; i < result.stmts.length; i++) {
+        const entry = result.stmts[i];
+        const loc = entry.stmt_location ?? 0;
+        if (i > 0) {
+          expect(loc).toBeGreaterThan(0);
+        }
+      }
+
+      // Verify we can extract the original SQL text using offsets
+      const firstStmt = result.stmts[0];
+      const loc = firstStmt.stmt_location ?? 0;
+      const len = firstStmt.stmt_len;
+      const stmtText = sql.substring(loc, loc + len);
+      expect(stmtText).toContain("CREATE TABLE users");
+    });
+  });
+
+  describe("performance benchmark", () => {
+    test("parses 1000-line SQL file in < 200ms", async () => {
+      const sql = readFileSync(
+        join(FIXTURES_DIR, "large-benchmark.sql"),
+        "utf-8",
+      );
+
+      // Warm up the WASM module
+      await parse("SELECT 1");
+
+      // Benchmark: run 5 times and take the median
+      const times: number[] = [];
+      const iterations = 5;
+
+      for (let i = 0; i < iterations; i++) {
+        const start = performance.now();
+        const result = await parse(sql);
+        const elapsed = performance.now() - start;
+        times.push(elapsed);
+
+        // Verify it actually parsed
+        expect(result.stmts.length).toBeGreaterThan(100);
+      }
+
+      times.sort((a, b) => a - b);
+      const median = times[Math.floor(times.length / 2)];
+      const min = times[0];
+      const max = times[times.length - 1];
+
+      console.log(
+        `\n  Parse benchmark (1000-line SQL, ${iterations} runs):`,
+      );
+      console.log(`    Min:    ${min.toFixed(2)}ms`);
+      console.log(`    Median: ${median.toFixed(2)}ms`);
+      console.log(`    Max:    ${max.toFixed(2)}ms`);
+      console.log(
+        `    Statements parsed: ${(await parse(sql)).stmts.length}`,
+      );
+
+      // Performance target: < 200ms
+      expect(median).toBeLessThan(200);
+    });
+
+    test("parseSync performance for 1000-line SQL", () => {
+      const sql = readFileSync(
+        join(FIXTURES_DIR, "large-benchmark.sql"),
+        "utf-8",
+      );
+
+      // Warm up
+      parseSync("SELECT 1");
+
+      const times: number[] = [];
+      const iterations = 5;
+
+      for (let i = 0; i < iterations; i++) {
+        const start = performance.now();
+        const result = parseSync(sql);
+        const elapsed = performance.now() - start;
+        times.push(elapsed);
+        expect(result.stmts.length).toBeGreaterThan(100);
+      }
+
+      times.sort((a, b) => a - b);
+      const median = times[Math.floor(times.length / 2)];
+      const min = times[0];
+      const max = times[times.length - 1];
+
+      console.log(
+        `\n  parseSync benchmark (1000-line SQL, ${iterations} runs):`,
+      );
+      console.log(`    Min:    ${min.toFixed(2)}ms`);
+      console.log(`    Median: ${median.toFixed(2)}ms`);
+      console.log(`    Max:    ${max.toFixed(2)}ms`);
+
+      expect(median).toBeLessThan(200);
+    });
+  });
+
+  describe("AST structure inspection", () => {
+    test("extracts column names from CREATE TABLE", async () => {
+      const sql = `CREATE TABLE orders (
+        id bigint PRIMARY KEY,
+        customer_id bigint NOT NULL,
+        total numeric(10,2),
+        status text DEFAULT 'pending'
+      )`;
+      const result = await parse(sql);
+      const createStmt = result.stmts[0].stmt.CreateStmt;
+
+      const colNames = createStmt.tableElts
+        .filter((e: any) => e.ColumnDef)
+        .map((e: any) => e.ColumnDef.colname);
+
+      expect(colNames).toEqual(["id", "customer_id", "total", "status"]);
+    });
+
+    test("extracts table name from INSERT", async () => {
+      const sql = "INSERT INTO users (email) VALUES ('test@test.com')";
+      const result = await parse(sql);
+      const insertStmt = result.stmts[0].stmt.InsertStmt;
+      expect(insertStmt.relation.relname).toBe("users");
+    });
+
+    test("extracts table names from SELECT with JOIN", async () => {
+      const sql = `
+        SELECT u.name, o.total
+        FROM users u
+        JOIN orders o ON o.user_id = u.id
+        WHERE o.status = 'completed'
+      `;
+      const result = await parse(sql);
+      const selectStmt = result.stmts[0].stmt.SelectStmt;
+      const fromClause = selectStmt.fromClause;
+
+      // With a JOIN, the fromClause contains a JoinExpr
+      expect(fromClause).toBeArray();
+      expect(fromClause[0]).toHaveProperty("JoinExpr");
+    });
+
+    test("identifies ALTER TABLE subcommand types", async () => {
+      const sql = `
+        ALTER TABLE users
+          ADD COLUMN nickname text,
+          ALTER COLUMN email SET NOT NULL,
+          DROP COLUMN IF EXISTS legacy_field;
+      `;
+      const result = await parse(sql);
+      const alterStmt = result.stmts[0].stmt.AlterTableStmt;
+
+      expect(alterStmt.cmds).toHaveLength(3);
+      // Each cmd has an AlterTableCmd with a subtype enum
+      for (const cmd of alterStmt.cmds) {
+        expect(cmd).toHaveProperty("AlterTableCmd");
+        expect(cmd.AlterTableCmd.subtype).toBeDefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Validates that `libpg-query` (the PostgreSQL parser based on `libpg_query`) works with `bun test` and `bun build --compile`. This is the **GO/NO-GO gate** for the static analysis architecture (SPEC DD4, Section 9 Phase 0).

**Verdict: GO** — the parser works flawlessly in both runtime and compiled binary.

Closes #9

## Research: Package Evaluation

| Package | Version | Type | Verdict |
|---------|---------|------|---------|
| `libpg-query` | 17.7.3 | **WASM** (emscripten) | **Chosen** — direct binding, zero native deps, smallest footprint |
| `pgsql-parser` | 17.9.14 | Wrapper over `libpg-query` + `pgsql-deparser` | Unnecessary indirection; adds deparser we don't need yet |
| `@pgsql/parser` | 1.2.1 | Multi-version wrapper | 5.6MB, adds version selection overhead |
| `pg-query-emscripten` | 5.1.0 | WASM (pganalyze) | Older (1 year stale), different maintainer |

### Key Discovery

**`libpg-query` is now pure WASM** (emscripten-compiled). It ships `.wasm` files — no native C addon, no `node-gyp`, no build tools required on the target machine. This eliminates the native-vs-WASM concern entirely. The "try native first, WASM second" plan turned out to be moot because the primary package *is* WASM.

## Recommendation

Use **`libpg-query`** directly (not the `pgsql-parser` wrapper). Reasons:
- Direct dependency, no unnecessary wrapper layers
- Provides both `parse()` (async) and `parseSync()` APIs
- Exports TypeScript types via `@pgsql/types`
- Pure WASM — works everywhere Bun runs, no platform-specific builds
- If we need deparsing later, add `pgsql-deparser` separately

## Benchmark Results

### `bun test` (macOS arm64)

| Metric | `parse()` (async) | `parseSync()` |
|--------|-------------------|---------------|
| Min | 1.51ms | 1.23ms |
| **Median** | **2.19ms** | **1.34ms** |
| Max | 4.07ms | 1.52ms |

- Input: 1017-line SQL file, 270 statements
- Target: < 200ms — **passed by ~100x margin**

### `bun build --compile` binary (macOS arm64)

| Metric | Value |
|--------|-------|
| WASM load time | ~5ms |
| Parse (200 stmts) | ~1.8ms median |
| Binary size | 57MB |

## Test Coverage (37/37 pass)

- **Basic parsing**: SELECT, CREATE TABLE, ALTER TABLE, CREATE INDEX, CREATE INDEX CONCURRENTLY
- **Multi-statement**: semicolon-separated scripts, statement locations (byte offsets), statement lengths
- **Dollar-quoted strings**: basic `$$`, named `$fn$`, nested quotes inside dollar-quoting
- **CREATE FUNCTION bodies**: function name extraction, trigger functions, CREATE OR REPLACE
- **Comments**: single-line `--`, block `/* */`, nested block comments
- **Edge cases**: GRANT/REVOKE, CREATE TYPE ENUM, CREATE VIEW, CTE, window functions, CREATE TRIGGER, CREATE EXTENSION
- **Error handling**: invalid SQL throws, incomplete statements throw, error messages present
- **Fixture parsing**: 18-statement edge-case file, byte offset extraction and text recovery
- **Benchmarks**: async and sync parse performance on 1000-line file

## AST Structure Notes

- Statement type is the key on `stmt` object: `CreateStmt`, `AlterTableStmt`, `IndexStmt`, etc.
- `stmt_location` uses protobuf zero-value omission: first statement at offset 0 has `undefined` location (normalize with `?? 0`)
- `stmt_len` is provided for all statements
- Column names accessible via `createStmt.tableElts[].ColumnDef.colname`
- Table names via `stmt.*.relation.relname`
- ALTER TABLE subcommands via `alterStmt.cmds[].AlterTableCmd.subtype`

## Caveats

1. **Protobuf zero-value omission**: `stmt_location` is `undefined` (not `0`) for the first statement. Code must normalize with `?? 0`.
2. **Binary size**: 57MB compiled binary (includes Bun runtime + WASM). Acceptable for a CLI tool.
3. **psql metacommands**: `libpg-query` parses SQL only, not `\i`, `\set`, etc. Pre-processing layer needed (per SPEC DD4).

## Test plan

- [x] `bun test` — 37/37 pass
- [x] `bun build --compile` — binary runs all parser tests successfully
- [ ] Linux CI validation (deferred to CI setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)