### PR TITLE
S2-1: Plan types + ID computation

### DIFF
--- a/src/plan/types.ts
+++ b/src/plan/types.ts
@@ -1,0 +1,286 @@
+// src/plan/types.ts — Core plan types and ID computation for sqlever
+//
+// Defines Change, Tag, Dependency, Project, Plan, and PlanEntry types.
+// Implements Sqitch-compatible SHA-1 ID computation (SPEC R2).
+//
+// CRITICAL: The ID algorithms MUST match Sqitch byte-for-byte.
+// change_id is the primary key in sqitch.changes — any divergence
+// breaks mid-deploy handoff from Sqitch to sqlever.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A project definition from plan pragmas (%project, %uri). */
+export interface Project {
+  /** Project name from %project pragma. */
+  name: string;
+  /** Optional project URI from %uri pragma. */
+  uri?: string;
+}
+
+/** Dependency type: require or conflict. */
+export type DependencyType = "require" | "conflict";
+
+/** A single dependency reference (require or conflict). */
+export interface Dependency {
+  /** Whether this is a require or conflict dependency. */
+  type: DependencyType;
+  /** Dependency name (change name, possibly with @tag suffix). */
+  name: string;
+  /** Cross-project reference, if using project:change syntax. */
+  project?: string;
+}
+
+/** A change entry in the plan. */
+export interface Change {
+  /** SHA-1 change ID computed per SPEC R2 algorithm. */
+  change_id: string;
+  /** Change name (e.g., "add_users"). */
+  name: string;
+  /** Project this change belongs to. */
+  project: string;
+  /** Free-text note (from # comment on change line). */
+  note: string;
+  /** Name of the person who planned this change. */
+  planner_name: string;
+  /** Email of the person who planned this change. */
+  planner_email: string;
+  /** ISO 8601 timestamp when this change was planned. */
+  planned_at: string;
+  /** Required dependencies (preserves declaration order). */
+  requires: string[];
+  /** Conflict dependencies (preserves declaration order). */
+  conflicts: string[];
+  /** Parent change ID, if this is not the first change in the plan. */
+  parent?: string;
+}
+
+/** A tag entry in the plan. */
+export interface Tag {
+  /** SHA-1 tag ID computed per SPEC R2 algorithm. */
+  tag_id: string;
+  /** Tag name without @ prefix (e.g., "v1.0"). */
+  name: string;
+  /** Project this tag belongs to. */
+  project: string;
+  /** Change ID that this tag is attached to. */
+  change_id: string;
+  /** Free-text note. */
+  note: string;
+  /** Name of the person who planned this tag. */
+  planner_name: string;
+  /** Email of the person who planned this tag. */
+  planner_email: string;
+  /** ISO 8601 timestamp when this tag was planned. */
+  planned_at: string;
+}
+
+/** Discriminated union of plan entries. */
+export type PlanEntry =
+  | { type: "change"; value: Change }
+  | { type: "tag"; value: Tag };
+
+/** A parsed plan file. */
+export interface Plan {
+  /** Project definition from pragmas. */
+  project: Project;
+  /** Raw pragmas from the plan file (key -> value). */
+  pragmas: Map<string, string>;
+  /** Ordered list of changes. */
+  changes: Change[];
+  /** Ordered list of tags. */
+  tags: Tag[];
+}
+
+// ---------------------------------------------------------------------------
+// Input types for ID computation
+// ---------------------------------------------------------------------------
+
+/** Input for computing a change ID. Excludes change_id itself. */
+export interface ChangeIdInput {
+  project: string;
+  uri?: string;
+  change: string;
+  parent?: string;
+  planner_name: string;
+  planner_email: string;
+  planned_at: string;
+  requires: string[];
+  conflicts: string[];
+  note: string;
+}
+
+/** Input for computing a tag ID. Excludes tag_id itself. */
+export interface TagIdInput {
+  project: string;
+  uri?: string;
+  tag: string;
+  change_id: string;
+  planner_name: string;
+  planner_email: string;
+  planned_at: string;
+  note: string;
+}
+
+// ---------------------------------------------------------------------------
+// ID computation — MUST match Sqitch byte-for-byte
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the content string for a change ID.
+ *
+ * Format (each line terminated by \n):
+ *   project <project_name>
+ *   uri <uri>                    (conditional: only if URI present)
+ *   change <change_name>
+ *   parent <parent_change_id>    (conditional: only if parent present)
+ *   planner <name> <<email>>
+ *   date <date_iso8601>
+ *   requires                     (conditional: only if requires exist)
+ *     + dep1                     (indented "  + " prefix)
+ *     + dep2
+ *   conflicts                    (conditional: only if conflicts exist)
+ *     - dep1                     (indented "  - " prefix)
+ *
+ *   <note_text>                  (blank line + note, only if note non-empty)
+ */
+export function buildChangeContent(input: ChangeIdInput): string {
+  const lines: string[] = [];
+
+  lines.push(`project ${input.project}`);
+
+  if (input.uri != null && input.uri !== "") {
+    lines.push(`uri ${input.uri}`);
+  }
+
+  lines.push(`change ${input.change}`);
+
+  if (input.parent != null && input.parent !== "") {
+    lines.push(`parent ${input.parent}`);
+  }
+
+  lines.push(`planner ${input.planner_name} <${input.planner_email}>`);
+  lines.push(`date ${input.planned_at}`);
+
+  if (input.requires.length > 0) {
+    lines.push("requires");
+    for (const dep of input.requires) {
+      lines.push(`  + ${dep}`);
+    }
+  }
+
+  if (input.conflicts.length > 0) {
+    lines.push("conflicts");
+    for (const dep of input.conflicts) {
+      lines.push(`  - ${dep}`);
+    }
+  }
+
+  if (input.note !== "") {
+    lines.push("");
+    lines.push(input.note);
+  }
+
+  // Each line terminated by \n, including the last one
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Compute a Sqitch-compatible change ID.
+ *
+ * SHA-1 envelope: `change <content_length>\0<content>`
+ * where content_length is the byte length of the UTF-8 encoded content.
+ */
+export function computeChangeId(input: ChangeIdInput): string {
+  const content = buildChangeContent(input);
+  const contentBytes = Buffer.from(content, "utf-8");
+  const header = `change ${contentBytes.length}\0`;
+  const headerBytes = Buffer.from(header, "utf-8");
+
+  const hash = createHash("sha1");
+  hash.update(headerBytes);
+  hash.update(contentBytes);
+
+  return hash.digest("hex");
+}
+
+/**
+ * Build the content string for a tag ID.
+ *
+ * Format (each line terminated by \n):
+ *   project <project_name>
+ *   uri <uri>                    (conditional)
+ *   tag @<tag_name>              (NOTE: @ prefix on tag name!)
+ *   change <change_id>
+ *   planner <name> <<email>>
+ *   date <date_iso8601>
+ *
+ *   <note_text>                  (blank line + note, only if note non-empty)
+ */
+export function buildTagContent(input: TagIdInput): string {
+  const lines: string[] = [];
+
+  lines.push(`project ${input.project}`);
+
+  if (input.uri != null && input.uri !== "") {
+    lines.push(`uri ${input.uri}`);
+  }
+
+  lines.push(`tag @${input.tag}`);
+  lines.push(`change ${input.change_id}`);
+  lines.push(`planner ${input.planner_name} <${input.planner_email}>`);
+  lines.push(`date ${input.planned_at}`);
+
+  if (input.note !== "") {
+    lines.push("");
+    lines.push(input.note);
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Compute a Sqitch-compatible tag ID.
+ *
+ * SHA-1 envelope: `tag <content_length>\0<content>`
+ * where content_length is the byte length of the UTF-8 encoded content.
+ */
+export function computeTagId(input: TagIdInput): string {
+  const content = buildTagContent(input);
+  const contentBytes = Buffer.from(content, "utf-8");
+  const header = `tag ${contentBytes.length}\0`;
+  const headerBytes = Buffer.from(header, "utf-8");
+
+  const hash = createHash("sha1");
+  hash.update(headerBytes);
+  hash.update(contentBytes);
+
+  return hash.digest("hex");
+}
+
+/**
+ * Compute script_hash: plain SHA-1 of raw file bytes.
+ *
+ * NO "blob <size>\0" prefix — Sqitch reads raw binary and feeds
+ * directly to SHA-1 (App::Sqitch::Plan::Change->_deploy_hash).
+ */
+export function computeScriptHash(filePath: string): string {
+  const raw = readFileSync(filePath);
+  const hash = createHash("sha1");
+  hash.update(raw);
+  return hash.digest("hex");
+}
+
+/**
+ * Compute script_hash from a Buffer of raw bytes.
+ * Useful when you already have the content in memory.
+ */
+export function computeScriptHashFromBytes(content: Buffer): string {
+  const hash = createHash("sha1");
+  hash.update(content);
+  return hash.digest("hex");
+}

--- a/tests/unit/plan-types.test.ts
+++ b/tests/unit/plan-types.test.ts
@@ -1,0 +1,854 @@
+// tests/unit/plan-types.test.ts — Tests for plan types and ID computation
+//
+// Validates that computeChangeId, computeTagId, and computeScriptHash
+// produce Sqitch-compatible SHA-1 hashes. All expected values are
+// manually computed reference hashes.
+
+import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import { writeFileSync, unlinkSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  buildChangeContent,
+  buildTagContent,
+  computeChangeId,
+  computeTagId,
+  computeScriptHash,
+  computeScriptHashFromBytes,
+} from "../../src/plan/types";
+
+import type {
+  Project,
+  Change,
+  Tag,
+  Dependency,
+  Plan,
+  PlanEntry,
+  ChangeIdInput,
+  TagIdInput,
+} from "../../src/plan/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Manually compute SHA-1 hex for verification. */
+function manualSha1(prefix: string, content: string): string {
+  const contentBytes = Buffer.from(content, "utf-8");
+  const header = `${prefix} ${contentBytes.length}\0`;
+  const hash = createHash("sha1");
+  hash.update(Buffer.from(header, "utf-8"));
+  hash.update(contentBytes);
+  return hash.digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Change ID computation
+// ---------------------------------------------------------------------------
+
+describe("computeChangeId", () => {
+  it("1: minimal change — first change, no parent, no deps, no note, no uri", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "first_change",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "",
+    };
+
+    const id = computeChangeId(input);
+    expect(id).toBe("8edcefb586de12c59f02512d70987ee81d7bc7b0");
+  });
+
+  it("2: change with parent (second change in plan)", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "second_change",
+      parent: "abc123def456",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "",
+    };
+
+    const id = computeChangeId(input);
+    expect(id).toBe("00e9f46974290ef11cb02c53561fc95a3c091b2c");
+  });
+
+  it("3: change with URI", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      uri: "https://example.com/myproject",
+      change: "first_change",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "",
+    };
+
+    const id = computeChangeId(input);
+    expect(id).toBe("485341707b64764137cbd58bcdfcdedd65b05f7f");
+  });
+
+  it("4: change with requires dependencies", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "add_users",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: ["create_schema", "add_roles"],
+      conflicts: [],
+      note: "",
+    };
+
+    const id = computeChangeId(input);
+    expect(id).toBe("4e3e43fe6db89b8abf8e352a877c06a8da54f363");
+  });
+
+  it("5: change with conflicts", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "add_users",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: ["old_users"],
+      note: "",
+    };
+
+    const id = computeChangeId(input);
+    expect(id).toBe("274e79b3e35726de4c3c95b8d5f857ed4e10dc85");
+  });
+
+  it("6: change with note", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "add_users",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "Add users table for authentication",
+    };
+
+    const id = computeChangeId(input);
+    expect(id).toBe("3a6c4fac7b6ffdf433106e1aeba7953f0f7b0efa");
+  });
+
+  it("7: full change — URI, parent, requires, conflicts, note", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      uri: "https://example.com/myproject",
+      change: "add_users",
+      parent: "abc123",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: ["create_schema", "add_roles"],
+      conflicts: ["old_users"],
+      note: "Add users table for authentication",
+    };
+
+    const id = computeChangeId(input);
+    expect(id).toBe("64c3d274330067d4e3df28e3f5019f787a7c5bf4");
+  });
+
+  it("11: unicode in change name, planner, and note", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "add_ñoño",
+      planner_name: "José García",
+      planner_email: "jose@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "Añadir tabla de usuarios",
+    };
+
+    const id = computeChangeId(input);
+    expect(id).toBe("f336cdde5f77b21c00bb285aa954501d4770dc31");
+  });
+
+  it("12: requires AND conflicts together", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "add_users",
+      parent: "abc123",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: ["create_schema"],
+      conflicts: ["old_users", "legacy_auth"],
+      note: "",
+    };
+
+    const id = computeChangeId(input);
+    expect(id).toBe("6306be797643dd66a6b06ed0cd9001befdff2bb7");
+  });
+
+  it("content uses byte length, not string length for unicode", () => {
+    // Unicode characters take more bytes than string length suggests.
+    // The envelope must use byte length.
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "add_ñoño",
+      planner_name: "José García",
+      planner_email: "jose@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "Añadir tabla de usuarios",
+    };
+
+    const content = buildChangeContent(input);
+    const byteLength = Buffer.from(content, "utf-8").length;
+    const stringLength = content.length;
+
+    // UTF-8 bytes > string length due to multi-byte chars
+    expect(byteLength).toBeGreaterThan(stringLength);
+    expect(byteLength).toBe(130);
+    expect(stringLength).toBe(125);
+  });
+
+  it("empty parent string is treated as no parent", () => {
+    const withoutParent: ChangeIdInput = {
+      project: "myproject",
+      change: "first_change",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "",
+    };
+
+    const withEmptyParent: ChangeIdInput = {
+      ...withoutParent,
+      parent: "",
+    };
+
+    expect(computeChangeId(withEmptyParent)).toBe(computeChangeId(withoutParent));
+  });
+
+  it("empty URI string is treated as no URI", () => {
+    const withoutUri: ChangeIdInput = {
+      project: "myproject",
+      change: "first_change",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "",
+    };
+
+    const withEmptyUri: ChangeIdInput = {
+      ...withoutUri,
+      uri: "",
+    };
+
+    expect(computeChangeId(withEmptyUri)).toBe(computeChangeId(withoutUri));
+  });
+
+  it("dependency order matters (not sorted)", () => {
+    const input1: ChangeIdInput = {
+      project: "myproject",
+      change: "add_users",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: ["alpha", "beta"],
+      conflicts: [],
+      note: "",
+    };
+
+    const input2: ChangeIdInput = {
+      ...input1,
+      requires: ["beta", "alpha"],
+    };
+
+    // Different order = different ID
+    expect(computeChangeId(input1)).not.toBe(computeChangeId(input2));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildChangeContent — verify exact content format
+// ---------------------------------------------------------------------------
+
+describe("buildChangeContent", () => {
+  it("minimal content format is correct", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "first_change",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "",
+    };
+
+    const content = buildChangeContent(input);
+    expect(content).toBe(
+      "project myproject\n" +
+        "change first_change\n" +
+        "planner Test User <test@example.com>\n" +
+        "date 2024-01-15T12:00:00Z\n",
+    );
+  });
+
+  it("full content format includes all sections in correct order", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      uri: "https://example.com/myproject",
+      change: "add_users",
+      parent: "abc123",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: ["create_schema", "add_roles"],
+      conflicts: ["old_users"],
+      note: "Add users table for authentication",
+    };
+
+    const content = buildChangeContent(input);
+    expect(content).toBe(
+      "project myproject\n" +
+        "uri https://example.com/myproject\n" +
+        "change add_users\n" +
+        "parent abc123\n" +
+        "planner Test User <test@example.com>\n" +
+        "date 2024-01-15T12:00:00Z\n" +
+        "requires\n" +
+        "  + create_schema\n" +
+        "  + add_roles\n" +
+        "conflicts\n" +
+        "  - old_users\n" +
+        "\n" +
+        "Add users table for authentication\n",
+    );
+  });
+
+  it("note is preceded by blank line separator", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "test",
+      planner_name: "User",
+      planner_email: "user@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "Some note",
+    };
+
+    const content = buildChangeContent(input);
+    // Should end with: ...date line\n\nSome note\n
+    expect(content).toContain("2024-01-15T12:00:00Z\n\nSome note\n");
+  });
+
+  it("no blank line when note is empty", () => {
+    const input: ChangeIdInput = {
+      project: "myproject",
+      change: "test",
+      planner_name: "User",
+      planner_email: "user@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      note: "",
+    };
+
+    const content = buildChangeContent(input);
+    // Should NOT have trailing blank line
+    expect(content).toBe(
+      "project myproject\n" +
+        "change test\n" +
+        "planner User <user@example.com>\n" +
+        "date 2024-01-15T12:00:00Z\n",
+    );
+  });
+
+  it("requires section with indented + prefix", () => {
+    const input: ChangeIdInput = {
+      project: "p",
+      change: "c",
+      planner_name: "U",
+      planner_email: "u@e.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: ["dep1", "dep2"],
+      conflicts: [],
+      note: "",
+    };
+
+    const content = buildChangeContent(input);
+    expect(content).toContain("requires\n  + dep1\n  + dep2\n");
+  });
+
+  it("conflicts section with indented - prefix", () => {
+    const input: ChangeIdInput = {
+      project: "p",
+      change: "c",
+      planner_name: "U",
+      planner_email: "u@e.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: ["conf1"],
+      note: "",
+    };
+
+    const content = buildChangeContent(input);
+    expect(content).toContain("conflicts\n  - conf1\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tag ID computation
+// ---------------------------------------------------------------------------
+
+describe("computeTagId", () => {
+  it("8: minimal tag — no uri, no note", () => {
+    const input: TagIdInput = {
+      project: "myproject",
+      tag: "v1.0",
+      change_id: "deadbeef",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      note: "",
+    };
+
+    const id = computeTagId(input);
+    expect(id).toBe("526fe5e1e63376bfb29593d303258cd79eaf87b0");
+  });
+
+  it("9: tag with URI and note", () => {
+    const input: TagIdInput = {
+      project: "myproject",
+      uri: "https://example.com/myproject",
+      tag: "v1.0",
+      change_id: "deadbeef",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      note: "First release",
+    };
+
+    const id = computeTagId(input);
+    expect(id).toBe("28bc678f48aa5604ae510ce254b017298e615f18");
+  });
+
+  it("tag name includes @ prefix in content", () => {
+    const input: TagIdInput = {
+      project: "myproject",
+      tag: "v1.0",
+      change_id: "deadbeef",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      note: "",
+    };
+
+    const content = buildTagContent(input);
+    expect(content).toContain("tag @v1.0\n");
+    // Must NOT have "tag v1.0" (without @)
+    expect(content).not.toMatch(/^tag v1\.0$/m);
+  });
+
+  it("tag envelope uses 'tag' prefix not 'change'", () => {
+    const input: TagIdInput = {
+      project: "myproject",
+      tag: "v1.0",
+      change_id: "deadbeef",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      note: "",
+    };
+
+    // Manually verify the envelope format
+    const content = buildTagContent(input);
+
+    // Verify the ID matches what we'd get with "tag" prefix
+    const expected = manualSha1("tag", content);
+    expect(computeTagId(input)).toBe(expected);
+
+    // Verify it does NOT match "change" prefix
+    const wrongPrefix = manualSha1("change", content);
+    expect(computeTagId(input)).not.toBe(wrongPrefix);
+  });
+
+  it("empty URI string is treated as no URI", () => {
+    const withoutUri: TagIdInput = {
+      project: "myproject",
+      tag: "v1.0",
+      change_id: "deadbeef",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      note: "",
+    };
+
+    const withEmptyUri: TagIdInput = {
+      ...withoutUri,
+      uri: "",
+    };
+
+    expect(computeTagId(withEmptyUri)).toBe(computeTagId(withoutUri));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTagContent — verify exact content format
+// ---------------------------------------------------------------------------
+
+describe("buildTagContent", () => {
+  it("minimal tag content format is correct", () => {
+    const input: TagIdInput = {
+      project: "myproject",
+      tag: "v1.0",
+      change_id: "deadbeef",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      note: "",
+    };
+
+    const content = buildTagContent(input);
+    expect(content).toBe(
+      "project myproject\n" +
+        "tag @v1.0\n" +
+        "change deadbeef\n" +
+        "planner Test User <test@example.com>\n" +
+        "date 2024-01-15T12:00:00Z\n",
+    );
+  });
+
+  it("full tag content includes URI and note with blank line", () => {
+    const input: TagIdInput = {
+      project: "myproject",
+      uri: "https://example.com/myproject",
+      tag: "v1.0",
+      change_id: "deadbeef",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      note: "First release",
+    };
+
+    const content = buildTagContent(input);
+    expect(content).toBe(
+      "project myproject\n" +
+        "uri https://example.com/myproject\n" +
+        "tag @v1.0\n" +
+        "change deadbeef\n" +
+        "planner Test User <test@example.com>\n" +
+        "date 2024-01-15T12:00:00Z\n" +
+        "\n" +
+        "First release\n",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// script_hash computation
+// ---------------------------------------------------------------------------
+
+describe("computeScriptHash", () => {
+  it("10: plain SHA-1 of raw file bytes (no blob prefix)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sqlever-test-"));
+    const filePath = join(dir, "deploy.sql");
+    const content = "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL);\n";
+    writeFileSync(filePath, content, "utf-8");
+
+    try {
+      const hash = computeScriptHash(filePath);
+      expect(hash).toBe("ace3589c10ea2a2ec813b87299be20aaefd4f52d");
+
+      // Verify this is NOT the git-style "blob <size>\0" hash
+      const gitHash = createHash("sha1")
+        .update(`blob ${Buffer.from(content).length}\0`)
+        .update(content)
+        .digest("hex");
+      expect(hash).not.toBe(gitHash);
+    } finally {
+      unlinkSync(filePath);
+    }
+  });
+
+  it("computeScriptHashFromBytes matches computeScriptHash", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sqlever-test-"));
+    const filePath = join(dir, "deploy.sql");
+    const content = "SELECT 1;\n";
+    writeFileSync(filePath, content, "utf-8");
+
+    try {
+      const fromFile = computeScriptHash(filePath);
+      const fromBytes = computeScriptHashFromBytes(Buffer.from(content, "utf-8"));
+      expect(fromFile).toBe(fromBytes);
+    } finally {
+      unlinkSync(filePath);
+    }
+  });
+
+  it("binary content is hashed without line-ending normalization", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sqlever-test-"));
+    const filePath = join(dir, "deploy.sql");
+
+    // Write content with explicit \r\n line endings
+    const content = Buffer.from("SELECT 1;\r\nSELECT 2;\r\n", "utf-8");
+    writeFileSync(filePath, content);
+
+    try {
+      const hash = computeScriptHash(filePath);
+      // Should hash the raw bytes including \r\n, not normalize to \n
+      const expected = createHash("sha1").update(content).digest("hex");
+      expect(hash).toBe(expected);
+    } finally {
+      unlinkSync(filePath);
+    }
+  });
+
+  it("empty file produces consistent hash", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sqlever-test-"));
+    const filePath = join(dir, "empty.sql");
+    writeFileSync(filePath, "", "utf-8");
+
+    try {
+      const hash = computeScriptHash(filePath);
+      // SHA-1 of empty input
+      const expected = createHash("sha1").update(Buffer.alloc(0)).digest("hex");
+      expect(hash).toBe(expected);
+    } finally {
+      unlinkSync(filePath);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type structure tests (compile-time + runtime shape)
+// ---------------------------------------------------------------------------
+
+describe("type structure", () => {
+  it("Change interface has all required fields", () => {
+    const change: Change = {
+      change_id: "abc123",
+      name: "add_users",
+      project: "myproject",
+      note: "Add users table",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: ["create_schema"],
+      conflicts: [],
+    };
+
+    expect(change.change_id).toBe("abc123");
+    expect(change.name).toBe("add_users");
+    expect(change.requires).toEqual(["create_schema"]);
+    expect(change.parent).toBeUndefined();
+  });
+
+  it("Change supports optional parent", () => {
+    const change: Change = {
+      change_id: "abc123",
+      name: "add_users",
+      project: "myproject",
+      note: "",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+      requires: [],
+      conflicts: [],
+      parent: "def456",
+    };
+
+    expect(change.parent).toBe("def456");
+  });
+
+  it("Tag interface has all required fields", () => {
+    const tag: Tag = {
+      tag_id: "abc123",
+      name: "v1.0",
+      project: "myproject",
+      change_id: "def456",
+      note: "First release",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T12:00:00Z",
+    };
+
+    expect(tag.tag_id).toBe("abc123");
+    expect(tag.name).toBe("v1.0");
+    expect(tag.change_id).toBe("def456");
+  });
+
+  it("Dependency interface supports both types", () => {
+    const req: Dependency = {
+      type: "require",
+      name: "create_schema",
+    };
+
+    const conflict: Dependency = {
+      type: "conflict",
+      name: "old_users",
+      project: "other_project",
+    };
+
+    expect(req.type).toBe("require");
+    expect(req.project).toBeUndefined();
+    expect(conflict.type).toBe("conflict");
+    expect(conflict.project).toBe("other_project");
+  });
+
+  it("Project interface supports optional URI", () => {
+    const withUri: Project = { name: "myproject", uri: "https://example.com" };
+    const withoutUri: Project = { name: "myproject" };
+
+    expect(withUri.uri).toBe("https://example.com");
+    expect(withoutUri.uri).toBeUndefined();
+  });
+
+  it("Plan interface has all fields", () => {
+    const plan: Plan = {
+      project: { name: "myproject" },
+      pragmas: new Map([["project", "myproject"]]),
+      changes: [],
+      tags: [],
+    };
+
+    expect(plan.project.name).toBe("myproject");
+    expect(plan.pragmas.get("project")).toBe("myproject");
+    expect(plan.changes).toEqual([]);
+    expect(plan.tags).toEqual([]);
+  });
+
+  it("PlanEntry discriminated union works", () => {
+    const changeEntry: PlanEntry = {
+      type: "change",
+      value: {
+        change_id: "abc",
+        name: "test",
+        project: "p",
+        note: "",
+        planner_name: "U",
+        planner_email: "u@e.com",
+        planned_at: "2024-01-15T12:00:00Z",
+        requires: [],
+        conflicts: [],
+      },
+    };
+
+    const tagEntry: PlanEntry = {
+      type: "tag",
+      value: {
+        tag_id: "def",
+        name: "v1",
+        project: "p",
+        change_id: "abc",
+        note: "",
+        planner_name: "U",
+        planner_email: "u@e.com",
+        planned_at: "2024-01-15T12:00:00Z",
+      },
+    };
+
+    expect(changeEntry.type).toBe("change");
+    expect(tagEntry.type).toBe("tag");
+
+    // TypeScript narrows correctly
+    if (changeEntry.type === "change") {
+      expect(changeEntry.value.change_id).toBe("abc");
+    }
+    if (tagEntry.type === "tag") {
+      expect(tagEntry.value.tag_id).toBe("def");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chain test: computing IDs for a sequence of changes
+// ---------------------------------------------------------------------------
+
+describe("chained change IDs", () => {
+  it("each change uses previous change_id as parent", () => {
+    const project = "myproject";
+    const planner_name = "Test User";
+    const planner_email = "test@example.com";
+    const planned_at = "2024-01-15T12:00:00Z";
+
+    // First change: no parent
+    const id1 = computeChangeId({
+      project,
+      change: "create_schema",
+      planner_name,
+      planner_email,
+      planned_at,
+      requires: [],
+      conflicts: [],
+      note: "",
+    });
+
+    // Second change: parent is id1
+    const id2 = computeChangeId({
+      project,
+      change: "add_users",
+      parent: id1,
+      planner_name,
+      planner_email,
+      planned_at,
+      requires: ["create_schema"],
+      conflicts: [],
+      note: "",
+    });
+
+    // Third change: parent is id2
+    const id3 = computeChangeId({
+      project,
+      change: "add_posts",
+      parent: id2,
+      planner_name,
+      planner_email,
+      planned_at,
+      requires: ["add_users"],
+      conflicts: [],
+      note: "",
+    });
+
+    // All IDs must be unique
+    expect(id1).not.toBe(id2);
+    expect(id2).not.toBe(id3);
+    expect(id1).not.toBe(id3);
+
+    // All IDs are 40-char hex strings
+    const hexPattern = /^[0-9a-f]{40}$/;
+    expect(id1).toMatch(hexPattern);
+    expect(id2).toMatch(hexPattern);
+    expect(id3).toMatch(hexPattern);
+
+    // Verify determinism: same inputs = same output
+    const id1Again = computeChangeId({
+      project,
+      change: "create_schema",
+      planner_name,
+      planner_email,
+      planned_at,
+      requires: [],
+      conflicts: [],
+      note: "",
+    });
+    expect(id1Again).toBe(id1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #20

- Define core plan types: `Change`, `Tag`, `Dependency`, `Project`, `Plan`, `PlanEntry` in `src/plan/types.ts`
- Implement Sqitch-compatible SHA-1 ID computation functions: `computeChangeId()`, `computeTagId()`, `computeScriptHash()`
- Content builders `buildChangeContent()` / `buildTagContent()` expose the exact string format for debugging and testing

### ID computation details (SPEC R2)

The algorithms match Sqitch byte-for-byte:
- **Change ID**: `SHA-1("change <byte_len>\0" + content)` where content includes conditional URI, parent, requires/conflicts sections with indented `+ ` / `- ` prefixes, and optional blank-line + note
- **Tag ID**: `SHA-1("tag <byte_len>\0" + content)` with `@`-prefixed tag name
- **script_hash**: plain `SHA-1(raw_file_bytes)` — no git-style `blob <size>\0` prefix

### Key correctness points
- Envelope uses UTF-8 **byte length**, not string length (critical for unicode)
- Requires/conflicts preserve declaration order (not sorted)
- Parent is set for every non-first change (not just reworked ones)
- Empty URI/parent/note are correctly omitted from content

## Test plan

38 tests across 7 describe blocks:
- [x] 9 change ID tests with manually computed reference SHA-1 values
- [x] Content format tests for change and tag (exact string matching)
- [x] 4 tag ID tests including envelope prefix verification
- [x] 4 script_hash tests (file-based, bytes-based, CRLF, empty file)
- [x] Type structure tests for all interfaces
- [x] Chained change IDs test (3-change sequence with parent propagation)
- [x] Edge cases: unicode byte length, empty strings, dependency ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)