### PR TITLE
S2-6: sqlever add

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@
 import packageJson from "../package.json";
 import { runInit } from "./commands/init";
 import { setConfig, type OutputFormat } from "./output";
+import { parseAddArgs, runAdd } from "./commands/add";
 
 // ---------------------------------------------------------------------------
 // Command registry — all commands from SPEC R1 plus sqlever extensions
@@ -285,6 +286,16 @@ export function main(argv: string[] = process.argv.slice(2)): void {
     runInit(args).catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(`sqlever init: ${msg}\n`);
+      process.exit(1);
+    });
+    return;
+  }
+
+  if (args.command === "add") {
+    const addOpts = parseAddArgs(args.rest);
+    addOpts.topDir = args.topDir;
+    runAdd(addOpts).catch((err: unknown) => {
+      process.stderr.write(`sqlever add: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exit(1);
     });
     return;

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,0 +1,433 @@
+// src/commands/add.ts — sqlever add command
+//
+// Creates migration files (deploy, revert, verify) and appends a
+// change entry to sqitch.plan. Implements SPEC R1 `add` semantics.
+
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { execSync } from "node:child_process";
+import { loadConfig, type MergedConfig } from "../config/index";
+import { computeChangeId, type ChangeIdInput } from "../plan/types";
+import { appendChange } from "../plan/writer";
+import type { Change } from "../plan/types";
+import { info, error, verbose } from "../output";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AddOptions {
+  /** Change name (required positional arg). */
+  name: string;
+  /** Note for the change (from -n / --note). */
+  note: string;
+  /** Required dependencies (from -r / --requires, repeatable). */
+  requires: string[];
+  /** Conflict dependencies (from -c / --conflicts, repeatable). */
+  conflicts: string[];
+  /** Skip verify file creation (from --no-verify). */
+  noVerify: boolean;
+  /** Project root directory (from --top-dir or cwd). */
+  topDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing for the add subcommand
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `rest` array from the CLI into AddOptions.
+ *
+ * Expected usage:
+ *   sqlever add <name> [-n note] [-r dep]... [-c conflict]... [--no-verify]
+ */
+export function parseAddArgs(rest: string[]): AddOptions {
+  const opts: AddOptions = {
+    name: "",
+    note: "",
+    requires: [],
+    conflicts: [],
+    noVerify: false,
+  };
+
+  let i = 0;
+  while (i < rest.length) {
+    const arg = rest[i]!;
+
+    if (arg === "-n" || arg === "--note") {
+      opts.note = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+    if (arg === "-r" || arg === "--requires") {
+      const val = rest[++i];
+      if (val) opts.requires.push(val);
+      i++;
+      continue;
+    }
+    if (arg === "-c" || arg === "--conflicts") {
+      const val = rest[++i];
+      if (val) opts.conflicts.push(val);
+      i++;
+      continue;
+    }
+    if (arg === "--no-verify") {
+      opts.noVerify = true;
+      i++;
+      continue;
+    }
+
+    // First non-flag argument is the change name
+    if (opts.name === "") {
+      opts.name = arg;
+    }
+    i++;
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Plan reading (minimal — extracts project name, existing changes, last ID)
+// ---------------------------------------------------------------------------
+
+interface PlanInfo {
+  /** Project name from %project pragma. */
+  projectName: string;
+  /** Project URI from %uri pragma (may be undefined). */
+  projectUri?: string;
+  /** Set of existing change names (for duplicate detection). */
+  existingNames: Set<string>;
+  /** The change_id of the last change in the plan (for parent linking). */
+  lastChangeId?: string;
+}
+
+/**
+ * Read plan file and extract minimal information needed for `add`.
+ *
+ * This is a lightweight reader that extracts pragmas and change entries
+ * without a full parse. The plan parser module may not be available yet.
+ */
+export function readPlanInfo(planPath: string): PlanInfo {
+  const content = readFileSync(planPath, "utf-8");
+  const lines = content.split("\n");
+
+  let projectName = "";
+  let projectUri: string | undefined;
+  const existingNames = new Set<string>();
+  let lastChangeId: string | undefined;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (trimmed === "" || trimmed.startsWith("--")) continue;
+
+    // Pragmas
+    if (trimmed.startsWith("%")) {
+      const match = trimmed.match(/^%(\S+?)=(.*)$/);
+      if (match) {
+        const [, key, value] = match;
+        if (key === "project") projectName = value!;
+        if (key === "uri") projectUri = value;
+      }
+      continue;
+    }
+
+    // Tags (start with @) — skip
+    if (trimmed.startsWith("@")) continue;
+
+    // Change lines: name [deps] timestamp planner <email> # note
+    // The name is the first non-whitespace token
+    const changeName = trimmed.split(/\s+/)[0];
+    if (changeName) {
+      existingNames.add(changeName);
+
+      // We need to recompute the change_id from the line to get the last one.
+      // But we actually need a full parse for that. Instead, since we're
+      // appending, we compute all IDs in order.
+      // For now, we'll recompute from parsed line data.
+      const parsedChange = parseChangeLine(trimmed, projectName, projectUri, lastChangeId);
+      if (parsedChange) {
+        lastChangeId = parsedChange.change_id;
+      }
+    }
+  }
+
+  return { projectName, projectUri, existingNames, lastChangeId };
+}
+
+/**
+ * Parse a single change line from the plan file and compute its change_id.
+ *
+ * Format: name [deps] timestamp planner_name <email> # note
+ */
+function parseChangeLine(
+  line: string,
+  project: string,
+  uri: string | undefined,
+  parent: string | undefined,
+): Change | null {
+  // Match: name [deps]? timestamp planner <email> (# note)?
+  // We need to handle optional deps block
+  const depsRegex = /^(\S+)\s+(?:\[([^\]]*)\]\s+)?(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+(.+?)\s+<([^>]+)>(?:\s+#\s+(.*))?$/;
+  const match = line.match(depsRegex);
+  if (!match) return null;
+
+  const [, name, depsStr, timestamp, plannerName, plannerEmail, note] = match;
+
+  const requires: string[] = [];
+  const conflicts: string[] = [];
+
+  if (depsStr) {
+    for (const dep of depsStr.split(/\s+/)) {
+      if (dep.startsWith("!")) {
+        conflicts.push(dep.slice(1));
+      } else if (dep !== "") {
+        requires.push(dep);
+      }
+    }
+  }
+
+  const changeId = computeChangeId({
+    project,
+    uri,
+    change: name!,
+    parent,
+    planner_name: plannerName!,
+    planner_email: plannerEmail!,
+    planned_at: timestamp!,
+    requires,
+    conflicts,
+    note: note ?? "",
+  });
+
+  return {
+    change_id: changeId,
+    name: name!,
+    project,
+    note: note ?? "",
+    planner_name: plannerName!,
+    planner_email: plannerEmail!,
+    planned_at: timestamp!,
+    requires,
+    conflicts,
+    parent,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Planner identity
+// ---------------------------------------------------------------------------
+
+export interface PlannerIdentity {
+  name: string;
+  email: string;
+}
+
+/**
+ * Determine planner name and email.
+ *
+ * Precedence:
+ *   1. SQLEVER_USER_NAME / SQLEVER_USER_EMAIL env vars
+ *   2. git config user.name / user.email
+ *   3. Fallback: "Unknown" / "unknown@example.com"
+ */
+export function getPlannerIdentity(
+  env: Record<string, string | undefined> = process.env,
+): PlannerIdentity {
+  let name = env.SQLEVER_USER_NAME;
+  let email = env.SQLEVER_USER_EMAIL;
+
+  if (!name) {
+    try {
+      name = execSync("git config user.name", { encoding: "utf-8" }).trim();
+    } catch {
+      // git not available or not configured
+    }
+  }
+
+  if (!email) {
+    try {
+      email = execSync("git config user.email", { encoding: "utf-8" }).trim();
+    } catch {
+      // git not available or not configured
+    }
+  }
+
+  return {
+    name: name || "Unknown",
+    email: email || "unknown@example.com",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// File templates
+// ---------------------------------------------------------------------------
+
+export function deployTemplate(name: string, requires: string[]): string {
+  const reqLine = requires.length > 0
+    ? `-- requires: ${requires.join(", ")}`
+    : "-- requires:";
+  return `-- Deploy ${name}\n${reqLine}\n\nBEGIN;\n\n-- XXX Add DDL here.\n\nCOMMIT;\n`;
+}
+
+export function revertTemplate(name: string): string {
+  return `-- Revert ${name}\n\nBEGIN;\n\n-- XXX Add revert DDL here.\n\nCOMMIT;\n`;
+}
+
+export function verifyTemplate(name: string): string {
+  return `-- Verify ${name}\n\nBEGIN;\n\n-- XXX Add verification here.\n\nROLLBACK;\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate an ISO 8601 timestamp in the format Sqitch uses.
+ * Example: 2024-01-15T10:30:00Z
+ */
+export function nowTimestamp(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+// ---------------------------------------------------------------------------
+// Main add logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `add` command.
+ *
+ * @param opts    - Parsed add options
+ * @param config  - Merged configuration (if not provided, loaded from cwd)
+ * @param env     - Environment variables (defaults to process.env)
+ */
+export async function runAdd(
+  opts: AddOptions,
+  config?: MergedConfig,
+  env?: Record<string, string | undefined>,
+): Promise<void> {
+  const environment = env ?? process.env;
+
+  // Validate change name
+  if (!opts.name) {
+    error("Error: change name is required. Usage: sqlever add <name>");
+    process.exit(1);
+  }
+
+  // Validate change name format (alphanumeric, underscores, hyphens)
+  if (!/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(opts.name)) {
+    error(
+      `Error: invalid change name '${opts.name}'. ` +
+      "Names must start with a letter or underscore and contain only " +
+      "letters, digits, underscores, and hyphens.",
+    );
+    process.exit(1);
+  }
+
+  // Load config if not provided
+  const cfg = config ?? loadConfig(opts.topDir, undefined, environment);
+
+  // Resolve directories relative to top_dir
+  const topDir = resolve(opts.topDir ?? cfg.core.top_dir);
+  const deployDir = resolve(topDir, cfg.core.deploy_dir);
+  const revertDir = resolve(topDir, cfg.core.revert_dir);
+  const verifyDir = resolve(topDir, cfg.core.verify_dir);
+  const planPath = resolve(topDir, cfg.core.plan_file);
+
+  // Ensure plan file exists
+  if (!existsSync(planPath)) {
+    error(`Error: plan file not found at ${planPath}. Run 'sqlever init' first.`);
+    process.exit(1);
+  }
+
+  // Read existing plan to check for duplicates and get last change ID
+  const planInfo = readPlanInfo(planPath);
+
+  if (planInfo.existingNames.has(opts.name)) {
+    error(
+      `Error: change '${opts.name}' already exists in the plan. ` +
+      "Use 'sqlever rework' to create a new version of an existing change.",
+    );
+    process.exit(1);
+  }
+
+  // Get planner identity
+  const planner = getPlannerIdentity(environment);
+  verbose(`Planner: ${planner.name} <${planner.email}>`);
+
+  // Compute timestamp and change ID
+  const timestamp = nowTimestamp();
+
+  const changeIdInput: ChangeIdInput = {
+    project: planInfo.projectName,
+    uri: planInfo.projectUri,
+    change: opts.name,
+    parent: planInfo.lastChangeId,
+    planner_name: planner.name,
+    planner_email: planner.email,
+    planned_at: timestamp,
+    requires: opts.requires,
+    conflicts: opts.conflicts,
+    note: opts.note,
+  };
+
+  const changeId = computeChangeId(changeIdInput);
+
+  // Build Change object
+  const change: Change = {
+    change_id: changeId,
+    name: opts.name,
+    project: planInfo.projectName,
+    note: opts.note,
+    planner_name: planner.name,
+    planner_email: planner.email,
+    planned_at: timestamp,
+    requires: opts.requires,
+    conflicts: opts.conflicts,
+    parent: planInfo.lastChangeId,
+  };
+
+  // Create directories if they don't exist
+  mkdirSync(deployDir, { recursive: true });
+  mkdirSync(revertDir, { recursive: true });
+  if (!opts.noVerify) {
+    mkdirSync(verifyDir, { recursive: true });
+  }
+
+  // Create migration files (error if they already exist)
+  const deployPath = join(deployDir, `${opts.name}.sql`);
+  const revertPath = join(revertDir, `${opts.name}.sql`);
+  const verifyPath = join(verifyDir, `${opts.name}.sql`);
+
+  if (existsSync(deployPath)) {
+    error(`Error: deploy script already exists at ${deployPath}`);
+    process.exit(1);
+  }
+  if (existsSync(revertPath)) {
+    error(`Error: revert script already exists at ${revertPath}`);
+    process.exit(1);
+  }
+  if (!opts.noVerify && existsSync(verifyPath)) {
+    error(`Error: verify script already exists at ${verifyPath}`);
+    process.exit(1);
+  }
+
+  writeFileSync(deployPath, deployTemplate(opts.name, opts.requires), "utf-8");
+  verbose(`Created ${deployPath}`);
+
+  writeFileSync(revertPath, revertTemplate(opts.name), "utf-8");
+  verbose(`Created ${revertPath}`);
+
+  if (!opts.noVerify) {
+    writeFileSync(verifyPath, verifyTemplate(opts.name), "utf-8");
+    verbose(`Created ${verifyPath}`);
+  }
+
+  // Append change to plan
+  await appendChange(planPath, change);
+  verbose(`Appended change to ${planPath}`);
+
+  info(`Added "${opts.name}" to ${planPath}`);
+}

--- a/tests/unit/add.test.ts
+++ b/tests/unit/add.test.ts
@@ -1,0 +1,1033 @@
+// tests/unit/add.test.ts — Tests for sqlever add command
+//
+// Validates add command: argument parsing, file creation, plan appending,
+// duplicate detection, planner identity, and config integration.
+
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { rmSync } from "node:fs";
+
+import {
+  parseAddArgs,
+  runAdd,
+  getPlannerIdentity,
+  deployTemplate,
+  revertTemplate,
+  verifyTemplate,
+  readPlanInfo,
+  nowTimestamp,
+} from "../../src/commands/add";
+import { computeChangeId } from "../../src/plan/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function createTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "sqlever-add-test-"));
+}
+
+/** Create a minimal project directory with sqitch.plan. */
+function setupProject(
+  dir: string,
+  planContent?: string,
+): { planPath: string; deployDir: string; revertDir: string; verifyDir: string } {
+  const planPath = join(dir, "sqitch.plan");
+  const deployDir = join(dir, "deploy");
+  const revertDir = join(dir, "revert");
+  const verifyDir = join(dir, "verify");
+
+  writeFileSync(
+    planPath,
+    planContent ??
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n",
+    "utf-8",
+  );
+
+  return { planPath, deployDir, revertDir, verifyDir };
+}
+
+/** Mock environment with planner identity to avoid git dependency. */
+const TEST_ENV: Record<string, string | undefined> = {
+  SQLEVER_USER_NAME: "Test User",
+  SQLEVER_USER_EMAIL: "test@example.com",
+};
+
+/** Create a minimal MergedConfig for testing. */
+function testConfig(topDir: string) {
+  // We import loadConfig lazily to avoid circular issues.
+  // Instead, create a minimal mock config.
+  return {
+    core: {
+      engine: undefined,
+      top_dir: topDir,
+      deploy_dir: "deploy",
+      revert_dir: "revert",
+      verify_dir: "verify",
+      plan_file: "sqitch.plan",
+    },
+    deploy: {
+      verify: true,
+      mode: "change" as const,
+      lock_retries: 0,
+      lock_timeout: "5s",
+      idle_in_transaction_session_timeout: "10min",
+      search_path: undefined,
+    },
+    engines: {},
+    targets: {},
+    analysis: {},
+    sqitchConf: { entries: [], rawLines: [], sections: new Set<string>() },
+    sqleverToml: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseAddArgs
+// ---------------------------------------------------------------------------
+
+describe("parseAddArgs", () => {
+  it("parses a simple change name", () => {
+    const opts = parseAddArgs(["create_users"]);
+    expect(opts.name).toBe("create_users");
+    expect(opts.note).toBe("");
+    expect(opts.requires).toEqual([]);
+    expect(opts.conflicts).toEqual([]);
+    expect(opts.noVerify).toBe(false);
+  });
+
+  it("parses -n / --note", () => {
+    const opts1 = parseAddArgs(["create_users", "-n", "Add users table"]);
+    expect(opts1.note).toBe("Add users table");
+
+    const opts2 = parseAddArgs(["create_users", "--note", "Add users table"]);
+    expect(opts2.note).toBe("Add users table");
+  });
+
+  it("parses -r / --requires (single)", () => {
+    const opts = parseAddArgs(["add_users", "-r", "create_schema"]);
+    expect(opts.requires).toEqual(["create_schema"]);
+  });
+
+  it("parses -r / --requires (multiple)", () => {
+    const opts = parseAddArgs([
+      "add_users",
+      "-r", "create_schema",
+      "--requires", "add_roles",
+    ]);
+    expect(opts.requires).toEqual(["create_schema", "add_roles"]);
+  });
+
+  it("parses -c / --conflicts (single)", () => {
+    const opts = parseAddArgs(["add_users", "-c", "old_users"]);
+    expect(opts.conflicts).toEqual(["old_users"]);
+  });
+
+  it("parses -c / --conflicts (multiple)", () => {
+    const opts = parseAddArgs([
+      "add_users",
+      "-c", "old_users",
+      "--conflicts", "legacy_auth",
+    ]);
+    expect(opts.conflicts).toEqual(["old_users", "legacy_auth"]);
+  });
+
+  it("parses --no-verify", () => {
+    const opts = parseAddArgs(["add_users", "--no-verify"]);
+    expect(opts.noVerify).toBe(true);
+  });
+
+  it("parses all flags together", () => {
+    const opts = parseAddArgs([
+      "add_users",
+      "-n", "Add users table",
+      "-r", "create_schema",
+      "-r", "add_roles",
+      "-c", "old_users",
+      "--no-verify",
+    ]);
+    expect(opts.name).toBe("add_users");
+    expect(opts.note).toBe("Add users table");
+    expect(opts.requires).toEqual(["create_schema", "add_roles"]);
+    expect(opts.conflicts).toEqual(["old_users"]);
+    expect(opts.noVerify).toBe(true);
+  });
+
+  it("returns empty name when no positional arg given", () => {
+    const opts = parseAddArgs(["-n", "some note"]);
+    expect(opts.name).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File templates
+// ---------------------------------------------------------------------------
+
+describe("deployTemplate", () => {
+  it("generates deploy script with no requires", () => {
+    const content = deployTemplate("create_users", []);
+    expect(content).toBe(
+      "-- Deploy create_users\n" +
+      "-- requires:\n" +
+      "\n" +
+      "BEGIN;\n" +
+      "\n" +
+      "-- XXX Add DDL here.\n" +
+      "\n" +
+      "COMMIT;\n",
+    );
+  });
+
+  it("generates deploy script with requires", () => {
+    const content = deployTemplate("add_users", ["create_schema", "add_roles"]);
+    expect(content).toContain("-- requires: create_schema, add_roles");
+  });
+});
+
+describe("revertTemplate", () => {
+  it("generates revert script", () => {
+    const content = revertTemplate("create_users");
+    expect(content).toBe(
+      "-- Revert create_users\n" +
+      "\n" +
+      "BEGIN;\n" +
+      "\n" +
+      "-- XXX Add revert DDL here.\n" +
+      "\n" +
+      "COMMIT;\n",
+    );
+  });
+});
+
+describe("verifyTemplate", () => {
+  it("generates verify script with ROLLBACK", () => {
+    const content = verifyTemplate("create_users");
+    expect(content).toBe(
+      "-- Verify create_users\n" +
+      "\n" +
+      "BEGIN;\n" +
+      "\n" +
+      "-- XXX Add verification here.\n" +
+      "\n" +
+      "ROLLBACK;\n",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nowTimestamp
+// ---------------------------------------------------------------------------
+
+describe("nowTimestamp", () => {
+  it("returns ISO 8601 format without milliseconds", () => {
+    const ts = nowTimestamp();
+    expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPlannerIdentity
+// ---------------------------------------------------------------------------
+
+describe("getPlannerIdentity", () => {
+  it("uses SQLEVER_USER_NAME and SQLEVER_USER_EMAIL env vars", () => {
+    const identity = getPlannerIdentity({
+      SQLEVER_USER_NAME: "Jane Doe",
+      SQLEVER_USER_EMAIL: "jane@example.com",
+    });
+    expect(identity.name).toBe("Jane Doe");
+    expect(identity.email).toBe("jane@example.com");
+  });
+
+  it("falls back to git config when env vars not set", () => {
+    // This test depends on git being configured; if not, it falls back
+    const identity = getPlannerIdentity({});
+    expect(identity.name).toBeTruthy();
+    expect(identity.email).toBeTruthy();
+  });
+
+  it("provides default fallback when nothing is configured", () => {
+    // We can't easily remove git config, so just check the types
+    const identity = getPlannerIdentity({
+      SQLEVER_USER_NAME: "",
+      SQLEVER_USER_EMAIL: "",
+    });
+    // With empty strings, should fall through to git or fallback
+    expect(typeof identity.name).toBe("string");
+    expect(typeof identity.email).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readPlanInfo
+// ---------------------------------------------------------------------------
+
+describe("readPlanInfo", () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads project name from pragma", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(
+      planPath,
+      "%syntax-version=1.0.0\n%project=testproject\n\n",
+      "utf-8",
+    );
+    const info = readPlanInfo(planPath);
+    expect(info.projectName).toBe("testproject");
+  });
+
+  it("reads project URI from pragma", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(
+      planPath,
+      "%syntax-version=1.0.0\n%project=testproject\n%uri=https://example.com/\n\n",
+      "utf-8",
+    );
+    const info = readPlanInfo(planPath);
+    expect(info.projectUri).toBe("https://example.com/");
+  });
+
+  it("detects existing change names", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(
+      planPath,
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "create_schema 2024-01-15T10:30:00Z Test User <test@example.com> # first\n" +
+      "add_users 2024-01-15T10:31:00Z Test User <test@example.com> # second\n",
+      "utf-8",
+    );
+    const info = readPlanInfo(planPath);
+    expect(info.existingNames.has("create_schema")).toBe(true);
+    expect(info.existingNames.has("add_users")).toBe(true);
+    expect(info.existingNames.has("nonexistent")).toBe(false);
+  });
+
+  it("computes lastChangeId correctly for a single change", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(
+      planPath,
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "create_schema 2024-01-15T10:30:00Z Test User <test@example.com> # first\n",
+      "utf-8",
+    );
+    const info = readPlanInfo(planPath);
+
+    // Compute expected ID manually
+    const expectedId = computeChangeId({
+      project: "myproject",
+      change: "create_schema",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T10:30:00Z",
+      requires: [],
+      conflicts: [],
+      note: "first",
+    });
+    expect(info.lastChangeId).toBe(expectedId);
+  });
+
+  it("computes lastChangeId with parent chaining for multiple changes", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(
+      planPath,
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "first 2024-01-15T10:30:00Z Test User <test@example.com>\n" +
+      "second 2024-01-15T10:31:00Z Test User <test@example.com>\n",
+      "utf-8",
+    );
+    const info = readPlanInfo(planPath);
+
+    // Compute expected IDs
+    const firstId = computeChangeId({
+      project: "myproject",
+      change: "first",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T10:30:00Z",
+      requires: [],
+      conflicts: [],
+      note: "",
+    });
+    const secondId = computeChangeId({
+      project: "myproject",
+      change: "second",
+      parent: firstId,
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T10:31:00Z",
+      requires: [],
+      conflicts: [],
+      note: "",
+    });
+    expect(info.lastChangeId).toBe(secondId);
+  });
+
+  it("handles empty plan (no changes)", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(
+      planPath,
+      "%syntax-version=1.0.0\n%project=myproject\n\n",
+      "utf-8",
+    );
+    const info = readPlanInfo(planPath);
+    expect(info.existingNames.size).toBe(0);
+    expect(info.lastChangeId).toBeUndefined();
+  });
+
+  it("skips tag lines", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(
+      planPath,
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "first 2024-01-15T10:30:00Z Test User <test@example.com>\n" +
+      "@v1.0 2024-01-15T10:31:00Z Test User <test@example.com> # tag\n",
+      "utf-8",
+    );
+    const info = readPlanInfo(planPath);
+    expect(info.existingNames.has("first")).toBe(true);
+    expect(info.existingNames.has("@v1.0")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runAdd — full integration (with temp dirs)
+// ---------------------------------------------------------------------------
+
+describe("runAdd", () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates deploy, revert, verify files and appends to plan", async () => {
+    const { planPath } = setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "create_users",
+        note: "Add users table",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    // Check files were created
+    expect(existsSync(join(tmpDir, "deploy", "create_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "revert", "create_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "verify", "create_users.sql"))).toBe(true);
+
+    // Check deploy script content
+    const deploySql = readFileSync(join(tmpDir, "deploy", "create_users.sql"), "utf-8");
+    expect(deploySql).toContain("-- Deploy create_users");
+    expect(deploySql).toContain("BEGIN;");
+    expect(deploySql).toContain("COMMIT;");
+
+    // Check revert script content
+    const revertSql = readFileSync(join(tmpDir, "revert", "create_users.sql"), "utf-8");
+    expect(revertSql).toContain("-- Revert create_users");
+
+    // Check verify script content
+    const verifySql = readFileSync(join(tmpDir, "verify", "create_users.sql"), "utf-8");
+    expect(verifySql).toContain("-- Verify create_users");
+    expect(verifySql).toContain("ROLLBACK;");
+
+    // Check plan was updated
+    const plan = readFileSync(planPath, "utf-8");
+    expect(plan).toContain("create_users");
+    expect(plan).toContain("Test User <test@example.com>");
+    expect(plan).toContain("# Add users table");
+  });
+
+  it("creates files with correct templates", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "add_roles",
+        note: "",
+        requires: ["create_schema"],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    const deploySql = readFileSync(join(tmpDir, "deploy", "add_roles.sql"), "utf-8");
+    expect(deploySql).toContain("-- requires: create_schema");
+  });
+
+  it("appends change with dependencies to plan", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "add_users",
+        note: "users",
+        requires: ["create_schema"],
+        conflicts: ["old_users"],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    expect(plan).toContain("[create_schema !old_users]");
+  });
+
+  it("computes correct change ID", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "create_users",
+        note: "Add users table",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+
+    // Parse the timestamp from the plan to compute expected ID
+    const changeLine = plan.split("\n").find((l) => l.startsWith("create_users"));
+    expect(changeLine).toBeTruthy();
+
+    // Extract timestamp from the line
+    const tsMatch = changeLine!.match(/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)/);
+    expect(tsMatch).toBeTruthy();
+
+    const expectedId = computeChangeId({
+      project: "myproject",
+      change: "create_users",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: tsMatch![1]!,
+      requires: [],
+      conflicts: [],
+      note: "Add users table",
+    });
+
+    // The change ID doesn't appear in the plan line itself
+    // (it's computed on read), but we verify it via readPlanInfo
+    const info = readPlanInfo(join(tmpDir, "sqitch.plan"));
+    expect(info.lastChangeId).toBe(expectedId);
+  });
+
+  it("errors on duplicate change name", async () => {
+    setupProject(
+      tmpDir,
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "create_users 2024-01-15T10:30:00Z Test User <test@example.com> # existing\n",
+    );
+    const cfg = testConfig(tmpDir);
+
+    // Mock process.exit to capture exit
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      await runAdd(
+        {
+          name: "create_users",
+          note: "duplicate",
+          requires: [],
+          conflicts: [],
+          noVerify: false,
+        },
+        cfg,
+        TEST_ENV,
+      );
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors when plan file does not exist", async () => {
+    // Don't create sqitch.plan
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      await runAdd(
+        {
+          name: "create_users",
+          note: "",
+          requires: [],
+          conflicts: [],
+          noVerify: false,
+        },
+        cfg,
+        TEST_ENV,
+      );
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors on invalid change name", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      await runAdd(
+        {
+          name: "123-invalid",
+          note: "",
+          requires: [],
+          conflicts: [],
+          noVerify: false,
+        },
+        cfg,
+        TEST_ENV,
+      );
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors when no change name provided", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      await runAdd(
+        {
+          name: "",
+          note: "",
+          requires: [],
+          conflicts: [],
+          noVerify: false,
+        },
+        cfg,
+        TEST_ENV,
+      );
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("skips verify file when --no-verify is set", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "create_users",
+        note: "",
+        requires: [],
+        conflicts: [],
+        noVerify: true,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    expect(existsSync(join(tmpDir, "deploy", "create_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "revert", "create_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "verify", "create_users.sql"))).toBe(false);
+  });
+
+  it("creates directories if they don't exist", async () => {
+    // Only create plan file, not the dirs
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(
+      planPath,
+      "%syntax-version=1.0.0\n%project=myproject\n\n",
+      "utf-8",
+    );
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "create_users",
+        note: "",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    expect(existsSync(join(tmpDir, "deploy"))).toBe(true);
+    expect(existsSync(join(tmpDir, "revert"))).toBe(true);
+    expect(existsSync(join(tmpDir, "verify"))).toBe(true);
+  });
+
+  it("uses custom directory names from config", async () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(
+      planPath,
+      "%syntax-version=1.0.0\n%project=myproject\n\n",
+      "utf-8",
+    );
+    const cfg = testConfig(tmpDir);
+    cfg.core.deploy_dir = "migrations/deploy";
+    cfg.core.revert_dir = "migrations/revert";
+    cfg.core.verify_dir = "migrations/verify";
+
+    await runAdd(
+      {
+        name: "create_users",
+        note: "",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    expect(existsSync(join(tmpDir, "migrations", "deploy", "create_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "migrations", "revert", "create_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "migrations", "verify", "create_users.sql"))).toBe(true);
+  });
+
+  it("sets parent ID when adding to a plan with existing changes", async () => {
+    // Set up a plan with one existing change
+    const planContent =
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "first 2024-01-15T10:30:00Z Test User <test@example.com> # first change\n";
+    setupProject(tmpDir, planContent);
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "second",
+        note: "second change",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    // Read back the plan info and verify the second change has the first as parent
+    const info = readPlanInfo(join(tmpDir, "sqitch.plan"));
+
+    // The first change's ID
+    const firstId = computeChangeId({
+      project: "myproject",
+      change: "first",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T10:30:00Z",
+      requires: [],
+      conflicts: [],
+      note: "first change",
+    });
+
+    // Parse the second change's timestamp from the plan
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const secondLine = plan.split("\n").find((l) => l.startsWith("second"));
+    expect(secondLine).toBeTruthy();
+    const tsMatch = secondLine!.match(/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)/);
+
+    const expectedSecondId = computeChangeId({
+      project: "myproject",
+      change: "second",
+      parent: firstId,
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: tsMatch![1]!,
+      requires: [],
+      conflicts: [],
+      note: "second change",
+    });
+
+    expect(info.lastChangeId).toBe(expectedSecondId);
+  });
+
+  it("handles plan with URI pragma", async () => {
+    setupProject(
+      tmpDir,
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "%uri=https://example.com/myproject\n" +
+      "\n",
+    );
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "create_users",
+        note: "users",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    // Verify it was added (the URI affects change ID computation)
+    const info = readPlanInfo(join(tmpDir, "sqitch.plan"));
+    expect(info.existingNames.has("create_users")).toBe(true);
+    expect(info.projectUri).toBe("https://example.com/myproject");
+  });
+
+  it("errors if deploy script already exists", async () => {
+    setupProject(tmpDir);
+    mkdirSync(join(tmpDir, "deploy"), { recursive: true });
+    writeFileSync(join(tmpDir, "deploy", "create_users.sql"), "existing", "utf-8");
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      await runAdd(
+        {
+          name: "create_users",
+          note: "",
+          requires: [],
+          conflicts: [],
+          noVerify: false,
+        },
+        cfg,
+        TEST_ENV,
+      );
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("correctly formats plan entry with multiple deps", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "add_users",
+        note: "users table",
+        requires: ["create_schema", "add_roles"],
+        conflicts: ["old_users"],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const changeLine = plan.split("\n").find((l) => l.startsWith("add_users"));
+    expect(changeLine).toBeTruthy();
+    expect(changeLine).toContain("[create_schema add_roles !old_users]");
+    expect(changeLine).toContain("# users table");
+  });
+
+  it("handles change name with hyphens and underscores", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "add-user_accounts",
+        note: "",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    expect(existsSync(join(tmpDir, "deploy", "add-user_accounts.sql"))).toBe(true);
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    expect(plan).toContain("add-user_accounts");
+  });
+
+  it("adds multiple changes sequentially", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await runAdd(
+      {
+        name: "first_change",
+        note: "first",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    await runAdd(
+      {
+        name: "second_change",
+        note: "second",
+        requires: ["first_change"],
+        conflicts: [],
+        noVerify: false,
+      },
+      cfg,
+      TEST_ENV,
+    );
+
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const lines = plan.split("\n").filter((l) => !l.startsWith("%") && l.trim() !== "");
+    expect(lines.length).toBe(2);
+    expect(lines[0]).toMatch(/^first_change /);
+    expect(lines[1]).toMatch(/^second_change /);
+    expect(lines[1]).toContain("[first_change]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI integration (subprocess)
+// ---------------------------------------------------------------------------
+
+describe("sqlever add (subprocess)", () => {
+  const CWD = import.meta.dir + "/../..";
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runCli(
+    ...args: string[]
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const proc = Bun.spawn(["bun", "run", join(CWD, "src/cli.ts"), ...args], {
+      cwd: tmpDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        SQLEVER_USER_NAME: "CLI Test",
+        SQLEVER_USER_EMAIL: "cli@test.com",
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("creates migration files via CLI", async () => {
+    setupProject(tmpDir);
+
+    const { stdout, exitCode } = await runCli(
+      "add", "create_users", "-n", "Add users table",
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Added");
+    expect(existsSync(join(tmpDir, "deploy", "create_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "revert", "create_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "verify", "create_users.sql"))).toBe(true);
+  });
+
+  it("exits 1 when no change name is provided", async () => {
+    setupProject(tmpDir);
+
+    const { exitCode, stderr } = await runCli("add");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("change name is required");
+  });
+
+  it("exits 1 when plan file is missing", async () => {
+    // No project setup
+    const { exitCode, stderr } = await runCli("add", "test_change");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("plan file not found");
+  });
+});

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -308,8 +308,8 @@ describe("unknown commands", () => {
 // ---------------------------------------------------------------------------
 
 describe("command stubs", () => {
-  // "help" is handled specially (not a stub), "init" is implemented — exclude both
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init");
+  // "help" is handled specially (not a stub), "init" and "add" are implemented — exclude all three
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {


### PR DESCRIPTION
## Summary
- Implements `sqlever add <name>` command that creates deploy/revert/verify migration files and appends a change entry to sqitch.plan
- Computes Sqitch-compatible SHA-1 change IDs with correct parent chaining
- Supports all required flags: `-n`/`--note`, `-r`/`--requires`, `-c`/`--conflicts`, `--no-verify`
- Planner identity resolved from `SQLEVER_USER_NAME`/`SQLEVER_USER_EMAIL` env vars, then `git config`, then fallback
- Respects sqitch.conf directory settings (`deploy_dir`, `revert_dir`, `verify_dir`)
- Validates change names and detects duplicates in the existing plan
- Wired into CLI router in `src/cli.ts`

## Test plan
- [x] 44 unit tests covering argument parsing, file templates, plan reading, planner identity, and full integration
- [x] 3 CLI subprocess tests verifying end-to-end behavior
- [x] All 503 tests pass (0 failures)
- [x] TypeScript type-checks cleanly (no new errors)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)