### PR TITLE
S4-3: sqlever log — deployment history with filters

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import packageJson from "../package.json";
 import { runInit } from "./commands/init";
 import { setConfig, type OutputFormat } from "./output";
 import { parseAddArgs, runAdd } from "./commands/add";
+import { runLogCommand } from "./commands/log";
 
 // ---------------------------------------------------------------------------
 // Command registry — all commands from SPEC R1 plus sqlever extensions
@@ -296,6 +297,14 @@ export function main(argv: string[] = process.argv.slice(2)): void {
     addOpts.topDir = args.topDir;
     runAdd(addOpts).catch((err: unknown) => {
       process.stderr.write(`sqlever add: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+    return;
+  }
+
+  if (args.command === "log") {
+    runLogCommand(args).catch((err: unknown) => {
+      process.stderr.write(`sqlever log: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exit(1);
     });
     return;

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -1,0 +1,287 @@
+// src/commands/log.ts — sqlever log command
+//
+// Shows deployment history from sqitch.events. Supports filtering by
+// event type, pagination (limit/offset), ordering, and JSON output.
+
+import { Registry, type Event } from "../db/registry";
+import { DatabaseClient } from "../db/client";
+import { info, error, json, table, verbose, getConfig } from "../output";
+import type { ParsedArgs } from "../cli";
+import { loadConfig } from "../config/index";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EventFilter = "deploy" | "revert" | "fail";
+
+export interface LogOptions {
+  /** Database connection URI. */
+  dbUri: string;
+  /** Project name (resolved from config/target). */
+  project: string;
+  /** Filter by event type. */
+  event?: EventFilter;
+  /** Maximum number of events to return. */
+  limit?: number;
+  /** Number of events to skip. */
+  offset?: number;
+  /** If true, show oldest-first (ASC); default is newest-first (DESC). */
+  reverse?: boolean;
+  /** Output format override. */
+  format?: "text" | "json";
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing for the log subcommand
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `rest` array from the CLI into LogOptions.
+ *
+ * Expected usage:
+ *   sqlever log [--event deploy|revert|fail] [--limit N] [--offset N] [--reverse] [--format json]
+ */
+export function parseLogArgs(
+  rest: string[],
+  args: ParsedArgs,
+): Omit<LogOptions, "dbUri" | "project"> {
+  const opts: Omit<LogOptions, "dbUri" | "project"> = {};
+
+  let i = 0;
+  while (i < rest.length) {
+    const arg = rest[i]!;
+
+    if (arg === "--event") {
+      const val = rest[++i];
+      if (val === "deploy" || val === "revert" || val === "fail") {
+        opts.event = val;
+      } else {
+        throw new Error(
+          `Invalid --event value '${val ?? ""}'. Expected 'deploy', 'revert', or 'fail'.`,
+        );
+      }
+      i++;
+      continue;
+    }
+
+    if (arg === "--limit") {
+      const val = rest[++i];
+      const num = Number(val);
+      if (!Number.isInteger(num) || num < 0) {
+        throw new Error(
+          `Invalid --limit value '${val ?? ""}'. Expected a non-negative integer.`,
+        );
+      }
+      opts.limit = num;
+      i++;
+      continue;
+    }
+
+    if (arg === "--offset") {
+      const val = rest[++i];
+      const num = Number(val);
+      if (!Number.isInteger(num) || num < 0) {
+        throw new Error(
+          `Invalid --offset value '${val ?? ""}'. Expected a non-negative integer.`,
+        );
+      }
+      opts.offset = num;
+      i++;
+      continue;
+    }
+
+    if (arg === "--reverse") {
+      opts.reverse = true;
+      i++;
+      continue;
+    }
+
+    if (arg === "--format") {
+      const val = rest[++i];
+      if (val === "json" || val === "text") {
+        opts.format = val;
+      } else {
+        throw new Error(
+          `Invalid --format value '${val ?? ""}'. Expected 'text' or 'json'.`,
+        );
+      }
+      i++;
+      continue;
+    }
+
+    // Unknown flag — skip
+    i++;
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a Date as a human-readable string for text output.
+ */
+function formatDate(d: Date): string {
+  if (!(d instanceof Date) || isNaN(d.getTime())) {
+    return String(d);
+  }
+  return d.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Format events as a text table for terminal display.
+ */
+export function formatEventsText(events: Event[]): void {
+  if (events.length === 0) {
+    info("No events found.");
+    return;
+  }
+
+  const rows = events.map((e) => ({
+    event: e.event,
+    change: e.change,
+    committed_at: formatDate(e.committed_at),
+    committer: e.committer_name,
+    note: e.note || "",
+  }));
+
+  table(rows, ["event", "change", "committed_at", "committer", "note"]);
+}
+
+/**
+ * Format events as JSON.
+ */
+export function formatEventsJson(events: Event[]): void {
+  json(events);
+}
+
+// ---------------------------------------------------------------------------
+// Main log logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `log` command.
+ *
+ * Connects to the database, queries sqitch.events with the given filters,
+ * and prints results in the requested format.
+ */
+export async function runLog(
+  opts: LogOptions,
+): Promise<void> {
+  verbose(`Connecting to database for log...`);
+
+  const client = new DatabaseClient(opts.dbUri, {
+    command: "log",
+    project: opts.project,
+  });
+
+  try {
+    await client.connect();
+    const registry = new Registry(client);
+
+    const events = await registry.getEvents(opts.project, {
+      event: opts.event,
+      limit: opts.limit,
+      offset: opts.offset,
+      reverse: opts.reverse,
+    });
+
+    const config = getConfig();
+    const format = opts.format ?? config.format;
+
+    if (format === "json") {
+      formatEventsJson(events);
+    } else {
+      formatEventsText(events);
+    }
+  } finally {
+    await client.disconnect();
+  }
+}
+
+/**
+ * Entry point called from CLI dispatch. Resolves config, parses
+ * subcommand flags, and delegates to runLog.
+ */
+export async function runLogCommand(args: ParsedArgs): Promise<void> {
+  const logOpts = parseLogArgs(args.rest, args);
+
+  // Resolve database URI from args or config
+  const config = loadConfig(args.topDir);
+
+  const dbUri = args.dbUri
+    ?? resolveTargetUri(config, args.target)
+    ?? undefined;
+
+  if (!dbUri) {
+    error("Error: no database URI specified. Use --db-uri or configure a target.");
+    process.exit(1);
+  }
+
+  // Resolve project name from config
+  const project = resolveProjectName(config);
+
+  await runLog({
+    dbUri,
+    project,
+    ...logOpts,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Config resolution helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a target URI from the merged config.
+ */
+function resolveTargetUri(
+  config: ReturnType<typeof loadConfig>,
+  targetName?: string,
+): string | null {
+  if (targetName && config.targets[targetName]) {
+    return config.targets[targetName]!.uri ?? null;
+  }
+
+  // Try the engine's default target
+  const engineName = config.core.engine;
+  if (engineName && config.engines[engineName]) {
+    const engineTarget = config.engines[engineName]!.target;
+    if (engineTarget && config.targets[engineTarget]) {
+      return config.targets[engineTarget]!.uri ?? null;
+    }
+    // The engine target might be a URI itself
+    if (engineTarget && engineTarget.includes("://")) {
+      return engineTarget;
+    }
+  }
+
+  // Try the first available target
+  const targetNames = Object.keys(config.targets);
+  if (targetNames.length > 0) {
+    return config.targets[targetNames[0]!]!.uri ?? null;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve project name from sqitch.conf or fallback to directory name.
+ */
+function resolveProjectName(
+  config: ReturnType<typeof loadConfig>,
+): string {
+  // Try to get from sqitch.conf entries
+  for (const entry of config.sqitchConf.entries) {
+    if (entry.key.toLowerCase() === "core.project") {
+      return entry.value;
+    }
+  }
+
+  // Fallback: use the current directory name
+  const cwd = process.cwd();
+  return cwd.split("/").pop() ?? "unknown";
+}

--- a/src/db/registry.ts
+++ b/src/db/registry.ts
@@ -474,6 +474,62 @@ export class Registry {
   }
 
   // -----------------------------------------------------------------------
+  // Events
+  // -----------------------------------------------------------------------
+
+  /**
+   * Query events from sqitch.events with optional filters.
+   *
+   * @param project  - Project name to filter by
+   * @param options  - Optional filters: event type, limit, offset, ordering
+   * @returns Matching event rows
+   */
+  async getEvents(
+    project: string,
+    options: {
+      event?: "deploy" | "revert" | "fail" | "merge";
+      limit?: number;
+      offset?: number;
+      reverse?: boolean;
+    } = {},
+  ): Promise<Event[]> {
+    const conditions: string[] = ["project = $1"];
+    const params: unknown[] = [project];
+    let paramIdx = 2;
+
+    if (options.event) {
+      conditions.push(`event = $${paramIdx}`);
+      params.push(options.event);
+      paramIdx++;
+    }
+
+    const direction = options.reverse ? "ASC" : "DESC";
+
+    let sql = `SELECT event, change_id, change, project, note,
+              requires, conflicts, tags,
+              committed_at, committer_name, committer_email,
+              planned_at, planner_name, planner_email
+       FROM sqitch.events
+       WHERE ${conditions.join(" AND ")}
+       ORDER BY committed_at ${direction}`;
+
+    if (options.limit !== undefined) {
+      sql += ` LIMIT $${paramIdx}`;
+      params.push(options.limit);
+      paramIdx++;
+    }
+
+    if (options.offset !== undefined) {
+      sql += ` OFFSET $${paramIdx}`;
+      params.push(options.offset);
+      paramIdx++;
+    }
+
+    const result = await this.db.query<Event>(sql, params);
+    return result.rows;
+  }
+
+  // -----------------------------------------------------------------------
   // Pending changes
   // -----------------------------------------------------------------------
 

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -308,8 +308,8 @@ describe("unknown commands", () => {
 // ---------------------------------------------------------------------------
 
 describe("command stubs", () => {
-  // "help" is handled specially (not a stub), "init" and "add" are implemented — exclude all three
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add");
+  // "help" is handled specially (not a stub), "init", "add", and "log" are implemented — exclude them
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {

--- a/tests/unit/log.test.ts
+++ b/tests/unit/log.test.ts
@@ -1,0 +1,496 @@
+import { describe, it, expect, beforeEach, spyOn, mock } from "bun:test";
+import { resetConfig, setConfig } from "../../src/output";
+
+// ---------------------------------------------------------------------------
+// Mock pg/lib/client — same approach as registry.test.ts
+// ---------------------------------------------------------------------------
+
+let mockInstances: MockPgClient[] = [];
+
+class MockPgClient {
+  options: Record<string, unknown>;
+  queries: Array<{ text: string; values?: unknown[] }> = [];
+  connected = false;
+  ended = false;
+  queryResults: Record<string, { rows: unknown[]; rowCount: number; command: string }> = {};
+
+  constructor(options: Record<string, unknown>) {
+    this.options = options;
+    mockInstances.push(this);
+  }
+
+  async connect() {
+    this.connected = true;
+  }
+
+  async query(text: string, values?: unknown[]) {
+    this.queries.push({ text, values });
+    return (
+      this.queryResults[text] ?? {
+        rows: [],
+        rowCount: 0,
+        command: "SELECT",
+      }
+    );
+  }
+
+  async end() {
+    this.ended = true;
+    this.connected = false;
+  }
+}
+
+mock.module("pg/lib/client", () => ({
+  default: MockPgClient,
+  __esModule: true,
+}));
+
+// Import after mocking
+const { DatabaseClient } = await import("../../src/db/client");
+const { Registry } = await import("../../src/db/registry");
+const { parseLogArgs, formatEventsText, formatEventsJson } = await import(
+  "../../src/commands/log"
+);
+const { parseArgs } = await import("../../src/cli");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createConnectedClient(): Promise<InstanceType<typeof DatabaseClient>> {
+  const client = new DatabaseClient("postgresql://host/db");
+  await client.connect();
+  return client;
+}
+
+function getPgClient(): MockPgClient {
+  return mockInstances[mockInstances.length - 1]!;
+}
+
+function captureWrites() {
+  let stdout = "";
+  let stderr = "";
+
+  const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+    (chunk: string | Uint8Array) => {
+      stdout += String(chunk);
+      return true;
+    },
+  );
+
+  const stderrSpy = spyOn(process.stderr, "write").mockImplementation(
+    (chunk: string | Uint8Array) => {
+      stderr += String(chunk);
+      return true;
+    },
+  );
+
+  return {
+    get stdout() {
+      return stdout;
+    },
+    get stderr() {
+      return stderr;
+    },
+    restore() {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+}
+
+// Sample event data
+function makeSampleEvent(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    event: "deploy",
+    change_id: "abc123",
+    change: "add_users_table",
+    project: "myproject",
+    note: "Add users table",
+    requires: [],
+    conflicts: [],
+    tags: [],
+    committed_at: new Date("2025-06-15T10:30:00Z"),
+    committer_name: "Test User",
+    committer_email: "test@example.com",
+    planned_at: new Date("2025-06-15T09:00:00Z"),
+    planner_name: "Plan User",
+    planner_email: "plan@example.com",
+    ...overrides,
+  };
+}
+
+const stubParsedArgs = {
+  command: "log",
+  rest: [] as string[],
+  help: false,
+  version: false,
+  format: "text" as const,
+  quiet: false,
+  verbose: false,
+  dbUri: undefined,
+  planFile: undefined,
+  topDir: undefined,
+  registry: undefined,
+  target: undefined,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("log command", () => {
+  beforeEach(() => {
+    mockInstances = [];
+    resetConfig();
+  });
+
+  // -----------------------------------------------------------------------
+  // parseLogArgs
+  // -----------------------------------------------------------------------
+
+  describe("parseLogArgs()", () => {
+    it("returns empty options when no flags given", () => {
+      const opts = parseLogArgs([], stubParsedArgs);
+      expect(opts).toEqual({});
+    });
+
+    it("parses --event deploy", () => {
+      const opts = parseLogArgs(["--event", "deploy"], stubParsedArgs);
+      expect(opts.event).toBe("deploy");
+    });
+
+    it("parses --event revert", () => {
+      const opts = parseLogArgs(["--event", "revert"], stubParsedArgs);
+      expect(opts.event).toBe("revert");
+    });
+
+    it("parses --event fail", () => {
+      const opts = parseLogArgs(["--event", "fail"], stubParsedArgs);
+      expect(opts.event).toBe("fail");
+    });
+
+    it("throws on invalid --event value", () => {
+      expect(() =>
+        parseLogArgs(["--event", "invalid"], stubParsedArgs),
+      ).toThrow("Invalid --event value 'invalid'");
+    });
+
+    it("parses --limit N", () => {
+      const opts = parseLogArgs(["--limit", "10"], stubParsedArgs);
+      expect(opts.limit).toBe(10);
+    });
+
+    it("throws on non-integer --limit", () => {
+      expect(() =>
+        parseLogArgs(["--limit", "abc"], stubParsedArgs),
+      ).toThrow("Invalid --limit value 'abc'");
+    });
+
+    it("throws on negative --limit", () => {
+      expect(() =>
+        parseLogArgs(["--limit", "-5"], stubParsedArgs),
+      ).toThrow("Invalid --limit value '-5'");
+    });
+
+    it("parses --offset N", () => {
+      const opts = parseLogArgs(["--offset", "5"], stubParsedArgs);
+      expect(opts.offset).toBe(5);
+    });
+
+    it("throws on invalid --offset value", () => {
+      expect(() =>
+        parseLogArgs(["--offset", "xyz"], stubParsedArgs),
+      ).toThrow("Invalid --offset value 'xyz'");
+    });
+
+    it("parses --reverse flag", () => {
+      const opts = parseLogArgs(["--reverse"], stubParsedArgs);
+      expect(opts.reverse).toBe(true);
+    });
+
+    it("parses --format json", () => {
+      const opts = parseLogArgs(["--format", "json"], stubParsedArgs);
+      expect(opts.format).toBe("json");
+    });
+
+    it("throws on invalid --format value", () => {
+      expect(() =>
+        parseLogArgs(["--format", "csv"], stubParsedArgs),
+      ).toThrow("Invalid --format value 'csv'");
+    });
+
+    it("parses all flags together", () => {
+      const opts = parseLogArgs(
+        ["--event", "deploy", "--limit", "20", "--offset", "10", "--reverse", "--format", "json"],
+        stubParsedArgs,
+      );
+      expect(opts.event).toBe("deploy");
+      expect(opts.limit).toBe(20);
+      expect(opts.offset).toBe(10);
+      expect(opts.reverse).toBe(true);
+      expect(opts.format).toBe("json");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Registry.getEvents()
+  // -----------------------------------------------------------------------
+
+  describe("Registry.getEvents()", () => {
+    it("queries sqitch.events with project filter", async () => {
+      const client = await createConnectedClient();
+      const pgClient = getPgClient();
+      const registry = new Registry(client);
+
+      await registry.getEvents("myproject");
+
+      const selectQuery = pgClient.queries.find(
+        (q) => q.text.includes("sqitch.events") && q.text.includes("SELECT"),
+      );
+      expect(selectQuery).toBeDefined();
+      expect(selectQuery!.text).toContain("project = $1");
+      expect(selectQuery!.values).toEqual(["myproject"]);
+    });
+
+    it("orders by committed_at DESC by default (newest-first)", async () => {
+      const client = await createConnectedClient();
+      const pgClient = getPgClient();
+      const registry = new Registry(client);
+
+      await registry.getEvents("myproject");
+
+      const selectQuery = pgClient.queries.find(
+        (q) => q.text.includes("sqitch.events"),
+      );
+      expect(selectQuery!.text).toContain("ORDER BY committed_at DESC");
+    });
+
+    it("orders by committed_at ASC when reverse=true", async () => {
+      const client = await createConnectedClient();
+      const pgClient = getPgClient();
+      const registry = new Registry(client);
+
+      await registry.getEvents("myproject", { reverse: true });
+
+      const selectQuery = pgClient.queries.find(
+        (q) => q.text.includes("sqitch.events"),
+      );
+      expect(selectQuery!.text).toContain("ORDER BY committed_at ASC");
+    });
+
+    it("adds event filter when event option is provided", async () => {
+      const client = await createConnectedClient();
+      const pgClient = getPgClient();
+      const registry = new Registry(client);
+
+      await registry.getEvents("myproject", { event: "deploy" });
+
+      const selectQuery = pgClient.queries.find(
+        (q) => q.text.includes("sqitch.events"),
+      );
+      expect(selectQuery!.text).toContain("event = $2");
+      expect(selectQuery!.values).toEqual(["myproject", "deploy"]);
+    });
+
+    it("adds LIMIT clause when limit option is provided", async () => {
+      const client = await createConnectedClient();
+      const pgClient = getPgClient();
+      const registry = new Registry(client);
+
+      await registry.getEvents("myproject", { limit: 10 });
+
+      const selectQuery = pgClient.queries.find(
+        (q) => q.text.includes("sqitch.events"),
+      );
+      expect(selectQuery!.text).toContain("LIMIT $2");
+      expect(selectQuery!.values).toEqual(["myproject", 10]);
+    });
+
+    it("adds OFFSET clause when offset option is provided", async () => {
+      const client = await createConnectedClient();
+      const pgClient = getPgClient();
+      const registry = new Registry(client);
+
+      await registry.getEvents("myproject", { offset: 5 });
+
+      const selectQuery = pgClient.queries.find(
+        (q) => q.text.includes("sqitch.events"),
+      );
+      expect(selectQuery!.text).toContain("OFFSET $2");
+      expect(selectQuery!.values).toEqual(["myproject", 5]);
+    });
+
+    it("combines event, limit, and offset with correct param indices", async () => {
+      const client = await createConnectedClient();
+      const pgClient = getPgClient();
+      const registry = new Registry(client);
+
+      await registry.getEvents("myproject", {
+        event: "revert",
+        limit: 25,
+        offset: 50,
+      });
+
+      const selectQuery = pgClient.queries.find(
+        (q) => q.text.includes("sqitch.events"),
+      );
+      expect(selectQuery!.text).toContain("event = $2");
+      expect(selectQuery!.text).toContain("LIMIT $3");
+      expect(selectQuery!.text).toContain("OFFSET $4");
+      expect(selectQuery!.values).toEqual(["myproject", "revert", 25, 50]);
+    });
+
+    it("returns rows from query result", async () => {
+      const client = await createConnectedClient();
+      const pgClient = getPgClient();
+      const registry = new Registry(client);
+
+      const eventRows = [makeSampleEvent(), makeSampleEvent({ change: "second_change", event: "revert" })];
+
+      pgClient.query = async (text: string, values?: unknown[]) => {
+        pgClient.queries.push({ text, values });
+        if (text.includes("sqitch.events") && text.includes("SELECT")) {
+          return { rows: eventRows, rowCount: eventRows.length, command: "SELECT" };
+        }
+        return { rows: [], rowCount: 0, command: "SELECT" };
+      };
+
+      const result = await registry.getEvents("myproject");
+      expect(result).toEqual(eventRows);
+      expect(result.length).toBe(2);
+    });
+
+    it("returns empty array when no events match", async () => {
+      const client = await createConnectedClient();
+      const registry = new Registry(client);
+
+      const result = await registry.getEvents("myproject", { event: "fail" });
+      expect(result).toEqual([]);
+    });
+
+    it("uses parameterized queries — no SQL injection", async () => {
+      const client = await createConnectedClient();
+      const pgClient = getPgClient();
+      const registry = new Registry(client);
+
+      await registry.getEvents("'; DROP TABLE sqitch.events; --", {
+        event: "deploy",
+      });
+
+      const selectQuery = pgClient.queries.find(
+        (q) => q.text.includes("sqitch.events"),
+      );
+      expect(selectQuery!.text).not.toContain("DROP TABLE");
+      expect(selectQuery!.values).toContain("'; DROP TABLE sqitch.events; --");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // formatEventsText()
+  // -----------------------------------------------------------------------
+
+  describe("formatEventsText()", () => {
+    it("prints 'No events found.' when events array is empty", () => {
+      const cap = captureWrites();
+      try {
+        formatEventsText([]);
+        expect(cap.stdout).toContain("No events found.");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("prints a table with headers for non-empty events", () => {
+      const cap = captureWrites();
+      try {
+        const events = [makeSampleEvent()] as any[];
+        formatEventsText(events);
+        expect(cap.stdout).toContain("event");
+        expect(cap.stdout).toContain("change");
+        expect(cap.stdout).toContain("committed_at");
+        expect(cap.stdout).toContain("committer");
+        expect(cap.stdout).toContain("add_users_table");
+        expect(cap.stdout).toContain("deploy");
+        expect(cap.stdout).toContain("Test User");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("formats dates as ISO without milliseconds", () => {
+      const cap = captureWrites();
+      try {
+        const events = [makeSampleEvent()] as any[];
+        formatEventsText(events);
+        // The date should be formatted without .000Z
+        expect(cap.stdout).toContain("2025-06-15 10:30:00Z");
+        expect(cap.stdout).not.toContain(".000Z");
+      } finally {
+        cap.restore();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // formatEventsJson()
+  // -----------------------------------------------------------------------
+
+  describe("formatEventsJson()", () => {
+    it("outputs valid JSON to stdout", () => {
+      const cap = captureWrites();
+      try {
+        const events = [makeSampleEvent()] as any[];
+        formatEventsJson(events);
+        const parsed = JSON.parse(cap.stdout);
+        expect(Array.isArray(parsed)).toBe(true);
+        expect(parsed.length).toBe(1);
+        expect(parsed[0].event).toBe("deploy");
+        expect(parsed[0].change).toBe("add_users_table");
+      } finally {
+        cap.restore();
+      }
+    });
+
+    it("outputs empty array for no events", () => {
+      const cap = captureWrites();
+      try {
+        formatEventsJson([]);
+        const parsed = JSON.parse(cap.stdout);
+        expect(parsed).toEqual([]);
+      } finally {
+        cap.restore();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // CLI integration — parseArgs for log command
+  // -----------------------------------------------------------------------
+
+  describe("CLI integration", () => {
+    it("parseArgs recognizes 'log' as a command", () => {
+      const args = parseArgs(["log"]);
+      expect(args.command).toBe("log");
+    });
+
+    it("parseArgs passes remaining flags to rest", () => {
+      const args = parseArgs(["log", "--event", "deploy", "--limit", "5"]);
+      expect(args.command).toBe("log");
+      expect(args.rest).toEqual(["--event", "deploy", "--limit", "5"]);
+    });
+
+    it("parseArgs handles global flags alongside log command", () => {
+      const args = parseArgs(["--quiet", "log", "--reverse"]);
+      expect(args.command).toBe("log");
+      expect(args.quiet).toBe(true);
+      expect(args.rest).toEqual(["--reverse"]);
+    });
+
+    it("parseArgs handles --db-uri before log command", () => {
+      const args = parseArgs(["--db-uri", "postgresql://host/db", "log"]);
+      expect(args.command).toBe("log");
+      expect(args.dbUri).toBe("postgresql://host/db");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `Registry.getEvents()` method with parameterized SQL queries supporting event type, limit, offset, and reverse ordering filters
- Create `src/commands/log.ts` with CLI argument parsing (`--event deploy|revert|fail`, `--limit N`, `--offset N`, `--reverse`, `--format json`), text table and JSON output formatters, and config-based DB URI/project resolution
- Wire the `log` command into CLI dispatch in `src/cli.ts`
- 33 unit tests covering argument parsing (valid/invalid), registry query construction, parameterized SQL injection prevention, output formatting (text table + JSON), and CLI integration

Closes #45

## Test plan
- [x] All 33 new tests in `tests/unit/log.test.ts` pass
- [x] All 733 tests across the full suite pass (0 failures)
- [ ] Manual test: `sqlever log --db-uri postgresql://... --event deploy --limit 5`
- [ ] Manual test: `sqlever log --db-uri postgresql://... --format json --reverse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)