### PR TITLE
S1-7: psql shell-out wrapper

### DIFF
--- a/src/psql.ts
+++ b/src/psql.ts
@@ -1,0 +1,319 @@
+// src/psql.ts — psql shell-out wrapper for script execution
+//
+// See SPEC.md DD12: sqlever executes migration scripts by shelling out
+// to psql, exactly like Sqitch. This guarantees 100% compatibility with
+// all psql metacommands (\i, \ir, \set, \copy, \if/\elif/\endif, etc.).
+//
+// node-postgres (pg) is used only for tracking-table operations,
+// advisory locks, and schema introspection — never for user scripts.
+
+import { spawn, type SpawnOptions } from "child_process";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PsqlRunOptions {
+  /** PostgreSQL connection URI (postgresql://user:pass@host:port/db). */
+  uri: string;
+
+  /** Key-value pairs passed as psql variables via -v key=value. */
+  variables?: Record<string, string>;
+
+  /** Wrap execution in a single transaction (--single-transaction). */
+  singleTransaction?: boolean;
+
+  /** Override psql binary path (takes precedence over constructor default). */
+  dbClient?: string;
+
+  /** Working directory for psql process (for \i relative paths). */
+  workingDir?: string;
+}
+
+export interface PsqlRunResult {
+  /** Process exit code (0 = success). */
+  exitCode: number;
+
+  /** Captured stdout. */
+  stdout: string;
+
+  /** Captured stderr. */
+  stderr: string;
+
+  /** Parsed error info from stderr, if any. */
+  error?: PsqlError;
+}
+
+export interface PsqlError {
+  /** Severity: ERROR, FATAL, PANIC. */
+  severity?: string;
+
+  /** The error message text. */
+  message: string;
+
+  /** Source file and line where the error was raised, if available. */
+  location?: string;
+
+  /** DETAIL line, if present. */
+  detail?: string;
+
+  /** HINT line, if present. */
+  hint?: string;
+
+  /** CONTEXT line, if present. */
+  context?: string;
+
+  /** STATEMENT line, if present. */
+  statement?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Error parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort extraction of structured error information from psql stderr.
+ *
+ * psql error output looks like:
+ *   psql:path/to/file.sql:42: ERROR:  relation "foo" does not exist
+ *   LINE 1: SELECT * FROM foo;
+ *                          ^
+ *   DETAIL:  ...
+ *   HINT:  ...
+ *
+ * Or sometimes just:
+ *   ERROR:  syntax error at or near "SELEC"
+ */
+export function parsePsqlStderr(stderr: string): PsqlError | undefined {
+  if (!stderr.trim()) return undefined;
+
+  // Match the primary error line. Two common formats:
+  //   psql:<file>:<line>: <SEVERITY>:  <message>
+  //   <SEVERITY>:  <message>
+  const errorLineRe =
+    /^(?:psql:([^:]+:\d+):\s*)?(ERROR|FATAL|PANIC):\s+(.+)$/m;
+  const match = stderr.match(errorLineRe);
+
+  if (!match) return undefined;
+
+  const error: PsqlError = {
+    message: match[3]!.trim(),
+  };
+
+  if (match[2]) error.severity = match[2];
+  if (match[1]) error.location = match[1];
+
+  // Extract supplementary fields (DETAIL, HINT, CONTEXT, STATEMENT).
+  const detailMatch = stderr.match(/^DETAIL:\s+(.+)$/m);
+  if (detailMatch) error.detail = detailMatch[1]!.trim();
+
+  const hintMatch = stderr.match(/^HINT:\s+(.+)$/m);
+  if (hintMatch) error.hint = hintMatch[1]!.trim();
+
+  const contextMatch = stderr.match(/^CONTEXT:\s+(.+)$/m);
+  if (contextMatch) error.context = contextMatch[1]!.trim();
+
+  const stmtMatch = stderr.match(/^STATEMENT:\s+(.+)$/m);
+  if (stmtMatch) error.statement = stmtMatch[1]!.trim();
+
+  return error;
+}
+
+// ---------------------------------------------------------------------------
+// URI password extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the password from a PostgreSQL URI and return the URI without it.
+ *
+ * This is critical for security: passwords must NEVER appear in process
+ * arguments (visible via `ps`). Instead, we pass the password via the
+ * PGPASSWORD environment variable.
+ *
+ * Returns { uri, password } where uri has the password removed.
+ */
+export function extractPassword(uri: string): {
+  cleanUri: string;
+  password: string | undefined;
+} {
+  // Match: scheme://user:password@host...
+  // The password is everything between the first : after :// and the last @.
+  const re = /^([a-zA-Z][a-zA-Z0-9+.:~-]*:\/\/)([^:@/]+):(.+)@(?=[^@]*$)/;
+  const match = uri.match(re);
+
+  if (!match) {
+    return { cleanUri: uri, password: undefined };
+  }
+
+  const password = match[3]!;
+  // Reconstruct URI without password: scheme://user@host...
+  const cleanUri = uri.replace(re, "$1$2@");
+
+  return { cleanUri, password };
+}
+
+// ---------------------------------------------------------------------------
+// Command builder
+// ---------------------------------------------------------------------------
+
+export interface PsqlCommand {
+  /** The psql binary to invoke. */
+  bin: string;
+
+  /** Arguments for the psql process. */
+  args: string[];
+
+  /** Environment variables to set on the child process. */
+  env: Record<string, string>;
+
+  /** Working directory for the child process. */
+  cwd?: string;
+}
+
+/**
+ * Build the psql command-line arguments and environment.
+ *
+ * This is a pure function (no I/O) so it can be unit-tested without
+ * spawning processes.
+ */
+export function buildPsqlCommand(
+  scriptPath: string,
+  options: PsqlRunOptions,
+  defaultBin: string,
+): PsqlCommand {
+  const bin = options.dbClient ?? defaultBin;
+  const args: string[] = [];
+  const env: Record<string, string> = {};
+
+  // --- Disable .psqlrc ---
+  // Both the env var and the flag for belt-and-suspenders safety.
+  env["PSQLRC"] = "/dev/null";
+  args.push("--no-psqlrc");
+
+  // --- ON_ERROR_STOP=1 --- abort on first error
+  args.push("-v", "ON_ERROR_STOP=1");
+
+  // --- Single transaction ---
+  if (options.singleTransaction) {
+    args.push("--single-transaction");
+  }
+
+  // --- User variables ---
+  if (options.variables) {
+    for (const [key, value] of Object.entries(options.variables)) {
+      args.push("-v", `${key}=${value}`);
+    }
+  }
+
+  // --- Connection URI ---
+  // Extract password from URI and pass via PGPASSWORD env var
+  // so it never appears in the process argument list (visible via `ps`).
+  const { cleanUri, password } = extractPassword(options.uri);
+  if (password) {
+    env["PGPASSWORD"] = password;
+  }
+  args.push("--dbname", cleanUri);
+
+  // --- Script file ---
+  args.push("-f", scriptPath);
+
+  return {
+    bin,
+    args,
+    env,
+    cwd: options.workingDir,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Subprocess execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Type for the spawn function, allowing injection for testing.
+ */
+export type SpawnFn = (
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+) => ReturnType<typeof spawn>;
+
+// ---------------------------------------------------------------------------
+// PsqlRunner class
+// ---------------------------------------------------------------------------
+
+/**
+ * Executes SQL scripts by shelling out to psql.
+ *
+ * Usage:
+ *   const runner = new PsqlRunner();
+ *   const result = await runner.run("deploy/001-init.sql", {
+ *     uri: "postgresql://user@localhost/mydb",
+ *     singleTransaction: true,
+ *     variables: { schema: "public" },
+ *   });
+ *
+ *   if (result.exitCode !== 0) {
+ *     console.error("psql failed:", result.error?.message ?? result.stderr);
+ *   }
+ */
+export class PsqlRunner {
+  private readonly defaultBin: string;
+  private readonly spawnFn: SpawnFn;
+
+  /**
+   * @param psqlPath — path to the psql binary (default: "psql")
+   * @param spawnFn — subprocess spawn function (for testing)
+   */
+  constructor(psqlPath?: string, spawnFn?: SpawnFn) {
+    this.defaultBin = psqlPath ?? "psql";
+    this.spawnFn = spawnFn ?? spawn;
+  }
+
+  /**
+   * Execute a SQL script file via psql.
+   *
+   * @param scriptPath — path to the .sql file (relative to workingDir or absolute)
+   * @param options — connection URI, variables, transaction mode, etc.
+   * @returns exit code, captured stdout/stderr, and parsed error (if any)
+   */
+  async run(scriptPath: string, options: PsqlRunOptions): Promise<PsqlRunResult> {
+    const cmd = buildPsqlCommand(scriptPath, options, this.defaultBin);
+
+    return new Promise<PsqlRunResult>((resolve, reject) => {
+      const child = this.spawnFn(cmd.bin, cmd.args, {
+        cwd: cmd.cwd,
+        env: { ...process.env, ...cmd.env },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      child.on("error", (err) => {
+        // Spawn failure (e.g., psql not found)
+        reject(err);
+      });
+
+      child.on("close", (code) => {
+        const exitCode = code ?? 1;
+        const error = exitCode !== 0 ? parsePsqlStderr(stderr) : undefined;
+
+        resolve({
+          exitCode,
+          stdout,
+          stderr,
+          error,
+        });
+      });
+    });
+  }
+}

--- a/tests/unit/psql.test.ts
+++ b/tests/unit/psql.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, expect } from "bun:test";
+import { EventEmitter } from "events";
+import {
+  PsqlRunner,
+  buildPsqlCommand,
+  parsePsqlStderr,
+  extractPassword,
+  type SpawnFn,
+  type PsqlRunOptions,
+} from "../../src/psql";
+
+// ---------------------------------------------------------------------------
+// Helpers — mock subprocess
+// ---------------------------------------------------------------------------
+
+interface MockChildProcess extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+}
+
+/**
+ * Create a mock spawn function that records calls and allows
+ * controlling stdout/stderr/exit of the child process.
+ */
+function createMockSpawn(
+  exitCode = 0,
+  stdoutData = "",
+  stderrData = "",
+) {
+  const calls: Array<{
+    command: string;
+    args: string[];
+    options: Record<string, unknown>;
+  }> = [];
+
+  const spawnFn: SpawnFn = (command, args, options) => {
+    calls.push({ command, args, options: options as Record<string, unknown> });
+
+    const child: MockChildProcess = Object.assign(new EventEmitter(), {
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+    });
+
+    // Emit data and close asynchronously to simulate real subprocess
+    queueMicrotask(() => {
+      if (stdoutData) child.stdout.emit("data", Buffer.from(stdoutData));
+      if (stderrData) child.stderr.emit("data", Buffer.from(stderrData));
+      child.emit("close", exitCode);
+    });
+
+    return child as ReturnType<typeof import("child_process").spawn>;
+  };
+
+  return { spawnFn, calls };
+}
+
+/**
+ * Create a mock spawn function that emits an error (e.g., binary not found).
+ */
+function createErrorSpawn(error: Error) {
+  const spawnFn: SpawnFn = () => {
+    const child: MockChildProcess = Object.assign(new EventEmitter(), {
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+    });
+
+    queueMicrotask(() => {
+      child.emit("error", error);
+    });
+
+    return child as ReturnType<typeof import("child_process").spawn>;
+  };
+
+  return { spawnFn };
+}
+
+// ---------------------------------------------------------------------------
+// Default options helper
+// ---------------------------------------------------------------------------
+
+const defaultUri = "postgresql://user@localhost:5432/testdb";
+
+function opts(overrides: Partial<PsqlRunOptions> = {}): PsqlRunOptions {
+  return { uri: defaultUri, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("psql module", () => {
+  // -----------------------------------------------------------------------
+  // buildPsqlCommand — argument construction
+  // -----------------------------------------------------------------------
+
+  describe("buildPsqlCommand()", () => {
+    it("builds minimal command with required args", () => {
+      const cmd = buildPsqlCommand("deploy/001.sql", opts(), "psql");
+
+      expect(cmd.bin).toBe("psql");
+      expect(cmd.args).toContain("--no-psqlrc");
+      expect(cmd.args).toContain("-f");
+      expect(cmd.args).toContain("deploy/001.sql");
+      expect(cmd.env["PSQLRC"]).toBe("/dev/null");
+    });
+
+    it("sets ON_ERROR_STOP=1", () => {
+      const cmd = buildPsqlCommand("test.sql", opts(), "psql");
+
+      // Should have -v ON_ERROR_STOP=1
+      const vIdx = cmd.args.indexOf("-v");
+      expect(vIdx).toBeGreaterThanOrEqual(0);
+      expect(cmd.args[vIdx + 1]).toBe("ON_ERROR_STOP=1");
+    });
+
+    it("passes --single-transaction when requested", () => {
+      const cmd = buildPsqlCommand(
+        "test.sql",
+        opts({ singleTransaction: true }),
+        "psql",
+      );
+
+      expect(cmd.args).toContain("--single-transaction");
+    });
+
+    it("omits --single-transaction when not requested", () => {
+      const cmd = buildPsqlCommand(
+        "test.sql",
+        opts({ singleTransaction: false }),
+        "psql",
+      );
+
+      expect(cmd.args).not.toContain("--single-transaction");
+    });
+
+    it("passes user variables via -v key=value", () => {
+      const cmd = buildPsqlCommand(
+        "test.sql",
+        opts({ variables: { schema: "public", version: "42" } }),
+        "psql",
+      );
+
+      // Find all -v arguments
+      const varArgs: string[] = [];
+      for (let i = 0; i < cmd.args.length; i++) {
+        if (cmd.args[i] === "-v" && i + 1 < cmd.args.length) {
+          varArgs.push(cmd.args[i + 1]!);
+        }
+      }
+
+      expect(varArgs).toContain("ON_ERROR_STOP=1");
+      expect(varArgs).toContain("schema=public");
+      expect(varArgs).toContain("version=42");
+    });
+
+    it("passes URI via --dbname", () => {
+      const cmd = buildPsqlCommand("test.sql", opts(), "psql");
+
+      const dbIdx = cmd.args.indexOf("--dbname");
+      expect(dbIdx).toBeGreaterThanOrEqual(0);
+      expect(cmd.args[dbIdx + 1]).toBe(defaultUri);
+    });
+
+    it("uses custom dbClient when provided", () => {
+      const cmd = buildPsqlCommand(
+        "test.sql",
+        opts({ dbClient: "/opt/pg16/bin/psql" }),
+        "psql",
+      );
+
+      expect(cmd.bin).toBe("/opt/pg16/bin/psql");
+    });
+
+    it("uses constructor default when dbClient not provided", () => {
+      const cmd = buildPsqlCommand("test.sql", opts(), "/usr/bin/psql");
+
+      expect(cmd.bin).toBe("/usr/bin/psql");
+    });
+
+    it("passes working directory through", () => {
+      const cmd = buildPsqlCommand(
+        "test.sql",
+        opts({ workingDir: "/home/project" }),
+        "psql",
+      );
+
+      expect(cmd.cwd).toBe("/home/project");
+    });
+
+    it("sets cwd to undefined when no workingDir specified", () => {
+      const cmd = buildPsqlCommand("test.sql", opts(), "psql");
+
+      expect(cmd.cwd).toBeUndefined();
+    });
+
+    it("places -f scriptPath as the last arguments", () => {
+      const cmd = buildPsqlCommand("deploy/001-init.sql", opts(), "psql");
+
+      const lastTwo = cmd.args.slice(-2);
+      expect(lastTwo).toEqual(["-f", "deploy/001-init.sql"]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // URI password handling — security
+  // -----------------------------------------------------------------------
+
+  describe("extractPassword()", () => {
+    it("extracts password from postgresql:// URI", () => {
+      const result = extractPassword("postgresql://user:secret@host/db");
+      expect(result.password).toBe("secret");
+      expect(result.cleanUri).toBe("postgresql://user@host/db");
+    });
+
+    it("extracts password from postgres:// URI", () => {
+      const result = extractPassword("postgres://admin:p4ssw0rd@db.example.com:5432/mydb");
+      expect(result.password).toBe("p4ssw0rd");
+      expect(result.cleanUri).toBe("postgres://admin@db.example.com:5432/mydb");
+    });
+
+    it("handles password with special characters", () => {
+      const result = extractPassword("postgresql://user:p@ss:word!@host/db");
+      expect(result.password).toBe("p@ss:word!");
+      expect(result.cleanUri).toBe("postgresql://user@host/db");
+    });
+
+    it("returns undefined password when URI has no password", () => {
+      const result = extractPassword("postgresql://user@host/db");
+      expect(result.password).toBeUndefined();
+      expect(result.cleanUri).toBe("postgresql://user@host/db");
+    });
+
+    it("returns undefined password for host-only URI", () => {
+      const result = extractPassword("postgresql://host/db");
+      expect(result.password).toBeUndefined();
+      expect(result.cleanUri).toBe("postgresql://host/db");
+    });
+  });
+
+  describe("password never appears in args", () => {
+    it("strips password from URI and sets PGPASSWORD env var", () => {
+      const cmd = buildPsqlCommand(
+        "test.sql",
+        opts({ uri: "postgresql://admin:s3cret@host:5432/db" }),
+        "psql",
+      );
+
+      // Password must NOT appear anywhere in args
+      const argsJoined = cmd.args.join(" ");
+      expect(argsJoined).not.toContain("s3cret");
+
+      // Password must be in PGPASSWORD env var
+      expect(cmd.env["PGPASSWORD"]).toBe("s3cret");
+
+      // The URI passed via --dbname must not contain the password
+      const dbIdx = cmd.args.indexOf("--dbname");
+      expect(cmd.args[dbIdx + 1]).toBe("postgresql://admin@host:5432/db");
+    });
+
+    it("does not set PGPASSWORD when URI has no password", () => {
+      const cmd = buildPsqlCommand(
+        "test.sql",
+        opts({ uri: "postgresql://user@host/db" }),
+        "psql",
+      );
+
+      expect(cmd.env["PGPASSWORD"]).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // parsePsqlStderr — error extraction
+  // -----------------------------------------------------------------------
+
+  describe("parsePsqlStderr()", () => {
+    it("returns undefined for empty stderr", () => {
+      expect(parsePsqlStderr("")).toBeUndefined();
+      expect(parsePsqlStderr("   ")).toBeUndefined();
+    });
+
+    it("parses standard psql error with file location", () => {
+      const stderr =
+        'psql:deploy/001-init.sql:42: ERROR:  relation "users" does not exist\n' +
+        "LINE 1: SELECT * FROM users;\n" +
+        "                       ^\n";
+
+      const err = parsePsqlStderr(stderr);
+      expect(err).toBeDefined();
+      expect(err!.severity).toBe("ERROR");
+      expect(err!.message).toBe('relation "users" does not exist');
+      expect(err!.location).toBe("deploy/001-init.sql:42");
+    });
+
+    it("parses error without file location", () => {
+      const stderr = 'ERROR:  syntax error at or near "SELEC"\n';
+
+      const err = parsePsqlStderr(stderr);
+      expect(err).toBeDefined();
+      expect(err!.severity).toBe("ERROR");
+      expect(err!.message).toBe('syntax error at or near "SELEC"');
+      expect(err!.location).toBeUndefined();
+    });
+
+    it("parses FATAL error", () => {
+      const stderr =
+        'FATAL:  database "nonexistent" does not exist\n';
+
+      const err = parsePsqlStderr(stderr);
+      expect(err).toBeDefined();
+      expect(err!.severity).toBe("FATAL");
+      expect(err!.message).toBe('database "nonexistent" does not exist');
+    });
+
+    it("extracts DETAIL line", () => {
+      const stderr =
+        'psql:test.sql:5: ERROR:  insert or update on table "orders" violates foreign key constraint "orders_user_id_fkey"\n' +
+        "DETAIL:  Key (user_id)=(999) is not present in table \"users\".\n";
+
+      const err = parsePsqlStderr(stderr);
+      expect(err).toBeDefined();
+      expect(err!.detail).toBe(
+        'Key (user_id)=(999) is not present in table "users".',
+      );
+    });
+
+    it("extracts HINT line", () => {
+      const stderr =
+        "ERROR:  column \"foo\" does not exist\n" +
+        'HINT:  Perhaps you meant to reference the column "bar.foo".\n';
+
+      const err = parsePsqlStderr(stderr);
+      expect(err).toBeDefined();
+      expect(err!.hint).toBe(
+        'Perhaps you meant to reference the column "bar.foo".',
+      );
+    });
+
+    it("extracts CONTEXT line", () => {
+      const stderr =
+        "ERROR:  null value in column \"id\" violates not-null constraint\n" +
+        "CONTEXT:  SQL function \"insert_foo\" statement 1\n";
+
+      const err = parsePsqlStderr(stderr);
+      expect(err).toBeDefined();
+      expect(err!.context).toBe(
+        'SQL function "insert_foo" statement 1',
+      );
+    });
+
+    it("extracts STATEMENT line", () => {
+      const stderr =
+        "ERROR:  division by zero\n" +
+        "STATEMENT:  SELECT 1/0;\n";
+
+      const err = parsePsqlStderr(stderr);
+      expect(err).toBeDefined();
+      expect(err!.statement).toBe("SELECT 1/0;");
+    });
+
+    it("returns undefined for non-error stderr output", () => {
+      // psql may emit notices or warnings to stderr
+      const stderr = "NOTICE:  table \"foo\" does not exist, skipping\n";
+
+      const err = parsePsqlStderr(stderr);
+      expect(err).toBeUndefined();
+    });
+
+    it("handles multi-field error output", () => {
+      const stderr =
+        'psql:deploy/002.sql:10: ERROR:  duplicate key value violates unique constraint "users_pkey"\n' +
+        "DETAIL:  Key (id)=(1) already exists.\n" +
+        "HINT:  Use ON CONFLICT to handle duplicates.\n" +
+        "CONTEXT:  SQL statement in PL/pgSQL function\n" +
+        "STATEMENT:  INSERT INTO users (id) VALUES (1);\n";
+
+      const err = parsePsqlStderr(stderr);
+      expect(err).toBeDefined();
+      expect(err!.severity).toBe("ERROR");
+      expect(err!.message).toBe(
+        'duplicate key value violates unique constraint "users_pkey"',
+      );
+      expect(err!.location).toBe("deploy/002.sql:10");
+      expect(err!.detail).toBe("Key (id)=(1) already exists.");
+      expect(err!.hint).toBe("Use ON CONFLICT to handle duplicates.");
+      expect(err!.context).toBe("SQL statement in PL/pgSQL function");
+      expect(err!.statement).toBe("INSERT INTO users (id) VALUES (1);");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // PsqlRunner — integration with mock subprocess
+  // -----------------------------------------------------------------------
+
+  describe("PsqlRunner", () => {
+    it("runs psql and returns stdout/stderr on success", async () => {
+      const { spawnFn, calls } = createMockSpawn(0, "SELECT 1\n", "");
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      const result = await runner.run("test.sql", opts());
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("SELECT 1\n");
+      expect(result.stderr).toBe("");
+      expect(result.error).toBeUndefined();
+
+      // Verify spawn was called with correct binary
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.command).toBe("psql");
+    });
+
+    it("returns parsed error on non-zero exit", async () => {
+      const stderrOutput =
+        'psql:deploy/001.sql:5: ERROR:  relation "foo" does not exist\n';
+      const { spawnFn } = createMockSpawn(2, "", stderrOutput);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      const result = await runner.run("deploy/001.sql", opts());
+
+      expect(result.exitCode).toBe(2);
+      expect(result.error).toBeDefined();
+      expect(result.error!.severity).toBe("ERROR");
+      expect(result.error!.message).toBe('relation "foo" does not exist');
+    });
+
+    it("does not parse errors when exit code is 0", async () => {
+      // Even if stderr has content, no error parsing on success
+      const { spawnFn } = createMockSpawn(
+        0,
+        "",
+        "NOTICE:  table created\n",
+      );
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      const result = await runner.run("test.sql", opts());
+
+      expect(result.exitCode).toBe(0);
+      expect(result.error).toBeUndefined();
+      expect(result.stderr).toBe("NOTICE:  table created\n");
+    });
+
+    it("rejects when spawn fails (e.g., binary not found)", async () => {
+      const spawnError = new Error("spawn psql ENOENT");
+      const { spawnFn } = createErrorSpawn(spawnError);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      await expect(runner.run("test.sql", opts())).rejects.toThrow(
+        "spawn psql ENOENT",
+      );
+    });
+
+    it("uses custom psql path from constructor", async () => {
+      const { spawnFn, calls } = createMockSpawn(0);
+      const runner = new PsqlRunner("/opt/pg16/bin/psql", spawnFn);
+
+      await runner.run("test.sql", opts());
+
+      expect(calls[0]!.command).toBe("/opt/pg16/bin/psql");
+    });
+
+    it("uses dbClient from options over constructor default", async () => {
+      const { spawnFn, calls } = createMockSpawn(0);
+      const runner = new PsqlRunner("/default/psql", spawnFn);
+
+      await runner.run("test.sql", opts({ dbClient: "/override/psql" }));
+
+      expect(calls[0]!.command).toBe("/override/psql");
+    });
+
+    it("passes PSQLRC=/dev/null in environment", async () => {
+      const { spawnFn, calls } = createMockSpawn(0);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      await runner.run("test.sql", opts());
+
+      const env = calls[0]!.options["env"] as Record<string, string>;
+      expect(env["PSQLRC"]).toBe("/dev/null");
+    });
+
+    it("passes PGPASSWORD in environment when URI has password", async () => {
+      const { spawnFn, calls } = createMockSpawn(0);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      await runner.run(
+        "test.sql",
+        opts({ uri: "postgresql://user:topsecret@host/db" }),
+      );
+
+      const env = calls[0]!.options["env"] as Record<string, string>;
+      expect(env["PGPASSWORD"]).toBe("topsecret");
+
+      // Password must not be in args
+      const args = calls[0]!.args;
+      expect(args.join(" ")).not.toContain("topsecret");
+    });
+
+    it("sets working directory when provided", async () => {
+      const { spawnFn, calls } = createMockSpawn(0);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      await runner.run("test.sql", opts({ workingDir: "/project/root" }));
+
+      expect(calls[0]!.options["cwd"]).toBe("/project/root");
+    });
+
+    it("passes --single-transaction when requested", async () => {
+      const { spawnFn, calls } = createMockSpawn(0);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      await runner.run("test.sql", opts({ singleTransaction: true }));
+
+      expect(calls[0]!.args).toContain("--single-transaction");
+    });
+
+    it("passes variables as -v key=value", async () => {
+      const { spawnFn, calls } = createMockSpawn(0);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      await runner.run(
+        "test.sql",
+        opts({ variables: { schema: "myschema", debug: "on" } }),
+      );
+
+      const args = calls[0]!.args;
+      // Find all -v args after ON_ERROR_STOP
+      const varArgs: string[] = [];
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === "-v" && i + 1 < args.length) {
+          varArgs.push(args[i + 1]!);
+        }
+      }
+
+      expect(varArgs).toContain("schema=myschema");
+      expect(varArgs).toContain("debug=on");
+    });
+
+    it("handles null exit code as exit code 1", async () => {
+      // When the process is killed, exit code can be null
+      const { spawnFn } = createMockSpawn(null as unknown as number);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      const result = await runner.run("test.sql", opts());
+
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("includes --no-psqlrc in args", async () => {
+      const { spawnFn, calls } = createMockSpawn(0);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      await runner.run("test.sql", opts());
+
+      expect(calls[0]!.args).toContain("--no-psqlrc");
+    });
+
+    it("uses stdin=ignore to prevent interactive prompts", async () => {
+      const { spawnFn, calls } = createMockSpawn(0);
+      const runner = new PsqlRunner("psql", spawnFn);
+
+      await runner.run("test.sql", opts());
+
+      const stdio = calls[0]!.options["stdio"] as string[];
+      expect(stdio[0]).toBe("ignore");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8

- Add `PsqlRunner` class in `src/psql.ts` that executes SQL migration scripts by shelling out to `psql`, per SPEC DD12
- Passwords are extracted from URIs and passed via `PGPASSWORD` env var (never in process args visible via `ps`)
- Sets `ON_ERROR_STOP=1`, disables `.psqlrc` (both env var and `--no-psqlrc` flag), supports `--single-transaction`, `-v key=value` variables, configurable psql path, and working directory
- Best-effort stderr parser extracts structured error info (severity, message, location, detail, hint, context, statement)
- 42 unit tests covering command construction, password security, error parsing, and subprocess behavior — all using mock spawn (no real psql required)

## Test plan

- [x] `bun test` — all 92 tests pass (42 new + 50 existing)
- [x] Verify command-line args are constructed correctly (ON_ERROR_STOP, --no-psqlrc, --single-transaction, -v vars, --dbname, -f script)
- [x] Verify passwords never appear in process arguments
- [x] Verify PGPASSWORD env var is set when URI contains a password
- [x] Verify psql stderr error messages are parsed into structured fields
- [x] Verify spawn errors (e.g., binary not found) propagate correctly
- [x] Verify working directory is passed through for `\i` relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)