### PR TITLE
S5-4: Analysis reporters — text, JSON, GitHub annotations, GitLab Code Quality

### DIFF
--- a/src/analysis/reporter.ts
+++ b/src/analysis/reporter.ts
@@ -1,0 +1,370 @@
+// src/analysis/reporter.ts — Output formatting for analysis findings
+//
+// Supports four output formats:
+//   text              — human-readable with ANSI colors (when TTY)
+//   json              — structured JSON per SPEC schema
+//   github-annotations — GitHub Actions workflow commands
+//   gitlab-codequality — GitLab Code Quality JSON report
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Severity = "error" | "warn" | "info";
+
+export interface Location {
+  file: string;
+  line: number;
+  column: number;
+}
+
+export interface Finding {
+  ruleId: string;
+  severity: Severity;
+  message: string;
+  location: Location;
+  suggestion?: string;
+}
+
+export interface ReportMetadata {
+  files_analyzed: number;
+  rules_checked: number;
+  duration_ms: number;
+}
+
+export interface ReportSummary {
+  errors: number;
+  warnings: number;
+  info: number;
+}
+
+export interface JsonReport {
+  version: 1;
+  metadata: ReportMetadata;
+  findings: Array<{
+    ruleId: string;
+    severity: Severity;
+    message: string;
+    location: Location;
+    suggestion?: string;
+  }>;
+  summary: ReportSummary;
+}
+
+export interface GitLabCodeQualityEntry {
+  description: string;
+  check_name: string;
+  fingerprint: string;
+  severity: "critical" | "major" | "minor";
+  location: {
+    path: string;
+    lines: {
+      begin: number;
+    };
+  };
+}
+
+export type ReportFormat =
+  | "text"
+  | "json"
+  | "github-annotations"
+  | "gitlab-codequality";
+
+// ---------------------------------------------------------------------------
+// ANSI helpers
+// ---------------------------------------------------------------------------
+
+const ANSI = {
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  reset: "\x1b[0m",
+} as const;
+
+function colorize(text: string, ...codes: string[]): string {
+  return codes.join("") + text + ANSI.reset;
+}
+
+// ---------------------------------------------------------------------------
+// Summary computation
+// ---------------------------------------------------------------------------
+
+export function computeSummary(findings: readonly Finding[]): ReportSummary {
+  let errors = 0;
+  let warnings = 0;
+  let info = 0;
+  for (const f of findings) {
+    switch (f.severity) {
+      case "error":
+        errors++;
+        break;
+      case "warn":
+        warnings++;
+        break;
+      case "info":
+        info++;
+        break;
+    }
+  }
+  return { errors, warnings, info };
+}
+
+// ---------------------------------------------------------------------------
+// Text formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format findings as human-readable text with ANSI colors.
+ *
+ * Each finding is rendered as:
+ *   <severity> <ruleId>: <message>
+ *     at <file>:<line>:<column>
+ *     suggestion: <suggestion>
+ *
+ * A summary line follows all findings.
+ *
+ * @param useColors - Whether to use ANSI color codes (default: true)
+ */
+export function formatText(
+  findings: readonly Finding[],
+  filePath?: string,
+  useColors: boolean = true,
+): string {
+  const lines: string[] = [];
+
+  if (filePath) {
+    const header = useColors
+      ? colorize(filePath, ANSI.bold)
+      : filePath;
+    lines.push(header);
+  }
+
+  for (const f of findings) {
+    const sevLabel = severityLabel(f.severity, useColors);
+    const ruleId = useColors
+      ? colorize(f.ruleId, ANSI.dim)
+      : f.ruleId;
+    lines.push(`  ${sevLabel} ${ruleId}: ${f.message}`);
+
+    const loc = `${f.location.file}:${f.location.line}:${f.location.column}`;
+    const locStr = useColors ? colorize(loc, ANSI.dim) : loc;
+    lines.push(`    at ${locStr}`);
+
+    if (f.suggestion) {
+      const sug = useColors
+        ? colorize(`suggestion: ${f.suggestion}`, ANSI.dim)
+        : `suggestion: ${f.suggestion}`;
+      lines.push(`    ${sug}`);
+    }
+  }
+
+  // Summary line
+  const summary = computeSummary(findings);
+  const parts: string[] = [];
+  if (summary.errors > 0) {
+    const t = `${summary.errors} error${summary.errors !== 1 ? "s" : ""}`;
+    parts.push(useColors ? colorize(t, ANSI.red) : t);
+  }
+  if (summary.warnings > 0) {
+    const t = `${summary.warnings} warning${summary.warnings !== 1 ? "s" : ""}`;
+    parts.push(useColors ? colorize(t, ANSI.yellow) : t);
+  }
+  if (summary.info > 0) {
+    const t = `${summary.info} info`;
+    parts.push(useColors ? colorize(t, ANSI.blue) : t);
+  }
+
+  if (parts.length > 0) {
+    lines.push("");
+    lines.push(parts.join(", "));
+  } else {
+    lines.push("");
+    lines.push("No issues found.");
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+function severityLabel(severity: Severity, useColors: boolean): string {
+  switch (severity) {
+    case "error":
+      return useColors ? colorize("error", ANSI.red, ANSI.bold) : "error";
+    case "warn":
+      return useColors ? colorize("warn ", ANSI.yellow) : "warn ";
+    case "info":
+      return useColors ? colorize("info ", ANSI.blue) : "info ";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format findings as structured JSON per SPEC schema.
+ *
+ * Returns a JSON string with the following shape:
+ *   { version: 1, metadata, findings, summary }
+ */
+export function formatJson(
+  findings: readonly Finding[],
+  metadata: ReportMetadata,
+): string {
+  const summary = computeSummary(findings);
+  const report: JsonReport = {
+    version: 1,
+    metadata,
+    findings: findings.map((f) => {
+      const entry: JsonReport["findings"][number] = {
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+        location: { ...f.location },
+      };
+      if (f.suggestion !== undefined) {
+        entry.suggestion = f.suggestion;
+      }
+      return entry;
+    }),
+    summary,
+  };
+  return JSON.stringify(report, null, 2) + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Annotations formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format findings as GitHub Actions workflow commands.
+ *
+ * Each finding becomes a line like:
+ *   ::error file=<path>,line=<line>,col=<col>::<ruleId>: <message>
+ *   ::warning file=<path>,line=<line>,col=<col>::<ruleId>: <message>
+ *   ::notice file=<path>,line=<line>,col=<col>::<ruleId>: <message>
+ *
+ * Severity mapping: error → error, warn → warning, info → notice
+ */
+export function formatGithubAnnotations(findings: readonly Finding[]): string {
+  const lines: string[] = [];
+  for (const f of findings) {
+    const level = ghAnnotationLevel(f.severity);
+    const loc = `file=${f.location.file},line=${f.location.line},col=${f.location.column}`;
+    const msg = f.suggestion
+      ? `${f.ruleId}: ${f.message} — ${f.suggestion}`
+      : `${f.ruleId}: ${f.message}`;
+    lines.push(`::${level} ${loc}::${msg}`);
+  }
+  return lines.join("\n") + (lines.length > 0 ? "\n" : "");
+}
+
+function ghAnnotationLevel(severity: Severity): string {
+  switch (severity) {
+    case "error":
+      return "error";
+    case "warn":
+      return "warning";
+    case "info":
+      return "notice";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitLab Code Quality formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format findings as GitLab Code Quality JSON.
+ *
+ * Returns a JSON array where each element has:
+ *   description, check_name, fingerprint, severity, location
+ *
+ * Severity mapping: error → critical, warn → major, info → minor
+ * Fingerprint: SHA-1 of (ruleId, filePath, line)
+ */
+export function formatGitlabCodeQuality(
+  findings: readonly Finding[],
+): string {
+  const entries: GitLabCodeQualityEntry[] = findings.map((f) => ({
+    description: f.suggestion
+      ? `${f.message} — ${f.suggestion}`
+      : f.message,
+    check_name: f.ruleId,
+    fingerprint: computeFingerprint(f.ruleId, f.location.file, f.location.line),
+    severity: glSeverity(f.severity),
+    location: {
+      path: f.location.file,
+      lines: {
+        begin: f.location.line,
+      },
+    },
+  }));
+  return JSON.stringify(entries, null, 2) + "\n";
+}
+
+function glSeverity(severity: Severity): "critical" | "major" | "minor" {
+  switch (severity) {
+    case "error":
+      return "critical";
+    case "warn":
+      return "major";
+    case "info":
+      return "minor";
+  }
+}
+
+/**
+ * Compute a stable SHA-1 fingerprint for deduplication across CI runs.
+ * Input: concatenation of ruleId, filePath, and line number.
+ */
+export function computeFingerprint(
+  ruleId: string,
+  filePath: string,
+  line: number,
+): string {
+  const hasher = new Bun.CryptoHasher("sha1");
+  hasher.update(`${ruleId}:${filePath}:${line}`);
+  return hasher.digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Unified format dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Format findings using the specified format.
+ * Convenience wrapper that dispatches to the appropriate formatter.
+ */
+export function formatFindings(
+  format: ReportFormat,
+  findings: readonly Finding[],
+  options?: {
+    filePath?: string;
+    metadata?: ReportMetadata;
+    useColors?: boolean;
+  },
+): string {
+  switch (format) {
+    case "text":
+      return formatText(
+        findings,
+        options?.filePath,
+        options?.useColors ?? true,
+      );
+    case "json":
+      return formatJson(
+        findings,
+        options?.metadata ?? {
+          files_analyzed: 0,
+          rules_checked: 0,
+          duration_ms: 0,
+        },
+      );
+    case "github-annotations":
+      return formatGithubAnnotations(findings);
+    case "gitlab-codequality":
+      return formatGitlabCodeQuality(findings);
+  }
+}

--- a/tests/unit/reporter.test.ts
+++ b/tests/unit/reporter.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect } from "bun:test";
+import {
+  formatText,
+  formatJson,
+  formatGithubAnnotations,
+  formatGitlabCodeQuality,
+  formatFindings,
+  computeSummary,
+  computeFingerprint,
+  type Finding,
+  type ReportMetadata,
+} from "../../src/analysis/reporter";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const errorFinding: Finding = {
+  ruleId: "SA004",
+  severity: "error",
+  message: "Adding a column with a volatile DEFAULT requires a full table rewrite",
+  location: { file: "deploy/001-add-col.sql", line: 5, column: 1 },
+  suggestion: "Add the column without DEFAULT, then backfill in batches",
+};
+
+const warnFinding: Finding = {
+  ruleId: "SA007",
+  severity: "warn",
+  message: "CREATE INDEX without CONCURRENTLY will lock the table",
+  location: { file: "deploy/002-add-index.sql", line: 12, column: 3 },
+  suggestion: "Use CREATE INDEX CONCURRENTLY",
+};
+
+const infoFinding: Finding = {
+  ruleId: "SA015",
+  severity: "info",
+  message: "Consider adding a comment to this table",
+  location: { file: "deploy/003-create-table.sql", line: 1, column: 1 },
+};
+
+const mixedFindings: Finding[] = [errorFinding, warnFinding, infoFinding];
+
+const defaultMetadata: ReportMetadata = {
+  files_analyzed: 3,
+  rules_checked: 21,
+  duration_ms: 42,
+};
+
+// ---------------------------------------------------------------------------
+// computeSummary
+// ---------------------------------------------------------------------------
+
+describe("computeSummary", () => {
+  it("counts errors, warnings, and info findings", () => {
+    const summary = computeSummary(mixedFindings);
+    expect(summary).toEqual({ errors: 1, warnings: 1, info: 1 });
+  });
+
+  it("returns zeros for empty findings", () => {
+    const summary = computeSummary([]);
+    expect(summary).toEqual({ errors: 0, warnings: 0, info: 0 });
+  });
+
+  it("counts multiple errors correctly", () => {
+    const summary = computeSummary([errorFinding, errorFinding, warnFinding]);
+    expect(summary).toEqual({ errors: 2, warnings: 1, info: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatText
+// ---------------------------------------------------------------------------
+
+describe("formatText", () => {
+  it("includes file path header when provided", () => {
+    const output = formatText([errorFinding], "deploy/001-add-col.sql", false);
+    expect(output).toStartWith("deploy/001-add-col.sql\n");
+  });
+
+  it("omits file path header when not provided", () => {
+    const output = formatText([errorFinding], undefined, false);
+    expect(output).toStartWith("  error");
+  });
+
+  it("renders severity, ruleId, and message", () => {
+    const output = formatText([errorFinding], undefined, false);
+    expect(output).toContain("error SA004: Adding a column with a volatile DEFAULT");
+  });
+
+  it("renders location line", () => {
+    const output = formatText([errorFinding], undefined, false);
+    expect(output).toContain("at deploy/001-add-col.sql:5:1");
+  });
+
+  it("renders suggestion when present", () => {
+    const output = formatText([errorFinding], undefined, false);
+    expect(output).toContain("suggestion: Add the column without DEFAULT");
+  });
+
+  it("omits suggestion when absent", () => {
+    const output = formatText([infoFinding], undefined, false);
+    expect(output).not.toContain("suggestion:");
+  });
+
+  it("renders summary with counts", () => {
+    const output = formatText(mixedFindings, undefined, false);
+    expect(output).toContain("1 error");
+    expect(output).toContain("1 warning");
+    expect(output).toContain("1 info");
+  });
+
+  it("pluralizes summary counts", () => {
+    const output = formatText(
+      [errorFinding, errorFinding, warnFinding, warnFinding],
+      undefined,
+      false,
+    );
+    expect(output).toContain("2 errors");
+    expect(output).toContain("2 warnings");
+  });
+
+  it("renders 'No issues found.' when empty", () => {
+    const output = formatText([], undefined, false);
+    expect(output).toContain("No issues found.");
+  });
+
+  it("includes ANSI codes when useColors is true", () => {
+    const output = formatText([errorFinding], undefined, true);
+    expect(output).toContain("\x1b[31m"); // red for error
+    expect(output).toContain("\x1b[0m");  // reset
+  });
+
+  it("excludes ANSI codes when useColors is false", () => {
+    const output = formatText([errorFinding], undefined, false);
+    expect(output).not.toContain("\x1b[");
+  });
+
+  it("renders warn severity with correct label", () => {
+    const output = formatText([warnFinding], undefined, false);
+    expect(output).toContain("warn  SA007:");
+  });
+
+  it("renders info severity with correct label", () => {
+    const output = formatText([infoFinding], undefined, false);
+    expect(output).toContain("info  SA015:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatJson
+// ---------------------------------------------------------------------------
+
+describe("formatJson", () => {
+  it("produces valid JSON", () => {
+    const output = formatJson(mixedFindings, defaultMetadata);
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it("includes version: 1", () => {
+    const parsed = JSON.parse(formatJson(mixedFindings, defaultMetadata));
+    expect(parsed.version).toBe(1);
+  });
+
+  it("includes metadata", () => {
+    const parsed = JSON.parse(formatJson(mixedFindings, defaultMetadata));
+    expect(parsed.metadata).toEqual({
+      files_analyzed: 3,
+      rules_checked: 21,
+      duration_ms: 42,
+    });
+  });
+
+  it("includes correct summary counts", () => {
+    const parsed = JSON.parse(formatJson(mixedFindings, defaultMetadata));
+    expect(parsed.summary).toEqual({ errors: 1, warnings: 1, info: 1 });
+  });
+
+  it("includes all findings with correct fields", () => {
+    const parsed = JSON.parse(formatJson(mixedFindings, defaultMetadata));
+    expect(parsed.findings).toHaveLength(3);
+    expect(parsed.findings[0].ruleId).toBe("SA004");
+    expect(parsed.findings[0].severity).toBe("error");
+    expect(parsed.findings[0].message).toBe(
+      "Adding a column with a volatile DEFAULT requires a full table rewrite",
+    );
+    expect(parsed.findings[0].location).toEqual({
+      file: "deploy/001-add-col.sql",
+      line: 5,
+      column: 1,
+    });
+    expect(parsed.findings[0].suggestion).toBe(
+      "Add the column without DEFAULT, then backfill in batches",
+    );
+  });
+
+  it("omits suggestion field when not present", () => {
+    const parsed = JSON.parse(formatJson([infoFinding], defaultMetadata));
+    expect(parsed.findings[0]).not.toHaveProperty("suggestion");
+  });
+
+  it("handles empty findings", () => {
+    const parsed = JSON.parse(formatJson([], defaultMetadata));
+    expect(parsed.findings).toEqual([]);
+    expect(parsed.summary).toEqual({ errors: 0, warnings: 0, info: 0 });
+  });
+
+  it("pretty-prints with 2-space indentation", () => {
+    const output = formatJson([errorFinding], defaultMetadata);
+    // The output should contain indented lines
+    expect(output).toContain('  "version": 1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatGithubAnnotations
+// ---------------------------------------------------------------------------
+
+describe("formatGithubAnnotations", () => {
+  it("formats error findings as ::error", () => {
+    const output = formatGithubAnnotations([errorFinding]);
+    expect(output).toContain(
+      "::error file=deploy/001-add-col.sql,line=5,col=1::SA004:",
+    );
+  });
+
+  it("formats warn findings as ::warning", () => {
+    const output = formatGithubAnnotations([warnFinding]);
+    expect(output).toContain(
+      "::warning file=deploy/002-add-index.sql,line=12,col=3::SA007:",
+    );
+  });
+
+  it("formats info findings as ::notice", () => {
+    const output = formatGithubAnnotations([infoFinding]);
+    expect(output).toContain(
+      "::notice file=deploy/003-create-table.sql,line=1,col=1::SA015:",
+    );
+  });
+
+  it("includes suggestion in message when present", () => {
+    const output = formatGithubAnnotations([errorFinding]);
+    expect(output).toContain(
+      "Add the column without DEFAULT, then backfill in batches",
+    );
+  });
+
+  it("does not include dash-dash separator when no suggestion", () => {
+    const output = formatGithubAnnotations([infoFinding]);
+    // Should not contain " — " since there's no suggestion
+    expect(output).not.toContain(" — ");
+  });
+
+  it("outputs one line per finding", () => {
+    const output = formatGithubAnnotations(mixedFindings);
+    const lines = output.trim().split("\n");
+    expect(lines).toHaveLength(3);
+  });
+
+  it("returns empty string for no findings", () => {
+    const output = formatGithubAnnotations([]);
+    expect(output).toBe("");
+  });
+
+  it("each line starts with :: annotation prefix", () => {
+    const output = formatGithubAnnotations(mixedFindings);
+    const lines = output.trim().split("\n");
+    for (const line of lines) {
+      expect(line).toMatch(/^::(error|warning|notice) /);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatGitlabCodeQuality
+// ---------------------------------------------------------------------------
+
+describe("formatGitlabCodeQuality", () => {
+  it("produces valid JSON array", () => {
+    const output = formatGitlabCodeQuality(mixedFindings);
+    const parsed = JSON.parse(output);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(3);
+  });
+
+  it("maps error severity to critical", () => {
+    const parsed = JSON.parse(formatGitlabCodeQuality([errorFinding]));
+    expect(parsed[0].severity).toBe("critical");
+  });
+
+  it("maps warn severity to major", () => {
+    const parsed = JSON.parse(formatGitlabCodeQuality([warnFinding]));
+    expect(parsed[0].severity).toBe("major");
+  });
+
+  it("maps info severity to minor", () => {
+    const parsed = JSON.parse(formatGitlabCodeQuality([infoFinding]));
+    expect(parsed[0].severity).toBe("minor");
+  });
+
+  it("sets check_name to ruleId", () => {
+    const parsed = JSON.parse(formatGitlabCodeQuality([errorFinding]));
+    expect(parsed[0].check_name).toBe("SA004");
+  });
+
+  it("sets location path and begin line", () => {
+    const parsed = JSON.parse(formatGitlabCodeQuality([errorFinding]));
+    expect(parsed[0].location).toEqual({
+      path: "deploy/001-add-col.sql",
+      lines: { begin: 5 },
+    });
+  });
+
+  it("includes suggestion in description when present", () => {
+    const parsed = JSON.parse(formatGitlabCodeQuality([errorFinding]));
+    expect(parsed[0].description).toContain(errorFinding.message);
+    expect(parsed[0].description).toContain(errorFinding.suggestion);
+  });
+
+  it("uses only message when no suggestion", () => {
+    const parsed = JSON.parse(formatGitlabCodeQuality([infoFinding]));
+    expect(parsed[0].description).toBe(infoFinding.message);
+  });
+
+  it("produces a hex SHA-1 fingerprint", () => {
+    const parsed = JSON.parse(formatGitlabCodeQuality([errorFinding]));
+    expect(parsed[0].fingerprint).toMatch(/^[a-f0-9]{40}$/);
+  });
+
+  it("returns empty JSON array for no findings", () => {
+    const output = formatGitlabCodeQuality([]);
+    expect(JSON.parse(output)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeFingerprint
+// ---------------------------------------------------------------------------
+
+describe("computeFingerprint", () => {
+  it("returns a 40-character hex string", () => {
+    const fp = computeFingerprint("SA004", "deploy/001.sql", 5);
+    expect(fp).toMatch(/^[a-f0-9]{40}$/);
+  });
+
+  it("produces stable fingerprints for same inputs", () => {
+    const fp1 = computeFingerprint("SA004", "deploy/001.sql", 5);
+    const fp2 = computeFingerprint("SA004", "deploy/001.sql", 5);
+    expect(fp1).toBe(fp2);
+  });
+
+  it("produces different fingerprints for different ruleIds", () => {
+    const fp1 = computeFingerprint("SA004", "deploy/001.sql", 5);
+    const fp2 = computeFingerprint("SA007", "deploy/001.sql", 5);
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it("produces different fingerprints for different files", () => {
+    const fp1 = computeFingerprint("SA004", "deploy/001.sql", 5);
+    const fp2 = computeFingerprint("SA004", "deploy/002.sql", 5);
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it("produces different fingerprints for different lines", () => {
+    const fp1 = computeFingerprint("SA004", "deploy/001.sql", 5);
+    const fp2 = computeFingerprint("SA004", "deploy/001.sql", 10);
+    expect(fp1).not.toBe(fp2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatFindings dispatcher
+// ---------------------------------------------------------------------------
+
+describe("formatFindings", () => {
+  it("dispatches to text formatter", () => {
+    const output = formatFindings("text", [errorFinding], { useColors: false });
+    expect(output).toContain("error SA004:");
+    expect(output).toContain("at deploy/001-add-col.sql:5:1");
+  });
+
+  it("dispatches to json formatter", () => {
+    const output = formatFindings("json", [errorFinding], {
+      metadata: defaultMetadata,
+    });
+    const parsed = JSON.parse(output);
+    expect(parsed.version).toBe(1);
+    expect(parsed.findings).toHaveLength(1);
+  });
+
+  it("dispatches to github-annotations formatter", () => {
+    const output = formatFindings("github-annotations", [errorFinding]);
+    expect(output).toContain("::error file=");
+  });
+
+  it("dispatches to gitlab-codequality formatter", () => {
+    const output = formatFindings("gitlab-codequality", [errorFinding]);
+    const parsed = JSON.parse(output);
+    expect(parsed[0].check_name).toBe("SA004");
+  });
+
+  it("provides default metadata for json when not specified", () => {
+    const output = formatFindings("json", [errorFinding]);
+    const parsed = JSON.parse(output);
+    expect(parsed.metadata).toEqual({
+      files_analyzed: 0,
+      rules_checked: 0,
+      duration_ms: 0,
+    });
+  });
+
+  it("passes filePath option to text formatter", () => {
+    const output = formatFindings("text", [errorFinding], {
+      filePath: "my-file.sql",
+      useColors: false,
+    });
+    expect(output).toStartWith("my-file.sql\n");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/analysis/reporter.ts` with four output formatters for analysis findings:
  - **`formatText`** — human-readable output with ANSI colors, severity labels, file:line:col locations, and suggestions
  - **`formatJson`** — structured JSON per SPEC schema: `{ version: 1, metadata, findings, summary }`
  - **`formatGithubAnnotations`** — GitHub Actions workflow commands (`::error`, `::warning`, `::notice` with file/line/col)
  - **`formatGitlabCodeQuality`** — GitLab Code Quality JSON with severity mapping (error→critical, warn→major, info→minor) and stable SHA-1 fingerprints
- Includes `formatFindings` dispatcher, `computeSummary`, `computeFingerprint` helpers, and full TypeScript types for all report structures
- 53 unit tests covering all formatters, edge cases, severity mappings, color toggling, pluralization, empty inputs, and fingerprint stability

## Test plan

- [x] All 53 new tests pass (`bun test tests/unit/reporter.test.ts`)
- [x] Full test suite passes (754 tests across 21 files)
- [x] TypeScript type check passes for new files (`tsc --noEmit`)
- [ ] Verify text output renders correctly in terminal with colors
- [ ] Verify GitHub annotations appear inline in PR diffs when used in CI

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)