### PR TITLE
S2-5: sqlever init — initialize project

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 // sqlever — Sqitch-compatible PostgreSQL migration tool
 
 import packageJson from "../package.json";
+import { runInit } from "./commands/init";
 import { setConfig, type OutputFormat } from "./output";
 
 // ---------------------------------------------------------------------------
@@ -277,6 +278,16 @@ export function main(argv: string[] = process.argv.slice(2)): void {
   if (!(args.command in COMMANDS)) {
     process.stderr.write(`sqlever: unknown command '${args.command}'\n`);
     process.exit(1);
+  }
+
+  // --- Dispatch to implemented commands ---
+  if (args.command === "init") {
+    runInit(args).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`sqlever init: ${msg}\n`);
+      process.exit(1);
+    });
+    return;
   }
 
   // Known command — stub handler

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,215 @@
+// src/commands/init.ts — sqlever init command
+//
+// Initializes a new project by creating:
+//   - sqitch.conf with [core] engine = pg and directory settings
+//   - sqitch.plan with pragmas (%syntax-version, %project, optional %uri)
+//   - deploy/, revert/, verify/ directories (respecting --top-dir)
+//
+// Matches Sqitch's `sqitch init` behavior for compatibility (SPEC R1).
+
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import type { ParsedArgs } from "../cli";
+import {
+  serializeSqitchConf,
+  confSet,
+  type SqitchConf,
+} from "../config/sqitch-conf";
+import { info, error } from "../output";
+import { serializePlan } from "../plan/writer";
+import type { Plan } from "../plan/types";
+
+// ---------------------------------------------------------------------------
+// Init-specific argument parsing
+// ---------------------------------------------------------------------------
+
+export interface InitOptions {
+  /** Project name. If not given, derived from the current directory name. */
+  projectName: string;
+  /** Top-level directory for the project (default: "."). */
+  topDir: string;
+  /** Database engine (default: "pg"). */
+  engine: string;
+  /** Optional project URI for the %uri pragma. */
+  uri?: string;
+  /** Path to the plan file (default: "sqitch.plan" under topDir). */
+  planFile?: string;
+  /** Force re-initialization even if sqitch.plan already exists. */
+  force: boolean;
+}
+
+/**
+ * Parse init-specific options from the CLI's parsed args.
+ *
+ * Usage: sqlever init [project_name] [--top-dir dir] [--engine pg] [--uri uri] [--plan-file path] [--force]
+ *
+ * Flags that appear in `rest` (after the command) are parsed here.
+ */
+export function parseInitOptions(args: ParsedArgs): InitOptions {
+  const topDir = args.topDir ?? ".";
+  let projectName: string | undefined;
+  let engine = "pg";
+  let uri: string | undefined;
+  let planFile: string | undefined;
+  let force = false;
+
+  // Parse rest array for init-specific flags and positional project name
+  const rest = args.rest;
+  let i = 0;
+  while (i < rest.length) {
+    const token = rest[i]!;
+
+    if (token === "--engine") {
+      engine = rest[++i] ?? "pg";
+      i++;
+      continue;
+    }
+    if (token === "--uri") {
+      uri = rest[++i];
+      i++;
+      continue;
+    }
+    if (token === "--plan-file") {
+      planFile = rest[++i];
+      i++;
+      continue;
+    }
+    if (token === "--force" || token === "-f") {
+      force = true;
+      i++;
+      continue;
+    }
+
+    // First non-flag token is the project name
+    if (projectName === undefined) {
+      projectName = token;
+    }
+    i++;
+  }
+
+  // Use global --plan-file if not overridden locally
+  if (planFile === undefined && args.planFile !== undefined) {
+    planFile = args.planFile;
+  }
+
+  // Default project name = basename of the resolved top directory
+  if (projectName === undefined) {
+    projectName = basename(resolve(topDir));
+  }
+
+  return { projectName, topDir, engine, uri, planFile, force };
+}
+
+// ---------------------------------------------------------------------------
+// File creation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build sqitch.conf content for a new project.
+ *
+ * Generates:
+ *   [core]
+ *       engine = <engine>
+ *       top_dir = <topDir>       (only if non-default)
+ *       plan_file = <planFile>   (only if non-default)
+ */
+export function buildSqitchConf(options: InitOptions): string {
+  const conf: SqitchConf = { entries: [], rawLines: [] };
+
+  confSet(conf, "core.engine", options.engine);
+
+  // Only write top_dir if it differs from default "."
+  if (options.topDir !== ".") {
+    confSet(conf, "core.top_dir", options.topDir);
+  }
+
+  // Only write plan_file if explicitly specified
+  if (options.planFile !== undefined) {
+    confSet(conf, "core.plan_file", options.planFile);
+  }
+
+  return serializeSqitchConf(conf);
+}
+
+/**
+ * Build an empty sqitch.plan with only pragmas.
+ */
+export function buildInitialPlan(options: InitOptions): string {
+  const pragmas = new Map<string, string>();
+  pragmas.set("syntax-version", "1.0.0");
+  pragmas.set("project", options.projectName);
+  if (options.uri !== undefined) {
+    pragmas.set("uri", options.uri);
+  }
+
+  const plan: Plan = {
+    project: { name: options.projectName, uri: options.uri },
+    pragmas,
+    changes: [],
+    tags: [],
+  };
+
+  return serializePlan(plan);
+}
+
+// ---------------------------------------------------------------------------
+// Main init command
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `init` command.
+ *
+ * Creates sqitch.conf, sqitch.plan, and deploy/revert/verify directories.
+ */
+export async function runInit(args: ParsedArgs): Promise<void> {
+  const options = parseInitOptions(args);
+  const topDir = resolve(options.topDir);
+
+  // Determine file paths
+  const confPath = join(topDir, "sqitch.conf");
+  const planPath = options.planFile
+    ? resolve(options.planFile)
+    : join(topDir, "sqitch.plan");
+
+  // Check if sqitch.plan already exists (unless --force)
+  if (!options.force) {
+    try {
+      const planStat = await stat(planPath);
+      if (planStat.isFile()) {
+        error(
+          `Plan file already exists: ${planPath}\n` +
+            `Use --force to reinitialize.`,
+        );
+        process.exit(1);
+      }
+    } catch {
+      // File doesn't exist — proceed
+    }
+  }
+
+  // Ensure top directory exists
+  await mkdir(topDir, { recursive: true });
+
+  // Create deploy/, revert/, verify/ directories under topDir
+  const dirs = ["deploy", "revert", "verify"];
+  for (const dir of dirs) {
+    await mkdir(join(topDir, dir), { recursive: true });
+  }
+
+  // Write sqitch.conf
+  const confContent = buildSqitchConf(options);
+  await writeFile(confPath, confContent, "utf-8");
+  info(`Created ${confPath}`);
+
+  // Write sqitch.plan
+  const planContent = buildInitialPlan(options);
+  await writeFile(planPath, planContent, "utf-8");
+  info(`Created ${planPath}`);
+
+  // Report created directories
+  for (const dir of dirs) {
+    info(`Created ${join(topDir, dir)}/`);
+  }
+
+  info(`Initialized project '${options.projectName}'`);
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -308,8 +308,8 @@ describe("unknown commands", () => {
 // ---------------------------------------------------------------------------
 
 describe("command stubs", () => {
-  // "help" is handled specially (not a stub), so exclude it
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help");
+  // "help" is handled specially (not a stub), "init" is implemented — exclude both
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -1,0 +1,476 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import {
+  parseInitOptions,
+  buildSqitchConf,
+  buildInitialPlan,
+} from "../../src/commands/init";
+import type { ParsedArgs } from "../../src/cli";
+import { parseSqitchConf, confGet } from "../../src/config/sqitch-conf";
+import { resetConfig } from "../../src/output";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CWD = import.meta.dir + "/../..";
+
+/** Create a fresh temp directory for each test. */
+async function makeTempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "sqlever-init-test-"));
+}
+
+/** Build a minimal ParsedArgs for init, overriding specific fields. */
+function makeArgs(overrides: Partial<ParsedArgs> = {}): ParsedArgs {
+  return {
+    command: "init",
+    rest: [],
+    help: false,
+    version: false,
+    format: "text",
+    quiet: false,
+    verbose: false,
+    dbUri: undefined,
+    planFile: undefined,
+    topDir: undefined,
+    registry: undefined,
+    target: undefined,
+    ...overrides,
+  };
+}
+
+/** Run init in a temp directory via subprocess. */
+async function runInit(
+  tempDir: string,
+  ...extraArgs: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(
+    ["bun", "run", "src/cli.ts", "init", "--top-dir", tempDir, ...extraArgs],
+    {
+      cwd: CWD,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: parseInitOptions (unit, no filesystem)
+// ---------------------------------------------------------------------------
+
+describe("parseInitOptions", () => {
+  test("defaults: project name from cwd basename, engine pg", () => {
+    const args = makeArgs({ rest: [] });
+    const opts = parseInitOptions(args);
+    expect(opts.engine).toBe("pg");
+    expect(opts.topDir).toBe(".");
+    expect(opts.force).toBe(false);
+    // Project name is derived from resolved "." — just check it's non-empty
+    expect(opts.projectName.length).toBeGreaterThan(0);
+  });
+
+  test("positional project name", () => {
+    const args = makeArgs({ rest: ["myproject"] });
+    const opts = parseInitOptions(args);
+    expect(opts.projectName).toBe("myproject");
+  });
+
+  test("--engine flag", () => {
+    const args = makeArgs({ rest: ["proj", "--engine", "sqlite"] });
+    const opts = parseInitOptions(args);
+    expect(opts.engine).toBe("sqlite");
+    expect(opts.projectName).toBe("proj");
+  });
+
+  test("--uri flag", () => {
+    const args = makeArgs({
+      rest: ["proj", "--uri", "urn:uuid:12345"],
+    });
+    const opts = parseInitOptions(args);
+    expect(opts.uri).toBe("urn:uuid:12345");
+  });
+
+  test("--plan-file flag in rest", () => {
+    const args = makeArgs({
+      rest: ["proj", "--plan-file", "custom.plan"],
+    });
+    const opts = parseInitOptions(args);
+    expect(opts.planFile).toBe("custom.plan");
+  });
+
+  test("global --plan-file used when not in rest", () => {
+    const args = makeArgs({
+      rest: ["proj"],
+      planFile: "global.plan",
+    });
+    const opts = parseInitOptions(args);
+    expect(opts.planFile).toBe("global.plan");
+  });
+
+  test("--force flag", () => {
+    const args = makeArgs({ rest: ["proj", "--force"] });
+    const opts = parseInitOptions(args);
+    expect(opts.force).toBe(true);
+  });
+
+  test("-f shorthand for --force", () => {
+    const args = makeArgs({ rest: ["proj", "-f"] });
+    const opts = parseInitOptions(args);
+    expect(opts.force).toBe(true);
+  });
+
+  test("--top-dir from global args", () => {
+    const args = makeArgs({ topDir: "/my/dir", rest: ["proj"] });
+    const opts = parseInitOptions(args);
+    expect(opts.topDir).toBe("/my/dir");
+    expect(opts.projectName).toBe("proj");
+  });
+
+  test("no project name uses top-dir basename", () => {
+    const args = makeArgs({ topDir: "/some/path/myapp" });
+    const opts = parseInitOptions(args);
+    expect(opts.projectName).toBe("myapp");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildSqitchConf (unit)
+// ---------------------------------------------------------------------------
+
+describe("buildSqitchConf", () => {
+  test("default config has engine = pg", () => {
+    const content = buildSqitchConf({
+      projectName: "test",
+      topDir: ".",
+      engine: "pg",
+      force: false,
+    });
+
+    const conf = parseSqitchConf(content);
+    expect(confGet(conf, "core.engine")).toBe("pg");
+  });
+
+  test("non-default top_dir is included", () => {
+    const content = buildSqitchConf({
+      projectName: "test",
+      topDir: "migrations",
+      engine: "pg",
+      force: false,
+    });
+
+    const conf = parseSqitchConf(content);
+    expect(confGet(conf, "core.top_dir")).toBe("migrations");
+  });
+
+  test("default top_dir omits top_dir key", () => {
+    const content = buildSqitchConf({
+      projectName: "test",
+      topDir: ".",
+      engine: "pg",
+      force: false,
+    });
+
+    const conf = parseSqitchConf(content);
+    expect(confGet(conf, "core.top_dir")).toBeUndefined();
+  });
+
+  test("plan_file is included when specified", () => {
+    const content = buildSqitchConf({
+      projectName: "test",
+      topDir: ".",
+      engine: "pg",
+      planFile: "custom.plan",
+      force: false,
+    });
+
+    const conf = parseSqitchConf(content);
+    expect(confGet(conf, "core.plan_file")).toBe("custom.plan");
+  });
+
+  test("custom engine is written", () => {
+    const content = buildSqitchConf({
+      projectName: "test",
+      topDir: ".",
+      engine: "sqlite",
+      force: false,
+    });
+
+    const conf = parseSqitchConf(content);
+    expect(confGet(conf, "core.engine")).toBe("sqlite");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildInitialPlan (unit)
+// ---------------------------------------------------------------------------
+
+describe("buildInitialPlan", () => {
+  test("contains syntax-version pragma", () => {
+    const content = buildInitialPlan({
+      projectName: "myproject",
+      topDir: ".",
+      engine: "pg",
+      force: false,
+    });
+
+    expect(content).toContain("%syntax-version=1.0.0");
+  });
+
+  test("contains project pragma", () => {
+    const content = buildInitialPlan({
+      projectName: "myproject",
+      topDir: ".",
+      engine: "pg",
+      force: false,
+    });
+
+    expect(content).toContain("%project=myproject");
+  });
+
+  test("contains uri pragma when provided", () => {
+    const content = buildInitialPlan({
+      projectName: "myproject",
+      topDir: ".",
+      engine: "pg",
+      uri: "https://example.com/myproject",
+      force: false,
+    });
+
+    expect(content).toContain("%uri=https://example.com/myproject");
+  });
+
+  test("omits uri pragma when not provided", () => {
+    const content = buildInitialPlan({
+      projectName: "myproject",
+      topDir: ".",
+      engine: "pg",
+      force: false,
+    });
+
+    expect(content).not.toContain("%uri=");
+  });
+
+  test("ends with trailing newline", () => {
+    const content = buildInitialPlan({
+      projectName: "myproject",
+      topDir: ".",
+      engine: "pg",
+      force: false,
+    });
+
+    expect(content.endsWith("\n")).toBe(true);
+  });
+
+  test("has no change or tag entries", () => {
+    const content = buildInitialPlan({
+      projectName: "myproject",
+      topDir: ".",
+      engine: "pg",
+      force: false,
+    });
+
+    // After the pragmas and blank separator line, there should be nothing else
+    const lines = content.trimEnd().split("\n");
+    // Should only have pragmas + blank line
+    for (const line of lines) {
+      if (line.trim() === "") continue;
+      expect(line.startsWith("%")).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: filesystem integration (subprocess, temp dirs)
+// ---------------------------------------------------------------------------
+
+describe("sqlever init (filesystem)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+    resetConfig();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("creates sqitch.conf, sqitch.plan, and directories", async () => {
+    const { exitCode, stdout } = await runInit(tempDir, "myproject");
+    expect(exitCode).toBe(0);
+
+    // Verify files exist
+    const confStat = await stat(join(tempDir, "sqitch.conf"));
+    expect(confStat.isFile()).toBe(true);
+
+    const planStat = await stat(join(tempDir, "sqitch.plan"));
+    expect(planStat.isFile()).toBe(true);
+
+    // Verify directories exist
+    for (const dir of ["deploy", "revert", "verify"]) {
+      const dirStat = await stat(join(tempDir, dir));
+      expect(dirStat.isDirectory()).toBe(true);
+    }
+
+    // Verify output messages
+    expect(stdout).toContain("Created");
+    expect(stdout).toContain("Initialized project 'myproject'");
+  });
+
+  test("sqitch.conf has correct engine", async () => {
+    await runInit(tempDir, "myproject");
+
+    const confContent = await readFile(join(tempDir, "sqitch.conf"), "utf-8");
+    const conf = parseSqitchConf(confContent);
+    expect(confGet(conf, "core.engine")).toBe("pg");
+  });
+
+  test("sqitch.plan has correct pragmas", async () => {
+    await runInit(tempDir, "myproject");
+
+    const planContent = await readFile(join(tempDir, "sqitch.plan"), "utf-8");
+    expect(planContent).toContain("%syntax-version=1.0.0");
+    expect(planContent).toContain("%project=myproject");
+  });
+
+  test("--uri flag is written to plan", async () => {
+    await runInit(tempDir, "myproject", "--uri", "urn:uuid:abc123");
+
+    const planContent = await readFile(join(tempDir, "sqitch.plan"), "utf-8");
+    expect(planContent).toContain("%uri=urn:uuid:abc123");
+  });
+
+  test("errors if sqitch.plan already exists", async () => {
+    // First init
+    await runInit(tempDir, "myproject");
+
+    // Second init without --force should fail
+    const { exitCode, stderr } = await runInit(tempDir, "myproject");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("already exists");
+  });
+
+  test("--force allows reinitializing", async () => {
+    // First init
+    await runInit(tempDir, "myproject");
+
+    // Second init with --force should succeed
+    const { exitCode } = await runInit(tempDir, "otherproject", "--force");
+    expect(exitCode).toBe(0);
+
+    // Verify plan has the new project name
+    const planContent = await readFile(join(tempDir, "sqitch.plan"), "utf-8");
+    expect(planContent).toContain("%project=otherproject");
+  });
+
+  test("uses directory name when no project name given", async () => {
+    const dirName = basename(tempDir);
+    const { exitCode } = await runInit(tempDir);
+    expect(exitCode).toBe(0);
+
+    const planContent = await readFile(join(tempDir, "sqitch.plan"), "utf-8");
+    expect(planContent).toContain(`%project=${dirName}`);
+  });
+
+  test("--engine flag changes engine in sqitch.conf", async () => {
+    await runInit(tempDir, "myproject", "--engine", "sqlite");
+
+    const confContent = await readFile(join(tempDir, "sqitch.conf"), "utf-8");
+    const conf = parseSqitchConf(confContent);
+    expect(confGet(conf, "core.engine")).toBe("sqlite");
+  });
+
+  test("--plan-file flag sets custom plan file location", async () => {
+    const customPlan = join(tempDir, "custom.plan");
+    await runInit(tempDir, "myproject", "--plan-file", customPlan);
+
+    // Custom plan file should exist
+    const planStat = await stat(customPlan);
+    expect(planStat.isFile()).toBe(true);
+
+    // sqitch.conf should reference the custom plan file
+    const confContent = await readFile(join(tempDir, "sqitch.conf"), "utf-8");
+    const conf = parseSqitchConf(confContent);
+    expect(confGet(conf, "core.plan_file")).toBe(customPlan);
+  });
+
+  test("--quiet suppresses output", async () => {
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        "src/cli.ts",
+        "--quiet",
+        "init",
+        "--top-dir",
+        tempDir,
+        "myproject",
+      ],
+      {
+        cwd: CWD,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [stdout, , exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+
+    // But files should still be created
+    const confStat = await stat(join(tempDir, "sqitch.conf"));
+    expect(confStat.isFile()).toBe(true);
+  });
+
+  test("creates nested top-dir if it doesn't exist", async () => {
+    const nestedDir = join(tempDir, "a", "b", "c");
+    const { exitCode } = await runInit(nestedDir, "myproject");
+    expect(exitCode).toBe(0);
+
+    const confStat = await stat(join(nestedDir, "sqitch.conf"));
+    expect(confStat.isFile()).toBe(true);
+    const deployStat = await stat(join(nestedDir, "deploy"));
+    expect(deployStat.isDirectory()).toBe(true);
+  });
+
+  test("sqitch.conf does not contain top_dir for default '.'", async () => {
+    // When --top-dir is used, the conf should reflect that,
+    // but the top_dir key should only appear if non-default.
+    // Since we run with --top-dir tempDir, top_dir IS non-default.
+    const { exitCode } = await runInit(tempDir, "myproject");
+    expect(exitCode).toBe(0);
+
+    const confContent = await readFile(join(tempDir, "sqitch.conf"), "utf-8");
+    // Since we passed --top-dir (a non-default dir), top_dir should appear
+    const conf = parseSqitchConf(confContent);
+    expect(confGet(conf, "core.top_dir")).toBe(tempDir);
+  });
+
+  test("generated plan is valid and round-trips through serializePlan", async () => {
+    await runInit(tempDir, "myproject", "--uri", "https://example.com/");
+
+    const planContent = await readFile(join(tempDir, "sqitch.plan"), "utf-8");
+
+    // Verify exact expected output
+    const expectedLines = [
+      "%syntax-version=1.0.0",
+      "%project=myproject",
+      "%uri=https://example.com/",
+      "",
+      "",
+    ];
+    expect(planContent).toBe(expectedLines.join("\n"));
+  });
+});


### PR DESCRIPTION
Closes #24

## Summary

- Implement `sqlever init [project_name]` command in `src/commands/init.ts`
- Creates `sqitch.conf` with `[core] engine = pg` and optional `top_dir`/`plan_file` settings
- Creates `sqitch.plan` with pragmas (`%syntax-version=1.0.0`, `%project=<name>`, optional `%uri=<uri>`) using `serializePlan()` from `src/plan/writer.ts`
- Creates `deploy/`, `revert/`, `verify/` directories (respecting `--top-dir`)
- Supports flags: `--top-dir`, `--engine pg`, `--uri`, `--plan-file`, `--force`
- Errors if `sqitch.plan` already exists unless `--force` is passed
- Wired into CLI router in `src/cli.ts`, replacing the stub handler for `init`
- Uses `serializeSqitchConf()` from `src/config/sqitch-conf.ts` for config generation

## Test plan

- [x] 34 tests in `tests/unit/init.test.ts` covering:
  - `parseInitOptions`: defaults, positional project name, all flags, top-dir basename derivation
  - `buildSqitchConf`: engine, top_dir inclusion/omission, plan_file, custom engine
  - `buildInitialPlan`: pragmas, uri presence/absence, trailing newline, no entries
  - Filesystem integration (subprocess in temp dirs): file creation, correct content, `--uri`, error on existing plan, `--force`, directory name fallback, `--engine`, `--plan-file`, `--quiet`, nested top-dir, round-trip validation
- [x] Updated existing CLI stub test to exclude `init` from stub commands
- [x] Full test suite passes (493 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)