### PR TITLE
S3-1: Topological sort

### DIFF
--- a/src/plan/sort.ts
+++ b/src/plan/sort.ts
@@ -1,0 +1,376 @@
+// src/plan/sort.ts — Dependency-aware topological sort for deploy ordering
+//
+// Implements Kahn's algorithm for topological sort, cycle detection,
+// conflict checking, and filtering for pending/target changes.
+//
+// Changes declare dependencies via `requires` (must be deployed first)
+// and `conflicts` (must NOT be deployed). The sort produces a valid
+// deploy order that respects all dependency constraints.
+
+import type { Change } from "./types";
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+/** Thrown when a dependency cycle is detected among changes. */
+export class CycleError extends Error {
+  /** The change names forming the cycle, e.g. ["A", "B", "C", "A"]. */
+  readonly cycle: string[];
+
+  constructor(cycle: string[]) {
+    super(`Dependency cycle detected: ${cycle.join(" -> ")}`);
+    this.name = "CycleError";
+    this.cycle = cycle;
+  }
+}
+
+/** Thrown when a required dependency is missing (not in changes or deployed). */
+export class MissingDependencyError extends Error {
+  /** The change that has the unsatisfied dependency. */
+  readonly change: string;
+  /** The dependency that is missing. */
+  readonly dependency: string;
+
+  constructor(change: string, dependency: string) {
+    super(
+      `Change "${change}" requires "${dependency}", which is not in the plan or deployed`,
+    );
+    this.name = "MissingDependencyError";
+    this.change = change;
+    this.dependency = dependency;
+  }
+}
+
+/** Thrown when a conflicting change is already deployed. */
+export class ConflictError extends Error {
+  /** The change that declares the conflict. */
+  readonly change: string;
+  /** The deployed change that conflicts. */
+  readonly conflictsWith: string;
+
+  constructor(change: string, conflictsWith: string) {
+    super(
+      `Change "${change}" conflicts with "${conflictsWith}", which is already deployed`,
+    );
+    this.name = "ConflictError";
+    this.change = change;
+    this.conflictsWith = conflictsWith;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Topological sort using Kahn's algorithm.
+ *
+ * Returns changes in a valid deploy order: every change appears after
+ * all of its `requires` dependencies. For changes with no dependency
+ * relationship, the original plan-file order is preserved (stable sort).
+ *
+ * Throws CycleError if a dependency cycle is detected.
+ *
+ * Dependencies referencing changes not in the input set are silently
+ * skipped (they are assumed to be already deployed). Use
+ * validateDependencies() to verify all dependencies are satisfiable
+ * before calling this function.
+ */
+export function topologicalSort(changes: Change[]): Change[] {
+  if (changes.length === 0) return [];
+
+  // Build name -> index map for O(1) lookup
+  const nameToIndex = new Map<string, number>();
+  for (let i = 0; i < changes.length; i++) {
+    const c = changes[i]!;
+    nameToIndex.set(c.name, i);
+  }
+
+  // Compute in-degree and adjacency (forward edges: dep -> dependant)
+  const n = changes.length;
+  const inDegree = new Array<number>(n).fill(0);
+  const adj = new Array<number[]>(n);
+  for (let i = 0; i < n; i++) {
+    adj[i] = [];
+  }
+
+  for (let i = 0; i < n; i++) {
+    const c = changes[i]!;
+    for (const req of c.requires) {
+      const depIdx = nameToIndex.get(req);
+      if (depIdx === undefined) {
+        // External dependency (already deployed or validated separately)
+        continue;
+      }
+      adj[depIdx]!.push(i);
+      inDegree[i]!++;
+    }
+  }
+
+  // Kahn's algorithm with stable ordering:
+  // Use a queue that always picks the node with the lowest original index
+  // among those with in-degree 0, preserving plan-file order for
+  // independent changes.
+  const queue: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (inDegree[i] === 0) {
+      queue.push(i);
+    }
+  }
+  // Sort initially by original index (ascending) so we process in plan order
+  queue.sort((a, b) => a - b);
+
+  const result: Change[] = [];
+  let processed = 0;
+
+  while (queue.length > 0) {
+    const idx = queue.shift()!;
+    result.push(changes[idx]!);
+    processed++;
+
+    // Collect newly freed nodes
+    const newlyFree: number[] = [];
+    for (const neighbor of adj[idx]!) {
+      inDegree[neighbor]!--;
+      if (inDegree[neighbor] === 0) {
+        newlyFree.push(neighbor);
+      }
+    }
+    // Insert newly freed nodes in sorted position to maintain stability
+    if (newlyFree.length > 0) {
+      newlyFree.sort((a, b) => a - b);
+      // Merge into queue maintaining sorted order
+      const merged: number[] = [];
+      let qi = 0;
+      let ni = 0;
+      while (qi < queue.length && ni < newlyFree.length) {
+        if (queue[qi]! <= newlyFree[ni]!) {
+          merged.push(queue[qi]!);
+          qi++;
+        } else {
+          merged.push(newlyFree[ni]!);
+          ni++;
+        }
+      }
+      while (qi < queue.length) {
+        merged.push(queue[qi]!);
+        qi++;
+      }
+      while (ni < newlyFree.length) {
+        merged.push(newlyFree[ni]!);
+        ni++;
+      }
+      queue.length = 0;
+      queue.push(...merged);
+    }
+  }
+
+  if (processed < n) {
+    // Cycle detected — find and report it
+    const cyclePath = findCyclePath(changes, nameToIndex, inDegree);
+    throw new CycleError(cyclePath);
+  }
+
+  return result;
+}
+
+/**
+ * Find a cycle path among remaining nodes (those with non-zero in-degree).
+ * Returns the cycle as [A, B, C, A] for reporting.
+ */
+function findCyclePath(
+  changes: Change[],
+  nameToIndex: Map<string, number>,
+  inDegree: number[],
+): string[] {
+  // DFS from nodes still in the graph (in-degree > 0)
+  const n = changes.length;
+  const visited = new Set<number>();
+  const onStack = new Set<number>();
+  const parent = new Map<number, number>();
+
+  for (let start = 0; start < n; start++) {
+    if (inDegree[start] === 0 || visited.has(start)) continue;
+
+    const stack: Array<{ node: number; reqIdx: number }> = [
+      { node: start, reqIdx: 0 },
+    ];
+    onStack.add(start);
+    visited.add(start);
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1]!;
+      const c = changes[frame.node]!;
+
+      if (frame.reqIdx >= c.requires.length) {
+        // Done with this node
+        onStack.delete(frame.node);
+        stack.pop();
+        continue;
+      }
+
+      const reqName = c.requires[frame.reqIdx]!;
+      frame.reqIdx++;
+
+      const neighbor = nameToIndex.get(reqName);
+      if (neighbor === undefined || inDegree[neighbor] === 0) continue;
+
+      if (onStack.has(neighbor)) {
+        // Found cycle: trace back from current node to neighbor
+        const cycle: string[] = [changes[neighbor]!.name];
+        for (let i = stack.length - 1; i >= 0; i--) {
+          cycle.push(changes[stack[i]!.node]!.name);
+          if (stack[i]!.node === neighbor) break;
+        }
+        cycle.reverse();
+        return cycle;
+      }
+
+      if (!visited.has(neighbor)) {
+        visited.add(neighbor);
+        onStack.add(neighbor);
+        parent.set(neighbor, frame.node);
+        stack.push({ node: neighbor, reqIdx: 0 });
+      }
+    }
+  }
+
+  // Fallback: shouldn't reach here if there's truly a cycle,
+  // but return something useful
+  const remaining = [];
+  for (let i = 0; i < n; i++) {
+    if (inDegree[i]! > 0) remaining.push(changes[i]!.name);
+  }
+  return [...remaining, remaining[0]!];
+}
+
+/**
+ * Validate that all dependencies are satisfiable.
+ *
+ * A dependency is satisfiable if it exists in `changes` (will be deployed)
+ * or in `deployed` (already deployed). Also checks conflict constraints:
+ * if a change declares a conflict with a deployed change, throws ConflictError.
+ *
+ * @param changes - The changes to validate
+ * @param deployed - Names of already-deployed changes
+ */
+export function validateDependencies(
+  changes: Change[],
+  deployed: string[],
+): void {
+  const deployedSet = new Set(deployed);
+  const changeNames = new Set(changes.map((c) => c.name));
+
+  for (const change of changes) {
+    // Check requires
+    for (const req of change.requires) {
+      if (!changeNames.has(req) && !deployedSet.has(req)) {
+        throw new MissingDependencyError(change.name, req);
+      }
+    }
+
+    // Check conflicts
+    for (const conflict of change.conflicts) {
+      if (deployedSet.has(conflict)) {
+        throw new ConflictError(change.name, conflict);
+      }
+    }
+  }
+}
+
+/**
+ * Detect dependency cycles among changes.
+ *
+ * Returns null if no cycle exists, or a CycleError with the cycle path
+ * if one is found. Does not throw — the caller decides how to handle it.
+ */
+export function detectCycles(changes: Change[]): CycleError | null {
+  if (changes.length === 0) return null;
+
+  const nameToIndex = new Map<string, number>();
+  for (let i = 0; i < changes.length; i++) {
+    nameToIndex.set(changes[i]!.name, i);
+  }
+
+  // DFS-based cycle detection
+  const n = changes.length;
+  const WHITE = 0; // unvisited
+  const GRAY = 1; // on current DFS stack
+  const BLACK = 2; // fully processed
+  const color = new Array<number>(n).fill(WHITE);
+
+  for (let start = 0; start < n; start++) {
+    if (color[start] !== WHITE) continue;
+
+    const stack: Array<{ node: number; reqIdx: number }> = [
+      { node: start, reqIdx: 0 },
+    ];
+    color[start] = GRAY;
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1]!;
+      const c = changes[frame.node]!;
+
+      if (frame.reqIdx >= c.requires.length) {
+        color[frame.node] = BLACK;
+        stack.pop();
+        continue;
+      }
+
+      const reqName = c.requires[frame.reqIdx]!;
+      frame.reqIdx++;
+
+      const neighbor = nameToIndex.get(reqName);
+      if (neighbor === undefined) continue; // external dep, skip
+
+      if (color[neighbor] === GRAY) {
+        // Found cycle — build the path
+        const cycle: string[] = [changes[neighbor]!.name];
+        for (let i = stack.length - 1; i >= 0; i--) {
+          cycle.push(changes[stack[i]!.node]!.name);
+          if (stack[i]!.node === neighbor) break;
+        }
+        cycle.reverse();
+        return new CycleError(cycle);
+      }
+
+      if (color[neighbor] === WHITE) {
+        color[neighbor] = GRAY;
+        stack.push({ node: neighbor, reqIdx: 0 });
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Filter to only pending (undeployed) changes.
+ *
+ * Returns changes from `allChanges` whose `change_id` is not in
+ * `deployedIds`. Preserves the original order.
+ */
+export function filterPending(
+  allChanges: Change[],
+  deployedIds: string[],
+): Change[] {
+  const deployed = new Set(deployedIds);
+  return allChanges.filter((c) => !deployed.has(c.change_id));
+}
+
+/**
+ * Filter changes up to and including a target change.
+ *
+ * Returns the subset of `changes` from the beginning up to and including
+ * the change whose name matches `target`. Preserves order.
+ *
+ * Throws if the target change is not found.
+ */
+export function filterToTarget(changes: Change[], target: string): Change[] {
+  const idx = changes.findIndex((c) => c.name === target);
+  if (idx === -1) {
+    throw new Error(`Target change "${target}" not found in plan`);
+  }
+  return changes.slice(0, idx + 1);
+}

--- a/tests/unit/topo-sort.test.ts
+++ b/tests/unit/topo-sort.test.ts
@@ -1,0 +1,501 @@
+// tests/unit/topo-sort.test.ts — Tests for topological sort and dependency handling
+//
+// Validates deploy ordering, cycle detection, conflict checking,
+// filtering, and edge cases for the topological sort module.
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  topologicalSort,
+  validateDependencies,
+  detectCycles,
+  filterPending,
+  filterToTarget,
+  CycleError,
+  MissingDependencyError,
+  ConflictError,
+} from "../../src/plan/sort";
+
+import type { Change } from "../../src/plan/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal Change object for testing. */
+function makeChange(
+  name: string,
+  opts?: {
+    requires?: string[];
+    conflicts?: string[];
+    change_id?: string;
+    project?: string;
+  },
+): Change {
+  return {
+    change_id: opts?.change_id ?? `id-${name}`,
+    name,
+    project: opts?.project ?? "test",
+    note: "",
+    planner_name: "Test User",
+    planner_email: "test@example.com",
+    planned_at: "2025-01-01T00:00:00Z",
+    requires: opts?.requires ?? [],
+    conflicts: opts?.conflicts ?? [],
+  };
+}
+
+/** Extract just the names from a Change array, for easy assertion. */
+function names(changes: Change[]): string[] {
+  return changes.map((c) => c.name);
+}
+
+// ---------------------------------------------------------------------------
+// topologicalSort
+// ---------------------------------------------------------------------------
+
+describe("topologicalSort", () => {
+  it("returns empty array for empty input", () => {
+    expect(topologicalSort([])).toEqual([]);
+  });
+
+  it("returns single change unchanged", () => {
+    const changes = [makeChange("A")];
+    expect(names(topologicalSort(changes))).toEqual(["A"]);
+  });
+
+  it("preserves plan order for sequential (no deps) changes", () => {
+    const changes = [
+      makeChange("A"),
+      makeChange("B"),
+      makeChange("C"),
+      makeChange("D"),
+    ];
+    expect(names(topologicalSort(changes))).toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("sorts linear dependencies: A -> B -> C", () => {
+    const changes = [
+      makeChange("C", { requires: ["B"] }),
+      makeChange("B", { requires: ["A"] }),
+      makeChange("A"),
+    ];
+    expect(names(topologicalSort(changes))).toEqual(["A", "B", "C"]);
+  });
+
+  it("sorts diamond dependencies: D -> B+C, B -> A, C -> A", () => {
+    // Diamond: A is at the base, B and C depend on A, D depends on B and C
+    const changes = [
+      makeChange("D", { requires: ["B", "C"] }),
+      makeChange("B", { requires: ["A"] }),
+      makeChange("C", { requires: ["A"] }),
+      makeChange("A"),
+    ];
+    const sorted = names(topologicalSort(changes));
+    // A must come first
+    expect(sorted[0]).toBe("A");
+    // B and C must come before D
+    expect(sorted.indexOf("B")).toBeLessThan(sorted.indexOf("D"));
+    expect(sorted.indexOf("C")).toBeLessThan(sorted.indexOf("D"));
+    // D must be last
+    expect(sorted[3]).toBe("D");
+  });
+
+  it("handles fan-out: A -> B, A -> C, A -> D", () => {
+    const changes = [
+      makeChange("A"),
+      makeChange("B", { requires: ["A"] }),
+      makeChange("C", { requires: ["A"] }),
+      makeChange("D", { requires: ["A"] }),
+    ];
+    const sorted = names(topologicalSort(changes));
+    expect(sorted[0]).toBe("A");
+    // B, C, D can be in any stable order (plan order)
+    expect(sorted.slice(1)).toEqual(["B", "C", "D"]);
+  });
+
+  it("handles fan-in: B -> D, C -> D", () => {
+    const changes = [
+      makeChange("B"),
+      makeChange("C"),
+      makeChange("D", { requires: ["B", "C"] }),
+    ];
+    const sorted = names(topologicalSort(changes));
+    expect(sorted.indexOf("B")).toBeLessThan(sorted.indexOf("D"));
+    expect(sorted.indexOf("C")).toBeLessThan(sorted.indexOf("D"));
+  });
+
+  it("preserves stable order among independent changes", () => {
+    // E has no deps, placed between dependent changes
+    const changes = [
+      makeChange("A"),
+      makeChange("E"),
+      makeChange("B", { requires: ["A"] }),
+      makeChange("F"),
+      makeChange("C", { requires: ["B"] }),
+    ];
+    const sorted = names(topologicalSort(changes));
+    // A < B < C must hold
+    expect(sorted.indexOf("A")).toBeLessThan(sorted.indexOf("B"));
+    expect(sorted.indexOf("B")).toBeLessThan(sorted.indexOf("C"));
+    // E and F should maintain relative plan order among independents
+    expect(sorted.indexOf("E")).toBeLessThan(sorted.indexOf("F"));
+  });
+
+  it("throws CycleError for direct cycle: A -> B -> A", () => {
+    const changes = [
+      makeChange("A", { requires: ["B"] }),
+      makeChange("B", { requires: ["A"] }),
+    ];
+    expect(() => topologicalSort(changes)).toThrow(CycleError);
+  });
+
+  it("throws CycleError for indirect cycle: A -> B -> C -> A", () => {
+    const changes = [
+      makeChange("A", { requires: ["C"] }),
+      makeChange("B", { requires: ["A"] }),
+      makeChange("C", { requires: ["B"] }),
+    ];
+    expect(() => topologicalSort(changes)).toThrow(CycleError);
+  });
+
+  it("cycle error includes the cycle path", () => {
+    const changes = [
+      makeChange("A", { requires: ["B"] }),
+      makeChange("B", { requires: ["A"] }),
+    ];
+    try {
+      topologicalSort(changes);
+      expect(true).toBe(false); // should not reach
+    } catch (e) {
+      expect(e).toBeInstanceOf(CycleError);
+      const err = e as CycleError;
+      // Cycle path should start and end with the same node
+      expect(err.cycle[0]).toBe(err.cycle[err.cycle.length - 1]);
+      expect(err.cycle.length).toBeGreaterThanOrEqual(3); // at least A -> B -> A
+      expect(err.message).toContain("->");
+    }
+  });
+
+  it("skips external dependencies not in input set", () => {
+    // "ext" is not in changes — treated as already deployed
+    const changes = [
+      makeChange("A", { requires: ["ext"] }),
+      makeChange("B", { requires: ["A"] }),
+    ];
+    const sorted = names(topologicalSort(changes));
+    expect(sorted).toEqual(["A", "B"]);
+  });
+
+  it("self-referencing change throws CycleError", () => {
+    const changes = [makeChange("A", { requires: ["A"] })];
+    expect(() => topologicalSort(changes)).toThrow(CycleError);
+  });
+
+  it("handles complex graph correctly", () => {
+    // A -> B -> D
+    // A -> C -> D
+    // E (independent)
+    // F -> D
+    const changes = [
+      makeChange("E"),
+      makeChange("A"),
+      makeChange("B", { requires: ["A"] }),
+      makeChange("C", { requires: ["A"] }),
+      makeChange("F"),
+      makeChange("D", { requires: ["B", "C", "F"] }),
+    ];
+    const sorted = names(topologicalSort(changes));
+    // A before B and C
+    expect(sorted.indexOf("A")).toBeLessThan(sorted.indexOf("B"));
+    expect(sorted.indexOf("A")).toBeLessThan(sorted.indexOf("C"));
+    // B, C, F before D
+    expect(sorted.indexOf("B")).toBeLessThan(sorted.indexOf("D"));
+    expect(sorted.indexOf("C")).toBeLessThan(sorted.indexOf("D"));
+    expect(sorted.indexOf("F")).toBeLessThan(sorted.indexOf("D"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDependencies
+// ---------------------------------------------------------------------------
+
+describe("validateDependencies", () => {
+  it("passes when all requires are in changes", () => {
+    const changes = [
+      makeChange("A"),
+      makeChange("B", { requires: ["A"] }),
+    ];
+    expect(() => validateDependencies(changes, [])).not.toThrow();
+  });
+
+  it("passes when requires are in deployed", () => {
+    const changes = [makeChange("B", { requires: ["A"] })];
+    expect(() => validateDependencies(changes, ["A"])).not.toThrow();
+  });
+
+  it("passes when requires are split between changes and deployed", () => {
+    const changes = [
+      makeChange("B"),
+      makeChange("C", { requires: ["A", "B"] }),
+    ];
+    expect(() => validateDependencies(changes, ["A"])).not.toThrow();
+  });
+
+  it("throws MissingDependencyError for missing require", () => {
+    const changes = [makeChange("B", { requires: ["A"] })];
+    expect(() => validateDependencies(changes, [])).toThrow(
+      MissingDependencyError,
+    );
+  });
+
+  it("missing dependency error has correct fields", () => {
+    const changes = [makeChange("B", { requires: ["A"] })];
+    try {
+      validateDependencies(changes, []);
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(MissingDependencyError);
+      const err = e as MissingDependencyError;
+      expect(err.change).toBe("B");
+      expect(err.dependency).toBe("A");
+    }
+  });
+
+  it("throws ConflictError when conflict is deployed", () => {
+    const changes = [makeChange("B", { conflicts: ["A"] })];
+    expect(() => validateDependencies(changes, ["A"])).toThrow(ConflictError);
+  });
+
+  it("conflict error has correct fields", () => {
+    const changes = [makeChange("B", { conflicts: ["A"] })];
+    try {
+      validateDependencies(changes, ["A"]);
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ConflictError);
+      const err = e as ConflictError;
+      expect(err.change).toBe("B");
+      expect(err.conflictsWith).toBe("A");
+    }
+  });
+
+  it("does not throw for conflict that is NOT deployed", () => {
+    const changes = [makeChange("B", { conflicts: ["A"] })];
+    expect(() => validateDependencies(changes, [])).not.toThrow();
+  });
+
+  it("does not throw for conflict that is in changes (not deployed)", () => {
+    // A conflict with an undeployed change in the same batch is okay
+    // (it means the change hasn't been deployed yet, so no conflict)
+    const changes = [
+      makeChange("A"),
+      makeChange("B", { conflicts: ["A"] }),
+    ];
+    expect(() => validateDependencies(changes, [])).not.toThrow();
+  });
+
+  it("handles changes with no deps", () => {
+    const changes = [makeChange("A"), makeChange("B")];
+    expect(() => validateDependencies(changes, [])).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectCycles
+// ---------------------------------------------------------------------------
+
+describe("detectCycles", () => {
+  it("returns null for empty input", () => {
+    expect(detectCycles([])).toBeNull();
+  });
+
+  it("returns null for acyclic graph", () => {
+    const changes = [
+      makeChange("A"),
+      makeChange("B", { requires: ["A"] }),
+      makeChange("C", { requires: ["B"] }),
+    ];
+    expect(detectCycles(changes)).toBeNull();
+  });
+
+  it("returns null for independent changes", () => {
+    const changes = [makeChange("A"), makeChange("B"), makeChange("C")];
+    expect(detectCycles(changes)).toBeNull();
+  });
+
+  it("detects direct cycle", () => {
+    const changes = [
+      makeChange("A", { requires: ["B"] }),
+      makeChange("B", { requires: ["A"] }),
+    ];
+    const err = detectCycles(changes);
+    expect(err).toBeInstanceOf(CycleError);
+    expect(err!.cycle[0]).toBe(err!.cycle[err!.cycle.length - 1]);
+  });
+
+  it("detects indirect cycle of length 3", () => {
+    const changes = [
+      makeChange("A", { requires: ["C"] }),
+      makeChange("B", { requires: ["A"] }),
+      makeChange("C", { requires: ["B"] }),
+    ];
+    const err = detectCycles(changes);
+    expect(err).toBeInstanceOf(CycleError);
+    expect(err!.cycle.length).toBe(4); // A -> B -> C -> A or similar
+  });
+
+  it("detects self-referencing cycle", () => {
+    const changes = [makeChange("A", { requires: ["A"] })];
+    const err = detectCycles(changes);
+    expect(err).toBeInstanceOf(CycleError);
+  });
+
+  it("ignores external dependencies when checking cycles", () => {
+    // "ext" is not in changes — it's an external/deployed dep
+    const changes = [makeChange("A", { requires: ["ext"] })];
+    const err = detectCycles(changes);
+    expect(err).toBeNull();
+  });
+
+  it("returns CycleError with meaningful message", () => {
+    const changes = [
+      makeChange("X", { requires: ["Y"] }),
+      makeChange("Y", { requires: ["X"] }),
+    ];
+    const err = detectCycles(changes);
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain("->");
+    expect(err!.message).toContain("cycle");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterPending
+// ---------------------------------------------------------------------------
+
+describe("filterPending", () => {
+  it("returns all changes when none deployed", () => {
+    const changes = [makeChange("A"), makeChange("B")];
+    expect(names(filterPending(changes, []))).toEqual(["A", "B"]);
+  });
+
+  it("filters out deployed changes by change_id", () => {
+    const changes = [
+      makeChange("A", { change_id: "id-1" }),
+      makeChange("B", { change_id: "id-2" }),
+      makeChange("C", { change_id: "id-3" }),
+    ];
+    expect(names(filterPending(changes, ["id-1", "id-3"]))).toEqual(["B"]);
+  });
+
+  it("returns empty when all deployed", () => {
+    const changes = [
+      makeChange("A", { change_id: "id-1" }),
+      makeChange("B", { change_id: "id-2" }),
+    ];
+    expect(filterPending(changes, ["id-1", "id-2"])).toEqual([]);
+  });
+
+  it("preserves order of pending changes", () => {
+    const changes = [
+      makeChange("A", { change_id: "id-1" }),
+      makeChange("B", { change_id: "id-2" }),
+      makeChange("C", { change_id: "id-3" }),
+      makeChange("D", { change_id: "id-4" }),
+    ];
+    expect(names(filterPending(changes, ["id-2", "id-4"]))).toEqual([
+      "A",
+      "C",
+    ]);
+  });
+
+  it("handles empty changes", () => {
+    expect(filterPending([], ["id-1"])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterToTarget
+// ---------------------------------------------------------------------------
+
+describe("filterToTarget", () => {
+  it("returns all changes up to target", () => {
+    const changes = [
+      makeChange("A"),
+      makeChange("B"),
+      makeChange("C"),
+      makeChange("D"),
+    ];
+    expect(names(filterToTarget(changes, "C"))).toEqual(["A", "B", "C"]);
+  });
+
+  it("returns single change when target is first", () => {
+    const changes = [makeChange("A"), makeChange("B"), makeChange("C")];
+    expect(names(filterToTarget(changes, "A"))).toEqual(["A"]);
+  });
+
+  it("returns all changes when target is last", () => {
+    const changes = [makeChange("A"), makeChange("B"), makeChange("C")];
+    expect(names(filterToTarget(changes, "C"))).toEqual(["A", "B", "C"]);
+  });
+
+  it("throws when target not found", () => {
+    const changes = [makeChange("A"), makeChange("B")];
+    expect(() => filterToTarget(changes, "Z")).toThrow(
+      'Target change "Z" not found in plan',
+    );
+  });
+
+  it("handles single-element list", () => {
+    const changes = [makeChange("A")];
+    expect(names(filterToTarget(changes, "A"))).toEqual(["A"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: sort + validate + filter
+// ---------------------------------------------------------------------------
+
+describe("integration: sort + validate + filter", () => {
+  it("full pipeline: filter pending, validate, sort", () => {
+    const all = [
+      makeChange("schema", { change_id: "deployed-1" }),
+      makeChange("users", { change_id: "deployed-2", requires: ["schema"] }),
+      makeChange("orders", { change_id: "pending-1", requires: ["users"] }),
+      makeChange("items", { change_id: "pending-2", requires: ["orders"] }),
+    ];
+    const pending = filterPending(all, ["deployed-1", "deployed-2"]);
+    expect(names(pending)).toEqual(["orders", "items"]);
+
+    // Validate with deployed names
+    validateDependencies(pending, ["schema", "users"]);
+
+    const sorted = topologicalSort(pending);
+    expect(names(sorted)).toEqual(["orders", "items"]);
+  });
+
+  it("filter to target then sort", () => {
+    const changes = [
+      makeChange("A"),
+      makeChange("B", { requires: ["A"] }),
+      makeChange("C", { requires: ["B"] }),
+      makeChange("D", { requires: ["C"] }),
+    ];
+    const subset = filterToTarget(changes, "C");
+    const sorted = topologicalSort(subset);
+    expect(names(sorted)).toEqual(["A", "B", "C"]);
+  });
+
+  it("conflict blocks deploy even when other deps satisfied", () => {
+    const changes = [
+      makeChange("new_feature", {
+        requires: ["schema"],
+        conflicts: ["old_feature"],
+      }),
+    ];
+    expect(() =>
+      validateDependencies(changes, ["schema", "old_feature"]),
+    ).toThrow(ConflictError);
+  });
+});


### PR DESCRIPTION
Closes #32

## Summary

- Add `src/plan/sort.ts` with dependency-aware topological sort (Kahn's algorithm), cycle detection, conflict checking, and filtering utilities
- `topologicalSort(changes)` — returns deploy order preserving plan-file order for independent changes
- `validateDependencies(changes, deployed)` — verifies all requires exist (in plan or deployed) and no conflicts are deployed
- `detectCycles(changes)` — DFS-based cycle detection returning clear error with cycle path
- `filterPending(allChanges, deployedIds)` — filters to undeployed changes only
- `filterToTarget(changes, target)` — filters up to `--to` target change
- Custom error types: `CycleError`, `MissingDependencyError`, `ConflictError`

## Test plan
- [x] 45 unit tests in `tests/unit/topo-sort.test.ts` (exceeds 20 minimum)
- [x] Linear deps deploy in order
- [x] Diamond deps deploy correctly (A base, B+C middle, D top)
- [x] Fan-out and fan-in patterns
- [x] Cycles detected with clear path (direct, indirect, self-referencing)
- [x] `--to` correctly selects subset
- [x] Conflict detection blocks when conflict is deployed
- [x] Sequential (no deps) preserves plan file order
- [x] Integration tests: full pipeline (filter pending + validate + sort)
- [x] All 653 tests pass (existing + new), no type errors in new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)