### PR TITLE
S3-3: Revert command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { runInit } from "./commands/init";
 import { setConfig, type OutputFormat } from "./output";
 import { parseAddArgs, runAdd } from "./commands/add";
 import { runLogCommand } from "./commands/log";
+import { runRevert } from "./commands/revert";
 
 // ---------------------------------------------------------------------------
 // Command registry — all commands from SPEC R1 plus sqlever extensions
@@ -305,6 +306,15 @@ export function main(argv: string[] = process.argv.slice(2)): void {
   if (args.command === "log") {
     runLogCommand(args).catch((err: unknown) => {
       process.stderr.write(`sqlever log: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+    return;
+  }
+
+  if (args.command === "revert") {
+    runRevert(args).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`sqlever revert: ${msg}\n`);
       process.exit(1);
     });
     return;

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -1,0 +1,518 @@
+// src/commands/revert.ts — sqlever revert command
+//
+// Reverts deployed changes in reverse order, updating tracking tables.
+// Implements SPEC R1 `revert` semantics:
+//   - Connect, acquire advisory lock
+//   - Read deployed changes from tracking tables
+//   - Compute changes to revert (reverse of deploy order)
+//   - If --to <change>: revert down to (but not including) the specified change
+//   - If no --to: revert all deployed changes
+//   - Prompt for confirmation unless -y/--no-prompt (or non-TTY stdin)
+//   - For each change (in reverse): execute revert script, record in tracking
+//   - Release advisory lock, print summary
+
+import { resolve, join } from "node:path";
+import { readFileSync } from "node:fs";
+import type { ParsedArgs } from "../cli";
+import { loadConfig, type MergedConfig } from "../config/index";
+import { parsePlan } from "../plan/parser";
+import type { Plan, Change as PlanChange } from "../plan/types";
+import { DatabaseClient } from "../db/client";
+import {
+  Registry,
+  REGISTRY_LOCK_KEY,
+  type Change as RegistryChange,
+  type RecordDeployInput,
+} from "../db/registry";
+import { PsqlRunner, type PsqlRunResult } from "../psql";
+import { ShutdownManager } from "../signals";
+import { info, error as logError, verbose } from "../output";
+
+// ---------------------------------------------------------------------------
+// Exit codes (SPEC R6)
+// ---------------------------------------------------------------------------
+
+/** Exit code for concurrent deploy/revert detected (advisory lock not acquired). */
+export const EXIT_CODE_CONCURRENT = 4;
+
+// ---------------------------------------------------------------------------
+// Revert-specific argument parsing
+// ---------------------------------------------------------------------------
+
+export interface RevertOptions {
+  /** Target database URI (from --db-uri or config). */
+  dbUri?: string;
+  /** Revert down to (but not including) this change name. */
+  toChange?: string;
+  /** Skip confirmation prompt (-y / --no-prompt). */
+  noPrompt: boolean;
+  /** Project root directory. */
+  topDir: string;
+  /** Target name (from --target). */
+  target?: string;
+  /** Plan file path override (from --plan-file). */
+  planFile?: string;
+}
+
+/**
+ * Parse revert-specific options from the CLI's parsed args.
+ *
+ * Usage: sqlever revert [target] [--to change] [-y] [--no-prompt]
+ */
+export function parseRevertOptions(args: ParsedArgs): RevertOptions {
+  const opts: RevertOptions = {
+    dbUri: args.dbUri,
+    noPrompt: false,
+    topDir: args.topDir ?? ".",
+    target: args.target,
+    planFile: args.planFile,
+  };
+
+  const rest = args.rest;
+  let i = 0;
+  while (i < rest.length) {
+    const token = rest[i]!;
+
+    if (token === "--to") {
+      opts.toChange = rest[++i];
+      i++;
+      continue;
+    }
+    if (token === "-y" || token === "--no-prompt") {
+      opts.noPrompt = true;
+      i++;
+      continue;
+    }
+
+    // First non-flag token could be a target name
+    if (opts.target === undefined) {
+      opts.target = token;
+    }
+    i++;
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Resolve target URI from config and options
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the database connection URI from the combined config sources.
+ *
+ * Precedence: --db-uri > target lookup > engine default target.
+ */
+export function resolveTargetUri(
+  opts: RevertOptions,
+  config: MergedConfig,
+): string | undefined {
+  // CLI --db-uri takes precedence
+  if (opts.dbUri) return opts.dbUri;
+
+  // Named target lookup
+  const targetName = opts.target ?? config.engines.pg?.target;
+  if (targetName && config.targets[targetName]) {
+    return config.targets[targetName]!.uri;
+  }
+
+  // Fall back to engine target (which may be a URI like db:pg://...)
+  if (targetName) return targetName;
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Confirmation prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Prompt the user for confirmation before reverting.
+ *
+ * If stdin is not a TTY (CI environment), requires -y or errors out.
+ * Returns true if the user confirms, false otherwise.
+ */
+export async function confirmRevert(
+  changes: RevertableChange[],
+  noPrompt: boolean,
+  stdin: NodeJS.ReadStream & { isTTY?: boolean } = process.stdin,
+  stdout: NodeJS.WriteStream = process.stdout,
+): Promise<boolean> {
+  if (noPrompt) return true;
+
+  // Non-TTY (piped input / CI): require -y
+  if (!stdin.isTTY) {
+    logError(
+      "Revert requires confirmation. Pass -y or --no-prompt to proceed in non-interactive mode.",
+    );
+    return false;
+  }
+
+  // Show what will be reverted
+  info(`The following changes will be reverted (in this order):`);
+  for (const c of changes) {
+    info(`  - ${c.name}`);
+  }
+
+  // Interactive prompt
+  stdout.write("\nProceed with revert? [y/N] ");
+
+  return new Promise<boolean>((resolve) => {
+    stdin.resume();
+    stdin.setEncoding("utf-8");
+    stdin.once("data", (data: string) => {
+      stdin.pause();
+      const answer = data.toString().trim().toLowerCase();
+      resolve(answer === "y" || answer === "yes");
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A change that can be reverted, combining deployed info with plan info. */
+export interface RevertableChange {
+  /** Change name. */
+  name: string;
+  /** Change ID from the tracking table. */
+  change_id: string;
+  /** Path to the revert script file. */
+  revertScriptPath: string;
+  /** The deployed change record (for building RecordDeployInput). */
+  deployed: RegistryChange;
+  /** Matching plan change (if found), for requires/conflicts/tags. */
+  planChange?: PlanChange;
+}
+
+// ---------------------------------------------------------------------------
+// Core revert logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the list of changes to revert based on deployed state and --to flag.
+ *
+ * Returns changes in reverse deployment order (last deployed first).
+ * If toChange is specified, reverts down to (but NOT including) that change.
+ * If toChange is not specified, reverts ALL deployed changes.
+ *
+ * @throws Error if --to change is not found in the deployed list
+ */
+export function computeChangesToRevert(
+  deployedChanges: RegistryChange[],
+  toChange?: string,
+): RegistryChange[] {
+  if (deployedChanges.length === 0) return [];
+
+  // Reverse order: last deployed first
+  const reversed = [...deployedChanges].reverse();
+
+  if (!toChange) {
+    return reversed;
+  }
+
+  // Find the --to change in the deployed list
+  const toIndex = deployedChanges.findIndex((c) => c.change === toChange);
+  if (toIndex === -1) {
+    throw new Error(
+      `Change '${toChange}' is not deployed. Cannot use as --to target.`,
+    );
+  }
+
+  // Revert everything AFTER the --to change (not including it)
+  // In the original order, we want everything from toIndex+1 onwards.
+  // Then reverse it.
+  const toRevert = deployedChanges.slice(toIndex + 1);
+  return toRevert.reverse();
+}
+
+/**
+ * Build the RecordDeployInput for a revert event.
+ *
+ * Maps deployed change info + plan metadata into the input shape
+ * expected by Registry.recordRevert().
+ */
+export function buildRevertInput(
+  deployed: RegistryChange,
+  planChange?: PlanChange,
+): RecordDeployInput {
+  return {
+    change_id: deployed.change_id,
+    script_hash: deployed.script_hash,
+    change: deployed.change,
+    project: deployed.project,
+    note: deployed.note,
+    committer_name: deployed.committer_name,
+    committer_email: deployed.committer_email,
+    planned_at: deployed.planned_at,
+    planner_name: deployed.planner_name,
+    planner_email: deployed.planner_email,
+    requires: planChange?.requires ?? [],
+    conflicts: planChange?.conflicts ?? [],
+    tags: [],
+    dependencies: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main revert command
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `revert` command.
+ *
+ * Flow:
+ * 1. Parse config, connect to database
+ * 2. Acquire advisory lock
+ * 3. Read deployed changes from tracking tables
+ * 4. Compute changes to revert
+ * 5. Prompt for confirmation unless -y
+ * 6. For each change: execute revert script, record in tracking
+ * 7. Release advisory lock
+ * 8. Print summary
+ */
+export async function runRevert(
+  args: ParsedArgs,
+  opts?: {
+    shutdownManager?: ShutdownManager;
+    psqlRunner?: PsqlRunner;
+    stdin?: NodeJS.ReadStream & { isTTY?: boolean };
+  },
+): Promise<void> {
+  const options = parseRevertOptions(args);
+  const topDir = resolve(options.topDir);
+
+  // 1. Load config
+  const config = loadConfig(topDir);
+
+  // Load plan file
+  const planFilePath = options.planFile
+    ? resolve(options.planFile)
+    : join(topDir, config.core.plan_file);
+
+  let plan: Plan;
+  try {
+    const planContent = readFileSync(planFilePath, "utf-8");
+    plan = parsePlan(planContent);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logError(`Failed to read plan file: ${msg}`);
+    process.exit(1);
+  }
+
+  // Resolve target URI
+  const targetUri = resolveTargetUri(options, config);
+  if (!targetUri) {
+    logError(
+      "No database target specified. Use --db-uri or configure a target in sqitch.conf.",
+    );
+    process.exit(1);
+  }
+
+  // 2. Connect to database
+  const db = new DatabaseClient(targetUri, {
+    command: "revert",
+    project: plan.project.name,
+  });
+
+  const shutdown = opts?.shutdownManager ?? new ShutdownManager();
+
+  // Register signal handlers for cleanup
+  shutdown.register({ quiet: true });
+  shutdown.onShutdown(async () => {
+    try {
+      await db.query("SELECT pg_advisory_unlock($1)", [REGISTRY_LOCK_KEY]);
+    } catch {
+      // Best-effort unlock
+    }
+    await db.disconnect();
+  });
+
+  await db.connect();
+
+  const registry = new Registry(db);
+  let lockAcquired = false;
+
+  try {
+    // 3. Acquire advisory lock (non-blocking)
+    const lockResult = await db.query<{ pg_try_advisory_lock: boolean }>(
+      "SELECT pg_try_advisory_lock($1)",
+      [REGISTRY_LOCK_KEY],
+    );
+    lockAcquired = lockResult.rows[0]?.pg_try_advisory_lock === true;
+
+    if (!lockAcquired) {
+      logError(
+        "Another deploy/revert operation is in progress. Aborting.",
+      );
+      process.exit(EXIT_CODE_CONCURRENT);
+    }
+
+    // 4. Read deployed changes
+    const deployedChanges = await registry.getDeployedChanges(plan.project.name);
+
+    if (deployedChanges.length === 0) {
+      info("Nothing to revert. No changes are deployed.");
+      return;
+    }
+
+    // 5. Compute changes to revert
+    let changesToRevert: RegistryChange[];
+    try {
+      changesToRevert = computeChangesToRevert(
+        deployedChanges,
+        options.toChange,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logError(msg);
+      process.exit(1);
+    }
+
+    if (changesToRevert.length === 0) {
+      info("Nothing to revert.");
+      return;
+    }
+
+    // Build revertable change list with script paths and plan metadata
+    const revertDir = join(topDir, config.core.revert_dir);
+    const planChangeMap = new Map(
+      plan.changes.map((c) => [c.change_id, c]),
+    );
+
+    const revertableChanges: RevertableChange[] = changesToRevert.map(
+      (deployed) => ({
+        name: deployed.change,
+        change_id: deployed.change_id,
+        revertScriptPath: join(revertDir, `${deployed.change}.sql`),
+        deployed,
+        planChange: planChangeMap.get(deployed.change_id),
+      }),
+    );
+
+    // 6. Prompt for confirmation
+    const confirmed = await confirmRevert(
+      revertableChanges,
+      options.noPrompt,
+      opts?.stdin,
+    );
+    if (!confirmed) {
+      info("Revert cancelled.");
+      process.exit(0);
+    }
+
+    // 7. Execute reverts
+    const psqlRunner = opts?.psqlRunner ?? new PsqlRunner();
+    let successCount = 0;
+    let failCount = 0;
+
+    for (const change of revertableChanges) {
+      if (shutdown.isShuttingDown()) {
+        logError("Shutdown requested. Stopping revert.");
+        break;
+      }
+
+      verbose(`Reverting: ${change.name}`);
+
+      let result: PsqlRunResult;
+      try {
+        result = await psqlRunner.run(change.revertScriptPath, {
+          uri: targetUri,
+          singleTransaction: true,
+          workingDir: topDir,
+        });
+      } catch (err) {
+        // Spawn failure (e.g., psql not found)
+        const msg = err instanceof Error ? err.message : String(err);
+        logError(`Failed to execute revert script for '${change.name}': ${msg}`);
+
+        // Record fail event
+        const failInput = buildRevertInput(change.deployed, change.planChange);
+        await safeRecordFail(registry, failInput, change.name);
+        failCount++;
+        break;
+      }
+
+      if (result.exitCode !== 0) {
+        // Revert script raised an exception (non-revertable migration)
+        const errMsg =
+          result.error?.message ?? result.stderr.trim() ?? "unknown error";
+        logError(
+          `Revert failed for '${change.name}': ${errMsg}`,
+        );
+
+        // Record fail event — tracking state stays consistent
+        const failInput = buildRevertInput(change.deployed, change.planChange);
+        await safeRecordFail(registry, failInput, change.name);
+        failCount++;
+        break;
+      }
+
+      // Success — record the revert in tracking tables
+      const revertInput = buildRevertInput(change.deployed, change.planChange);
+      await registry.recordRevert(revertInput);
+
+      // Also delete associated tags for this change
+      await deleteTagsForChange(db, change.change_id);
+
+      info(`  - ${change.name}`);
+      successCount++;
+    }
+
+    // 8. Print summary
+    if (failCount > 0) {
+      logError(
+        `Revert incomplete: ${successCount} reverted, ${failCount} failed.`,
+      );
+      process.exit(1);
+    }
+
+    info(`Revert complete: ${successCount} change(s) reverted.`);
+  } finally {
+    // 9. Release advisory lock (always)
+    if (lockAcquired) {
+      try {
+        await db.query("SELECT pg_advisory_unlock($1)", [REGISTRY_LOCK_KEY]);
+      } catch {
+        // Best-effort unlock
+      }
+    }
+
+    await db.disconnect();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely record a 'fail' event. Wraps Registry.recordFailEvent() with
+ * error handling so that a failure to record doesn't crash the revert flow.
+ */
+async function safeRecordFail(
+  registry: Registry,
+  input: RecordDeployInput,
+  changeName: string,
+): Promise<void> {
+  try {
+    await registry.recordFailEvent(input);
+  } catch {
+    logError(`Warning: Could not record fail event for '${changeName}'.`);
+  }
+}
+
+/**
+ * Delete tags associated with a reverted change.
+ */
+async function deleteTagsForChange(
+  db: DatabaseClient,
+  changeId: string,
+): Promise<void> {
+  try {
+    await db.query("DELETE FROM sqitch.tags WHERE change_id = $1", [changeId]);
+  } catch {
+    // Best-effort — tags table may not exist yet
+  }
+}

--- a/src/db/registry.ts
+++ b/src/db/registry.ts
@@ -473,6 +473,37 @@ export class Registry {
     ]);
   }
 
+  /**
+   * Record a 'fail' event: insert into events only (no changes/deps deleted).
+   *
+   * Used when a revert script raises an exception. The change remains
+   * deployed, but the failure is logged in the event table for auditing.
+   */
+  async recordFailEvent(input: RecordDeployInput): Promise<void> {
+    await this.db.query(
+      `INSERT INTO sqitch.events (event, change_id, change, project, note,
+                                  requires, conflicts, tags,
+                                  committer_name, committer_email,
+                                  planned_at, planner_name, planner_email)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+      [
+        "fail",
+        input.change_id,
+        input.change,
+        input.project,
+        input.note,
+        input.requires,
+        input.conflicts,
+        input.tags,
+        input.committer_name,
+        input.committer_email,
+        input.planned_at,
+        input.planner_name,
+        input.planner_email,
+      ],
+    );
+  }
+
   // -----------------------------------------------------------------------
   // Events
   // -----------------------------------------------------------------------

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -308,8 +308,8 @@ describe("unknown commands", () => {
 // ---------------------------------------------------------------------------
 
 describe("command stubs", () => {
-  // "help" is handled specially (not a stub), "init", "add", and "log" are implemented — exclude them
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log");
+  // "help" is handled specially (not a stub), "init", "add", "log", and "revert" are implemented — exclude them
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log" && c !== "revert");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {

--- a/tests/unit/revert.test.ts
+++ b/tests/unit/revert.test.ts
@@ -1,0 +1,521 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { resetConfig } from "../../src/output";
+
+// ---------------------------------------------------------------------------
+// Mock pg/lib/client — same approach as registry.test.ts
+// ---------------------------------------------------------------------------
+
+let mockInstances: MockPgClient[] = [];
+
+class MockPgClient {
+  options: Record<string, unknown>;
+  queries: Array<{ text: string; values?: unknown[] }> = [];
+  connected = false;
+  ended = false;
+
+  constructor(options: Record<string, unknown>) {
+    this.options = options;
+    mockInstances.push(this);
+  }
+
+  async connect() {
+    this.connected = true;
+  }
+
+  async query(text: string, values?: unknown[]) {
+    this.queries.push({ text, values });
+    return { rows: [], rowCount: 0, command: "SELECT" };
+  }
+
+  async end() {
+    this.ended = true;
+    this.connected = false;
+  }
+}
+
+mock.module("pg/lib/client", () => ({
+  default: MockPgClient,
+  __esModule: true,
+}));
+
+// Import after mocking
+const { DatabaseClient } = await import("../../src/db/client");
+const { Registry } = await import("../../src/db/registry");
+const {
+  parseRevertOptions,
+  computeChangesToRevert,
+  buildRevertInput,
+  confirmRevert,
+  resolveTargetUri,
+} = await import("../../src/commands/revert");
+const { parseArgs } = await import("../../src/cli");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal RegistryChange for testing. */
+function makeDeployedChange(
+  name: string,
+  changeId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    change_id: changeId,
+    script_hash: `hash_${changeId}`,
+    change: name,
+    project: "testproject",
+    note: `Note for ${name}`,
+    committed_at: new Date("2025-01-15T10:00:00Z"),
+    committer_name: "Test User",
+    committer_email: "test@example.com",
+    planned_at: new Date("2025-01-15T10:00:00Z"),
+    planner_name: "Plan User",
+    planner_email: "plan@example.com",
+    ...overrides,
+  };
+}
+
+/** Build a minimal PlanChange for testing. */
+function makePlanChange(
+  name: string,
+  changeId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    change_id: changeId,
+    name,
+    project: "testproject",
+    note: `Note for ${name}`,
+    planner_name: "Plan User",
+    planner_email: "plan@example.com",
+    planned_at: "2025-01-15T10:00:00Z",
+    requires: [] as string[],
+    conflicts: [] as string[],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("revert command", () => {
+  beforeEach(() => {
+    mockInstances = [];
+    resetConfig();
+  });
+
+  // -----------------------------------------------------------------------
+  // parseRevertOptions
+  // -----------------------------------------------------------------------
+
+  describe("parseRevertOptions()", () => {
+    it("parses --to flag", () => {
+      const args = parseArgs(["revert", "--to", "add_users"]);
+      const opts = parseRevertOptions(args);
+      expect(opts.toChange).toBe("add_users");
+    });
+
+    it("parses -y flag", () => {
+      const args = parseArgs(["revert", "-y"]);
+      const opts = parseRevertOptions(args);
+      expect(opts.noPrompt).toBe(true);
+    });
+
+    it("parses --no-prompt flag", () => {
+      const args = parseArgs(["revert", "--no-prompt"]);
+      const opts = parseRevertOptions(args);
+      expect(opts.noPrompt).toBe(true);
+    });
+
+    it("parses positional target", () => {
+      const args = parseArgs(["revert", "production"]);
+      const opts = parseRevertOptions(args);
+      expect(opts.target).toBe("production");
+    });
+
+    it("parses combined --to and -y", () => {
+      const args = parseArgs(["revert", "--to", "create_schema", "-y"]);
+      const opts = parseRevertOptions(args);
+      expect(opts.toChange).toBe("create_schema");
+      expect(opts.noPrompt).toBe(true);
+    });
+
+    it("defaults noPrompt to false", () => {
+      const args = parseArgs(["revert"]);
+      const opts = parseRevertOptions(args);
+      expect(opts.noPrompt).toBe(false);
+    });
+
+    it("inherits --db-uri from global args", () => {
+      const args = parseArgs(["--db-uri", "postgresql://host/db", "revert"]);
+      const opts = parseRevertOptions(args);
+      expect(opts.dbUri).toBe("postgresql://host/db");
+    });
+
+    it("inherits --plan-file from global args", () => {
+      const args = parseArgs(["--plan-file", "custom.plan", "revert"]);
+      const opts = parseRevertOptions(args);
+      expect(opts.planFile).toBe("custom.plan");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // computeChangesToRevert
+  // -----------------------------------------------------------------------
+
+  describe("computeChangesToRevert()", () => {
+    it("returns all changes in reverse order when no --to", () => {
+      const deployed = [
+        makeDeployedChange("a", "id_a"),
+        makeDeployedChange("b", "id_b"),
+        makeDeployedChange("c", "id_c"),
+      ];
+
+      const result = computeChangesToRevert(deployed);
+      expect(result.map((c) => c.change)).toEqual(["c", "b", "a"]);
+    });
+
+    it("returns empty array when no changes deployed", () => {
+      const result = computeChangesToRevert([]);
+      expect(result).toEqual([]);
+    });
+
+    it("reverts down to (not including) --to change", () => {
+      const deployed = [
+        makeDeployedChange("a", "id_a"),
+        makeDeployedChange("b", "id_b"),
+        makeDeployedChange("c", "id_c"),
+        makeDeployedChange("d", "id_d"),
+      ];
+
+      const result = computeChangesToRevert(deployed, "b");
+      expect(result.map((c) => c.change)).toEqual(["d", "c"]);
+    });
+
+    it("returns empty when --to is the last deployed change", () => {
+      const deployed = [
+        makeDeployedChange("a", "id_a"),
+        makeDeployedChange("b", "id_b"),
+      ];
+
+      const result = computeChangesToRevert(deployed, "b");
+      expect(result).toEqual([]);
+    });
+
+    it("throws when --to change is not deployed", () => {
+      const deployed = [
+        makeDeployedChange("a", "id_a"),
+        makeDeployedChange("b", "id_b"),
+      ];
+
+      expect(() => computeChangesToRevert(deployed, "nonexistent")).toThrow(
+        "Change 'nonexistent' is not deployed",
+      );
+    });
+
+    it("reverts single change when --to is the first change", () => {
+      const deployed = [
+        makeDeployedChange("a", "id_a"),
+        makeDeployedChange("b", "id_b"),
+      ];
+
+      const result = computeChangesToRevert(deployed, "a");
+      expect(result.map((c) => c.change)).toEqual(["b"]);
+    });
+
+    it("returns single change reversed when only one deployed", () => {
+      const deployed = [makeDeployedChange("a", "id_a")];
+
+      const result = computeChangesToRevert(deployed);
+      expect(result.map((c) => c.change)).toEqual(["a"]);
+    });
+
+    it("preserves full change objects (not just names)", () => {
+      const deployed = [
+        makeDeployedChange("a", "id_a", { note: "Custom note" }),
+      ];
+
+      const result = computeChangesToRevert(deployed);
+      expect(result[0]!.note).toBe("Custom note");
+      expect(result[0]!.change_id).toBe("id_a");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildRevertInput
+  // -----------------------------------------------------------------------
+
+  describe("buildRevertInput()", () => {
+    it("maps deployed change to RecordDeployInput", () => {
+      const deployed = makeDeployedChange("add_users", "id_123");
+      const input = buildRevertInput(deployed);
+
+      expect(input.change_id).toBe("id_123");
+      expect(input.change).toBe("add_users");
+      expect(input.project).toBe("testproject");
+      expect(input.requires).toEqual([]);
+      expect(input.conflicts).toEqual([]);
+      expect(input.tags).toEqual([]);
+      expect(input.dependencies).toEqual([]);
+    });
+
+    it("includes plan change requires and conflicts when available", () => {
+      const deployed = makeDeployedChange("add_users", "id_123");
+      const planChange = makePlanChange("add_users", "id_123", {
+        requires: ["create_schema"],
+        conflicts: ["old_users"],
+      });
+
+      const input = buildRevertInput(deployed, planChange);
+
+      expect(input.requires).toEqual(["create_schema"]);
+      expect(input.conflicts).toEqual(["old_users"]);
+    });
+
+    it("preserves committer and planner fields", () => {
+      const deployed = makeDeployedChange("x", "id_x", {
+        committer_name: "Alice",
+        committer_email: "alice@co.com",
+        planner_name: "Bob",
+        planner_email: "bob@co.com",
+      });
+
+      const input = buildRevertInput(deployed);
+
+      expect(input.committer_name).toBe("Alice");
+      expect(input.committer_email).toBe("alice@co.com");
+      expect(input.planner_name).toBe("Bob");
+      expect(input.planner_email).toBe("bob@co.com");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // confirmRevert — prompt behavior
+  // -----------------------------------------------------------------------
+
+  describe("confirmRevert()", () => {
+    it("returns true when noPrompt is true", async () => {
+      const changes = [
+        {
+          name: "a",
+          change_id: "id_a",
+          revertScriptPath: "/path/a.sql",
+          deployed: makeDeployedChange("a", "id_a"),
+        },
+      ];
+
+      const result = await confirmRevert(changes, true);
+      expect(result).toBe(true);
+    });
+
+    it("returns false when stdin is not a TTY and noPrompt is false", async () => {
+      const changes = [
+        {
+          name: "a",
+          change_id: "id_a",
+          revertScriptPath: "/path/a.sql",
+          deployed: makeDeployedChange("a", "id_a"),
+        },
+      ];
+
+      // Create a mock stdin with isTTY = false
+      const mockStdin = {
+        isTTY: false,
+      } as unknown as NodeJS.ReadStream & { isTTY?: boolean };
+
+      const result = await confirmRevert(changes, false, mockStdin);
+      expect(result).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveTargetUri
+  // -----------------------------------------------------------------------
+
+  describe("resolveTargetUri()", () => {
+    it("returns --db-uri when provided", () => {
+      const uri = resolveTargetUri(
+        { dbUri: "postgresql://host/db", noPrompt: false, topDir: "." },
+        { targets: {}, engines: {} } as never,
+      );
+      expect(uri).toBe("postgresql://host/db");
+    });
+
+    it("looks up named target from config", () => {
+      const uri = resolveTargetUri(
+        { target: "prod", noPrompt: false, topDir: "." },
+        {
+          targets: { prod: { name: "prod", uri: "postgresql://prod/db" } },
+          engines: {},
+        } as never,
+      );
+      expect(uri).toBe("postgresql://prod/db");
+    });
+
+    it("falls back to engine target string", () => {
+      const uri = resolveTargetUri(
+        { noPrompt: false, topDir: "." },
+        {
+          targets: {},
+          engines: { pg: { name: "pg", target: "db:pg://local/mydb" } },
+        } as never,
+      );
+      expect(uri).toBe("db:pg://local/mydb");
+    });
+
+    it("returns undefined when no target configured", () => {
+      const uri = resolveTargetUri(
+        { noPrompt: false, topDir: "." },
+        { targets: {}, engines: {} } as never,
+      );
+      expect(uri).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Registry.recordFailEvent
+  // -----------------------------------------------------------------------
+
+  describe("Registry.recordFailEvent()", () => {
+    it("inserts a 'fail' event into sqitch.events", async () => {
+      const client = new DatabaseClient("postgresql://host/db");
+      await client.connect();
+      const pgClient = mockInstances[mockInstances.length - 1]!;
+      const registry = new Registry(client);
+
+      const input = {
+        change_id: "id_fail",
+        script_hash: "hash_fail",
+        change: "broken_migration",
+        project: "testproject",
+        note: "This migration fails",
+        committer_name: "Test",
+        committer_email: "test@test.com",
+        planned_at: new Date("2025-01-01"),
+        planner_name: "Planner",
+        planner_email: "planner@test.com",
+        requires: ["dep1"],
+        conflicts: [],
+        tags: [],
+        dependencies: [],
+      };
+
+      await registry.recordFailEvent(input);
+
+      const eventInsert = pgClient.queries.find(
+        (q) => q.text.includes("INSERT INTO sqitch.events"),
+      );
+      expect(eventInsert).toBeDefined();
+      expect(eventInsert!.values![0]).toBe("fail");
+      expect(eventInsert!.values![1]).toBe("id_fail");
+      expect(eventInsert!.values![2]).toBe("broken_migration");
+    });
+
+    it("does NOT delete from changes table (unlike recordRevert)", async () => {
+      const client = new DatabaseClient("postgresql://host/db");
+      await client.connect();
+      const pgClient = mockInstances[mockInstances.length - 1]!;
+      const registry = new Registry(client);
+
+      const input = {
+        change_id: "id_fail",
+        script_hash: null,
+        change: "broken",
+        project: "testproject",
+        note: "",
+        committer_name: "Test",
+        committer_email: "test@test.com",
+        planned_at: new Date("2025-01-01"),
+        planner_name: "Planner",
+        planner_email: "planner@test.com",
+        requires: [],
+        conflicts: [],
+        tags: [],
+        dependencies: [],
+      };
+
+      await registry.recordFailEvent(input);
+
+      const deleteQuery = pgClient.queries.find(
+        (q) => q.text.includes("DELETE FROM sqitch.changes"),
+      );
+      expect(deleteQuery).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Integration: revert order with --to
+  // -----------------------------------------------------------------------
+
+  describe("revert ordering integration", () => {
+    it("5 deployed, --to second: reverts last 3 in reverse order", () => {
+      const deployed = [
+        makeDeployedChange("a", "1"),
+        makeDeployedChange("b", "2"),
+        makeDeployedChange("c", "3"),
+        makeDeployedChange("d", "4"),
+        makeDeployedChange("e", "5"),
+      ];
+
+      const result = computeChangesToRevert(deployed, "b");
+      expect(result.map((c) => c.change)).toEqual(["e", "d", "c"]);
+    });
+
+    it("5 deployed, --to first: reverts last 4 in reverse order", () => {
+      const deployed = [
+        makeDeployedChange("a", "1"),
+        makeDeployedChange("b", "2"),
+        makeDeployedChange("c", "3"),
+        makeDeployedChange("d", "4"),
+        makeDeployedChange("e", "5"),
+      ];
+
+      const result = computeChangesToRevert(deployed, "a");
+      expect(result.map((c) => c.change)).toEqual(["e", "d", "c", "b"]);
+    });
+
+    it("buildRevertInput falls back gracefully when no plan change", () => {
+      const deployed = makeDeployedChange("orphan", "id_orphan");
+      const input = buildRevertInput(deployed, undefined);
+
+      expect(input.requires).toEqual([]);
+      expect(input.conflicts).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // CLI integration via parseArgs
+  // -----------------------------------------------------------------------
+
+  describe("CLI routing", () => {
+    it("parseArgs recognizes 'revert' command", () => {
+      const args = parseArgs(["revert"]);
+      expect(args.command).toBe("revert");
+    });
+
+    it("parseArgs passes --to and -y through to rest", () => {
+      const args = parseArgs(["revert", "--to", "v1", "-y"]);
+      expect(args.command).toBe("revert");
+      expect(args.rest).toContain("--to");
+      expect(args.rest).toContain("v1");
+      expect(args.rest).toContain("-y");
+    });
+
+    it("parseArgs handles global flags before revert", () => {
+      const args = parseArgs([
+        "--verbose",
+        "--db-uri",
+        "postgresql://h/d",
+        "revert",
+        "--to",
+        "x",
+      ]);
+      expect(args.command).toBe("revert");
+      expect(args.verbose).toBe(true);
+      expect(args.dbUri).toBe("postgresql://h/d");
+      expect(args.rest).toContain("--to");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `sqlever revert [target] [--to change] [-y]` per SPEC R1 and issue #34
- Full revert flow: advisory lock, deployed change lookup, reverse-order execution via PsqlRunner, tracking table updates, graceful failure handling with `fail` event recording
- Non-TTY stdin detection requires `-y` or errors out (CI safety)
- Add `Registry.recordFailEvent()` to record failures without deleting changes from tracking tables

## Changes
- **`src/commands/revert.ts`** (new) — Core revert command: argument parsing, target URI resolution, confirmation prompt, change computation, script execution loop, fail-event recording, advisory lock lifecycle
- **`src/db/registry.ts`** — Add `recordFailEvent()` method for recording `fail` events without deleting change/dependency rows
- **`src/cli.ts`** — Wire `revert` command into CLI router
- **`tests/unit/revert.test.ts`** (new) — 33 unit tests covering: argument parsing (8), revert ordering (8), input building (3), confirmation prompt (2), target URI resolution (4), Registry.recordFailEvent (2), integration scenarios (3), CLI routing (3)
- **`tests/unit/cli.test.ts`** — Remove `revert` from stub command list

## Test plan
- [x] 33 new unit tests pass (`bun test tests/unit/revert.test.ts`)
- [x] Full suite: 733 tests pass, 0 failures (`bun test`)
- [x] No new TypeScript errors (`bun x tsc --noEmit`)
- [ ] Integration: deploy 3+ changes, `revert --to <mid>` reverts only later ones
- [ ] Integration: `revert -y` skips prompt
- [ ] Integration: non-revertable migration (exception in revert script) records `fail` event, exits 1

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)