### PR TITLE
S4-7: sqlever rework — rework an existing change

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { parseAddArgs, runAdd } from "./commands/add";
 import { runLogCommand } from "./commands/log";
 import { runRevert } from "./commands/revert";
 import { parseTagArgs, runTag } from "./commands/tag";
+import { parseReworkArgs, runRework } from "./commands/rework";
 
 // ---------------------------------------------------------------------------
 // Command registry — all commands from SPEC R1 plus sqlever extensions
@@ -326,6 +327,16 @@ export function main(argv: string[] = process.argv.slice(2)): void {
     tagOpts.topDir = args.topDir;
     runTag(tagOpts).catch((err: unknown) => {
       process.stderr.write(`sqlever tag: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+    return;
+  }
+
+  if (args.command === "rework") {
+    const reworkOpts = parseReworkArgs(args.rest);
+    reworkOpts.topDir = args.topDir;
+    runRework(reworkOpts).catch((err: unknown) => {
+      process.stderr.write(`sqlever rework: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exit(1);
     });
     return;

--- a/src/commands/rework.ts
+++ b/src/commands/rework.ts
@@ -1,0 +1,313 @@
+// src/commands/rework.ts — sqlever rework command
+//
+// Reworks an existing change by creating a new version with the same name.
+// Sqitch rework semantics (SPEC R1, R2):
+//   1. Verify the change exists in the plan
+//   2. Verify a tag exists after the change's last occurrence
+//   3. Copy current deploy/revert/verify scripts to <change>@<tag>.sql
+//   4. Create fresh deploy/revert/verify files for the new version
+//   5. Append a new plan entry with the same name, depending on change@tag
+
+import { existsSync, readFileSync, mkdirSync, copyFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { loadConfig, type MergedConfig } from "../config/index";
+import { parsePlan } from "../plan/parser";
+import { computeChangeId, type ChangeIdInput, type Change, type Tag } from "../plan/types";
+import { appendChange } from "../plan/writer";
+import {
+  getPlannerIdentity,
+  nowTimestamp,
+  deployTemplate,
+  revertTemplate,
+  verifyTemplate,
+} from "./add";
+import { info, error, verbose } from "../output";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReworkOptions {
+  /** Change name to rework (required positional arg). */
+  name: string;
+  /** Note for the reworked change (from -n / --note). */
+  note: string;
+  /** Project root directory (from --top-dir or cwd). */
+  topDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing for the rework subcommand
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `rest` array from the CLI into ReworkOptions.
+ *
+ * Expected usage:
+ *   sqlever rework <name> [-n note]
+ */
+export function parseReworkArgs(rest: string[]): ReworkOptions {
+  const opts: ReworkOptions = {
+    name: "",
+    note: "",
+  };
+
+  let i = 0;
+  while (i < rest.length) {
+    const arg = rest[i]!;
+
+    if (arg === "-n" || arg === "--note") {
+      opts.note = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+
+    // First non-flag argument is the change name
+    if (opts.name === "") {
+      opts.name = arg;
+    }
+    i++;
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Plan analysis helpers
+// ---------------------------------------------------------------------------
+
+export interface ReworkContext {
+  /** The last occurrence of the change in the plan. */
+  lastChange: Change;
+  /** Index of the last occurrence in the changes array. */
+  lastChangeIndex: number;
+  /** The tag that appears after the last occurrence. */
+  tagAfterChange: Tag;
+  /** All tags in the plan (for finding tag after change). */
+  allTags: Tag[];
+  /** Project name from pragmas. */
+  projectName: string;
+  /** Project URI from pragmas (may be undefined). */
+  projectUri?: string;
+  /** The change_id of the last change in the plan (for parent linking). */
+  lastPlanChangeId: string;
+}
+
+/**
+ * Find the rework context: the last occurrence of the change name,
+ * and the tag that must exist after it.
+ *
+ * @throws Error if the change doesn't exist or has no tag after it
+ */
+export function findReworkContext(
+  planContent: string,
+  changeName: string,
+): ReworkContext {
+  const plan = parsePlan(planContent);
+
+  // Find all occurrences of this change name
+  const occurrences: { change: Change; index: number }[] = [];
+  for (let i = 0; i < plan.changes.length; i++) {
+    if (plan.changes[i]!.name === changeName) {
+      occurrences.push({ change: plan.changes[i]!, index: i });
+    }
+  }
+
+  if (occurrences.length === 0) {
+    throw new ReworkError(
+      `Unknown change: "${changeName}". The change must exist in the plan to be reworked.`,
+    );
+  }
+
+  const lastOccurrence = occurrences[occurrences.length - 1]!;
+
+  // Build a map from change_id to tags that follow that change
+  // We need to find a tag that appears after the last occurrence
+  // In Sqitch semantics, a tag is "after" a change if the tag's change_id
+  // matches ANY change from the last occurrence onward (including changes
+  // that come after the last occurrence but before any tag).
+  //
+  // More precisely: we need a tag that is attached to a change at or after
+  // the last occurrence index. The tag we want is the FIRST such tag.
+  const changeIdsAtOrAfterLast = new Set<string>();
+  for (let i = lastOccurrence.index; i < plan.changes.length; i++) {
+    changeIdsAtOrAfterLast.add(plan.changes[i]!.change_id);
+  }
+
+  let tagAfterChange: Tag | undefined;
+  for (const tag of plan.tags) {
+    if (changeIdsAtOrAfterLast.has(tag.change_id)) {
+      tagAfterChange = tag;
+      break;
+    }
+  }
+
+  if (!tagAfterChange) {
+    throw new ReworkError(
+      `Cannot rework "${changeName}": no tag exists after the change. ` +
+      `Use 'sqlever tag' to create a tag before reworking.`,
+    );
+  }
+
+  // The last change in the plan for parent linking
+  const lastPlanChange = plan.changes[plan.changes.length - 1]!;
+
+  return {
+    lastChange: lastOccurrence.change,
+    lastChangeIndex: lastOccurrence.index,
+    tagAfterChange,
+    allTags: plan.tags,
+    projectName: plan.project.name,
+    projectUri: plan.project.uri,
+    lastPlanChangeId: lastPlanChange.change_id,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+export class ReworkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReworkError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main rework logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `rework` command.
+ *
+ * @param opts    - Parsed rework options
+ * @param config  - Merged configuration (if not provided, loaded from cwd)
+ * @param env     - Environment variables (defaults to process.env)
+ */
+export async function runRework(
+  opts: ReworkOptions,
+  config?: MergedConfig,
+  env?: Record<string, string | undefined>,
+): Promise<void> {
+  const environment = env ?? process.env;
+
+  // Validate change name
+  if (!opts.name) {
+    error("Error: change name is required. Usage: sqlever rework <name> [-n note]");
+    process.exit(1);
+  }
+
+  // Load config if not provided
+  const cfg = config ?? loadConfig(opts.topDir, undefined, environment);
+
+  // Resolve directories relative to top_dir
+  const topDir = resolve(opts.topDir ?? cfg.core.top_dir);
+  const deployDir = resolve(topDir, cfg.core.deploy_dir);
+  const revertDir = resolve(topDir, cfg.core.revert_dir);
+  const verifyDir = resolve(topDir, cfg.core.verify_dir);
+  const planPath = resolve(topDir, cfg.core.plan_file);
+
+  // Ensure plan file exists
+  if (!existsSync(planPath)) {
+    error(`Error: plan file not found at ${planPath}. Run 'sqlever init' first.`);
+    process.exit(1);
+  }
+
+  // Read and analyze the plan
+  const planContent = readFileSync(planPath, "utf-8");
+  let ctx: ReworkContext;
+  try {
+    ctx = findReworkContext(planContent, opts.name);
+  } catch (err) {
+    if (err instanceof ReworkError) {
+      error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const tagName = ctx.tagAfterChange.name;
+
+  // --- Step 1: Copy current scripts to @tag versions (backup) ---
+  const deployScript = join(deployDir, `${opts.name}.sql`);
+  const revertScript = join(revertDir, `${opts.name}.sql`);
+  const verifyScript = join(verifyDir, `${opts.name}.sql`);
+
+  const deployBackup = join(deployDir, `${opts.name}@${tagName}.sql`);
+  const revertBackup = join(revertDir, `${opts.name}@${tagName}.sql`);
+  const verifyBackup = join(verifyDir, `${opts.name}@${tagName}.sql`);
+
+  // Ensure directories exist
+  mkdirSync(deployDir, { recursive: true });
+  mkdirSync(revertDir, { recursive: true });
+  mkdirSync(verifyDir, { recursive: true });
+
+  // Copy existing scripts to @tag versions
+  if (existsSync(deployScript)) {
+    copyFileSync(deployScript, deployBackup);
+    verbose(`Copied ${deployScript} -> ${deployBackup}`);
+  }
+  if (existsSync(revertScript)) {
+    copyFileSync(revertScript, revertBackup);
+    verbose(`Copied ${revertScript} -> ${revertBackup}`);
+  }
+  if (existsSync(verifyScript)) {
+    copyFileSync(verifyScript, verifyBackup);
+    verbose(`Copied ${verifyScript} -> ${verifyBackup}`);
+  }
+
+  // --- Step 2: Overwrite the original scripts with fresh templates ---
+  writeFileSync(
+    deployScript,
+    deployTemplate(opts.name, [`${opts.name}@${tagName}`]),
+    "utf-8",
+  );
+  verbose(`Created fresh ${deployScript}`);
+
+  writeFileSync(revertScript, revertTemplate(opts.name), "utf-8");
+  verbose(`Created fresh ${revertScript}`);
+
+  writeFileSync(verifyScript, verifyTemplate(opts.name), "utf-8");
+  verbose(`Created fresh ${verifyScript}`);
+
+  // --- Step 3: Append the reworked change to the plan ---
+  const planner = getPlannerIdentity(environment);
+  const timestamp = nowTimestamp();
+
+  // The reworked change depends on change@tag
+  const requires = [`${opts.name}@${tagName}`];
+
+  const changeIdInput: ChangeIdInput = {
+    project: ctx.projectName,
+    uri: ctx.projectUri,
+    change: opts.name,
+    parent: ctx.lastPlanChangeId,
+    planner_name: planner.name,
+    planner_email: planner.email,
+    planned_at: timestamp,
+    requires,
+    conflicts: [],
+    note: opts.note,
+  };
+
+  const changeId = computeChangeId(changeIdInput);
+
+  const change: Change = {
+    change_id: changeId,
+    name: opts.name,
+    project: ctx.projectName,
+    note: opts.note,
+    planner_name: planner.name,
+    planner_email: planner.email,
+    planned_at: timestamp,
+    requires,
+    conflicts: [],
+    parent: ctx.lastPlanChangeId,
+  };
+
+  await appendChange(planPath, change);
+  verbose(`Appended reworked change to ${planPath}`);
+
+  info(`Reworked "${opts.name}" referencing @${tagName}`);
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -308,8 +308,8 @@ describe("unknown commands", () => {
 // ---------------------------------------------------------------------------
 
 describe("command stubs", () => {
-  // "help" is handled specially (not a stub), "init", "add", "log", "revert", and "tag" are implemented — exclude them
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log" && c !== "revert" && c !== "tag");
+  // "help" is handled specially (not a stub), "init", "add", "log", "revert", "tag", and "rework" are implemented — exclude them
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log" && c !== "revert" && c !== "tag" && c !== "rework");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {

--- a/tests/unit/rework.test.ts
+++ b/tests/unit/rework.test.ts
@@ -1,0 +1,710 @@
+// tests/unit/rework.test.ts — Tests for sqlever rework command
+//
+// Validates rework command: argument parsing, plan analysis, script backup,
+// fresh file creation, plan appending, error cases, and CLI integration.
+
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { rmSync } from "node:fs";
+
+import {
+  parseReworkArgs,
+  runRework,
+  findReworkContext,
+  ReworkError,
+} from "../../src/commands/rework";
+import { computeChangeId } from "../../src/plan/types";
+import { parsePlan } from "../../src/plan/parser";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function createTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "sqlever-rework-test-"));
+}
+
+/** Mock environment with planner identity to avoid git dependency. */
+const TEST_ENV: Record<string, string | undefined> = {
+  SQLEVER_USER_NAME: "Test User",
+  SQLEVER_USER_EMAIL: "test@example.com",
+};
+
+/** Create a minimal MergedConfig for testing. */
+function testConfig(topDir: string) {
+  return {
+    core: {
+      engine: undefined,
+      top_dir: topDir,
+      deploy_dir: "deploy",
+      revert_dir: "revert",
+      verify_dir: "verify",
+      plan_file: "sqitch.plan",
+    },
+    deploy: {
+      verify: true,
+      mode: "change" as const,
+      lock_retries: 0,
+      lock_timeout: "5s",
+      idle_in_transaction_session_timeout: "10min",
+      search_path: undefined,
+    },
+    engines: {},
+    targets: {},
+    analysis: {},
+    sqitchConf: { entries: [], rawLines: [], sections: new Set<string>() },
+    sqleverToml: null,
+  };
+}
+
+/** Standard plan with one change and a tag after it. */
+const PLAN_WITH_TAG =
+  "%syntax-version=1.0.0\n" +
+  "%project=myproject\n" +
+  "\n" +
+  "add_users 2024-01-01T00:00:00Z Test User <test@example.com> # add users table\n" +
+  "@v1.0 2024-01-01T00:01:00Z Test User <test@example.com> # tag v1.0\n";
+
+/** Plan with two changes, tag after first only. */
+const PLAN_TWO_CHANGES_TAG_AFTER_FIRST =
+  "%syntax-version=1.0.0\n" +
+  "%project=myproject\n" +
+  "\n" +
+  "add_users 2024-01-01T00:00:00Z Test User <test@example.com> # add users table\n" +
+  "@v1.0 2024-01-01T00:01:00Z Test User <test@example.com> # tag v1.0\n" +
+  "add_roles 2024-01-02T00:00:00Z Test User <test@example.com> # add roles table\n";
+
+/** Plan with no tag after the change. */
+const PLAN_NO_TAG =
+  "%syntax-version=1.0.0\n" +
+  "%project=myproject\n" +
+  "\n" +
+  "add_users 2024-01-01T00:00:00Z Test User <test@example.com> # add users table\n";
+
+/** Set up a project with plan and existing scripts. */
+function setupReworkProject(
+  dir: string,
+  planContent: string,
+  changeName: string = "add_users",
+): { planPath: string } {
+  const planPath = join(dir, "sqitch.plan");
+  writeFileSync(planPath, planContent, "utf-8");
+
+  // Create directories and script files
+  const deployDir = join(dir, "deploy");
+  const revertDir = join(dir, "revert");
+  const verifyDir = join(dir, "verify");
+  mkdirSync(deployDir, { recursive: true });
+  mkdirSync(revertDir, { recursive: true });
+  mkdirSync(verifyDir, { recursive: true });
+
+  writeFileSync(
+    join(deployDir, `${changeName}.sql`),
+    `-- Deploy ${changeName}\nCREATE TABLE users (id int);\n`,
+    "utf-8",
+  );
+  writeFileSync(
+    join(revertDir, `${changeName}.sql`),
+    `-- Revert ${changeName}\nDROP TABLE users;\n`,
+    "utf-8",
+  );
+  writeFileSync(
+    join(verifyDir, `${changeName}.sql`),
+    `-- Verify ${changeName}\nSELECT 1 FROM users;\n`,
+    "utf-8",
+  );
+
+  return { planPath };
+}
+
+// ---------------------------------------------------------------------------
+// parseReworkArgs
+// ---------------------------------------------------------------------------
+
+describe("parseReworkArgs", () => {
+  it("parses a simple change name", () => {
+    const opts = parseReworkArgs(["add_users"]);
+    expect(opts.name).toBe("add_users");
+    expect(opts.note).toBe("");
+  });
+
+  it("parses -n / --note", () => {
+    const opts1 = parseReworkArgs(["add_users", "-n", "reworked users"]);
+    expect(opts1.name).toBe("add_users");
+    expect(opts1.note).toBe("reworked users");
+
+    const opts2 = parseReworkArgs(["add_users", "--note", "reworked users"]);
+    expect(opts2.name).toBe("add_users");
+    expect(opts2.note).toBe("reworked users");
+  });
+
+  it("returns empty name when no positional arg given", () => {
+    const opts = parseReworkArgs(["-n", "some note"]);
+    expect(opts.name).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findReworkContext
+// ---------------------------------------------------------------------------
+
+describe("findReworkContext", () => {
+  it("finds change and tag for a simple rework scenario", () => {
+    const ctx = findReworkContext(PLAN_WITH_TAG, "add_users");
+    expect(ctx.lastChange.name).toBe("add_users");
+    expect(ctx.tagAfterChange.name).toBe("v1.0");
+    expect(ctx.projectName).toBe("myproject");
+  });
+
+  it("throws ReworkError when change does not exist", () => {
+    expect(() => findReworkContext(PLAN_WITH_TAG, "nonexistent")).toThrow(
+      ReworkError,
+    );
+    expect(() => findReworkContext(PLAN_WITH_TAG, "nonexistent")).toThrow(
+      /Unknown change/,
+    );
+  });
+
+  it("throws ReworkError when no tag exists after the change", () => {
+    expect(() => findReworkContext(PLAN_NO_TAG, "add_users")).toThrow(
+      ReworkError,
+    );
+    expect(() => findReworkContext(PLAN_NO_TAG, "add_users")).toThrow(
+      /no tag exists/,
+    );
+  });
+
+  it("finds the correct tag when change is not the last in the plan", () => {
+    const ctx = findReworkContext(PLAN_TWO_CHANGES_TAG_AFTER_FIRST, "add_users");
+    expect(ctx.tagAfterChange.name).toBe("v1.0");
+    // lastPlanChangeId should be the ID of add_roles (the last change)
+    expect(ctx.lastPlanChangeId).toBeTruthy();
+    expect(ctx.lastChange.name).toBe("add_users");
+  });
+
+  it("uses the last occurrence when a change name appears multiple times", () => {
+    // Plan with already-reworked change
+    const plan =
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "add_users 2024-01-01T00:00:00Z Test User <test@example.com> # original\n" +
+      "@v1.0 2024-01-01T00:01:00Z Test User <test@example.com> # tag v1.0\n" +
+      "add_users [add_users@v1.0] 2024-02-01T00:00:00Z Test User <test@example.com> # rework 1\n" +
+      "@v2.0 2024-02-01T00:01:00Z Test User <test@example.com> # tag v2.0\n";
+
+    const ctx = findReworkContext(plan, "add_users");
+    // Should find the second (reworked) occurrence
+    expect(ctx.lastChange.note).toBe("rework 1");
+    // Should find the tag after the second occurrence
+    expect(ctx.tagAfterChange.name).toBe("v2.0");
+  });
+
+  it("throws when last occurrence of a reworked change has no tag", () => {
+    const plan =
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "add_users 2024-01-01T00:00:00Z Test User <test@example.com> # original\n" +
+      "@v1.0 2024-01-01T00:01:00Z Test User <test@example.com> # tag v1.0\n" +
+      "add_users [add_users@v1.0] 2024-02-01T00:00:00Z Test User <test@example.com> # rework 1\n";
+
+    expect(() => findReworkContext(plan, "add_users")).toThrow(
+      /no tag exists/,
+    );
+  });
+
+  it("returns correct project URI when present", () => {
+    const plan =
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "%uri=https://example.com/myproject\n" +
+      "\n" +
+      "add_users 2024-01-01T00:00:00Z Test User <test@example.com> # add users\n" +
+      "@v1.0 2024-01-01T00:01:00Z Test User <test@example.com>\n";
+
+    const ctx = findReworkContext(plan, "add_users");
+    expect(ctx.projectUri).toBe("https://example.com/myproject");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runRework — full integration (with temp dirs)
+// ---------------------------------------------------------------------------
+
+describe("runRework", () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("copies existing scripts to @tag backup files", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+    const cfg = testConfig(tmpDir);
+
+    await runRework(
+      { name: "add_users", note: "rework users" },
+      cfg,
+      TEST_ENV,
+    );
+
+    // Backup files should exist with original content
+    const deployBackup = readFileSync(
+      join(tmpDir, "deploy", "add_users@v1.0.sql"),
+      "utf-8",
+    );
+    expect(deployBackup).toContain("CREATE TABLE users");
+
+    const revertBackup = readFileSync(
+      join(tmpDir, "revert", "add_users@v1.0.sql"),
+      "utf-8",
+    );
+    expect(revertBackup).toContain("DROP TABLE users");
+
+    const verifyBackup = readFileSync(
+      join(tmpDir, "verify", "add_users@v1.0.sql"),
+      "utf-8",
+    );
+    expect(verifyBackup).toContain("SELECT 1 FROM users");
+  });
+
+  it("creates fresh deploy/revert/verify scripts", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+    const cfg = testConfig(tmpDir);
+
+    await runRework(
+      { name: "add_users", note: "rework users" },
+      cfg,
+      TEST_ENV,
+    );
+
+    // Fresh scripts should be template content (not original)
+    const deploySql = readFileSync(
+      join(tmpDir, "deploy", "add_users.sql"),
+      "utf-8",
+    );
+    expect(deploySql).toContain("-- Deploy add_users");
+    expect(deploySql).toContain("-- requires: add_users@v1.0");
+    expect(deploySql).not.toContain("CREATE TABLE users");
+
+    const revertSql = readFileSync(
+      join(tmpDir, "revert", "add_users.sql"),
+      "utf-8",
+    );
+    expect(revertSql).toContain("-- Revert add_users");
+    expect(revertSql).not.toContain("DROP TABLE users");
+
+    const verifySql = readFileSync(
+      join(tmpDir, "verify", "add_users.sql"),
+      "utf-8",
+    );
+    expect(verifySql).toContain("-- Verify add_users");
+    expect(verifySql).not.toContain("SELECT 1 FROM users");
+  });
+
+  it("appends reworked change to plan with correct dependency", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+    const cfg = testConfig(tmpDir);
+
+    await runRework(
+      { name: "add_users", note: "rework users" },
+      cfg,
+      TEST_ENV,
+    );
+
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const lines = plan.split("\n");
+
+    // Find the reworked change line (the second add_users entry)
+    const addUserLines = lines.filter((l) => l.startsWith("add_users"));
+    expect(addUserLines.length).toBe(2);
+
+    const reworkedLine = addUserLines[1]!;
+    expect(reworkedLine).toContain("[add_users@v1.0]");
+    expect(reworkedLine).toContain("Test User <test@example.com>");
+    expect(reworkedLine).toContain("# rework users");
+  });
+
+  it("sets correct parent for reworked change", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+    const cfg = testConfig(tmpDir);
+
+    await runRework(
+      { name: "add_users", note: "rework users" },
+      cfg,
+      TEST_ENV,
+    );
+
+    // Parse the resulting plan
+    const planContent = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const plan = parsePlan(planContent);
+
+    expect(plan.changes.length).toBe(2);
+    // The reworked change should have the original as parent
+    const reworked = plan.changes[1]!;
+    expect(reworked.name).toBe("add_users");
+    expect(reworked.parent).toBe(plan.changes[0]!.change_id);
+    expect(reworked.requires).toEqual(["add_users@v1.0"]);
+  });
+
+  it("errors when change name not provided", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      await runRework({ name: "", note: "" }, cfg, TEST_ENV);
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors when change does not exist in plan", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      await runRework(
+        { name: "nonexistent_change", note: "" },
+        cfg,
+        TEST_ENV,
+      );
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors when no tag exists after the change", async () => {
+    setupReworkProject(tmpDir, PLAN_NO_TAG);
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      await runRework({ name: "add_users", note: "" }, cfg, TEST_ENV);
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors when plan file does not exist", async () => {
+    // Don't create plan file
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      await runRework({ name: "add_users", note: "" }, cfg, TEST_ENV);
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("handles rework when change is not the last change in plan", async () => {
+    // Setup project with two changes, tag after first
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(planPath, PLAN_TWO_CHANGES_TAG_AFTER_FIRST, "utf-8");
+
+    // Create script directories and files for add_users
+    const deployDir = join(tmpDir, "deploy");
+    const revertDir = join(tmpDir, "revert");
+    const verifyDir = join(tmpDir, "verify");
+    mkdirSync(deployDir, { recursive: true });
+    mkdirSync(revertDir, { recursive: true });
+    mkdirSync(verifyDir, { recursive: true });
+
+    writeFileSync(
+      join(deployDir, "add_users.sql"),
+      "-- Deploy add_users\nCREATE TABLE users (id int);\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(revertDir, "add_users.sql"),
+      "-- Revert add_users\nDROP TABLE users;\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(verifyDir, "add_users.sql"),
+      "-- Verify add_users\nSELECT 1 FROM users;\n",
+      "utf-8",
+    );
+
+    const cfg = testConfig(tmpDir);
+
+    await runRework(
+      { name: "add_users", note: "rework users" },
+      cfg,
+      TEST_ENV,
+    );
+
+    // The reworked entry should be appended at the end
+    const plan = readFileSync(planPath, "utf-8");
+    const lines = plan.split("\n").filter((l) => l.trim() !== "" && !l.startsWith("%"));
+    const lastNonEmpty = lines[lines.length - 1]!;
+    expect(lastNonEmpty).toMatch(/^add_users /);
+    expect(lastNonEmpty).toContain("[add_users@v1.0]");
+
+    // Parent should be the last change (add_roles), not add_users
+    const parsedPlan = parsePlan(plan);
+    const reworkedChange = parsedPlan.changes[parsedPlan.changes.length - 1]!;
+    expect(reworkedChange.name).toBe("add_users");
+    // Parent should be add_roles (the preceding change in the plan)
+    const addRolesChange = parsedPlan.changes.find(c => c.name === "add_roles");
+    expect(reworkedChange.parent).toBe(addRolesChange!.change_id);
+  });
+
+  it("handles rework with empty note", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+    const cfg = testConfig(tmpDir);
+
+    await runRework(
+      { name: "add_users", note: "" },
+      cfg,
+      TEST_ENV,
+    );
+
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const reworkedLine = plan.split("\n").filter(l => l.startsWith("add_users"))[1];
+    expect(reworkedLine).toBeTruthy();
+    // Should not have a note comment
+    expect(reworkedLine).not.toContain("#");
+  });
+
+  it("handles missing scripts gracefully (no error if scripts don't exist)", async () => {
+    // Set up plan but don't create script files
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(planPath, PLAN_WITH_TAG, "utf-8");
+
+    const cfg = testConfig(tmpDir);
+
+    // Should not throw even without existing scripts
+    await runRework(
+      { name: "add_users", note: "rework" },
+      cfg,
+      TEST_ENV,
+    );
+
+    // Fresh scripts should still be created
+    expect(existsSync(join(tmpDir, "deploy", "add_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "revert", "add_users.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "verify", "add_users.sql"))).toBe(true);
+
+    // Backup files should NOT exist (nothing to copy)
+    expect(existsSync(join(tmpDir, "deploy", "add_users@v1.0.sql"))).toBe(false);
+  });
+
+  it("produces a plan that parsePlan can re-parse cleanly", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+    const cfg = testConfig(tmpDir);
+
+    await runRework(
+      { name: "add_users", note: "rework users" },
+      cfg,
+      TEST_ENV,
+    );
+
+    const planContent = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    // Should parse without errors
+    const plan = parsePlan(planContent);
+    expect(plan.changes.length).toBe(2);
+    expect(plan.tags.length).toBe(1);
+    expect(plan.changes[0]!.name).toBe("add_users");
+    expect(plan.changes[1]!.name).toBe("add_users");
+  });
+
+  it("uses custom directory names from config", async () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(planPath, PLAN_WITH_TAG, "utf-8");
+
+    // Create custom dirs with scripts
+    mkdirSync(join(tmpDir, "custom-deploy"), { recursive: true });
+    mkdirSync(join(tmpDir, "custom-revert"), { recursive: true });
+    mkdirSync(join(tmpDir, "custom-verify"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "custom-deploy", "add_users.sql"),
+      "-- custom deploy\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(tmpDir, "custom-revert", "add_users.sql"),
+      "-- custom revert\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(tmpDir, "custom-verify", "add_users.sql"),
+      "-- custom verify\n",
+      "utf-8",
+    );
+
+    const cfg = testConfig(tmpDir);
+    cfg.core.deploy_dir = "custom-deploy";
+    cfg.core.revert_dir = "custom-revert";
+    cfg.core.verify_dir = "custom-verify";
+
+    await runRework(
+      { name: "add_users", note: "rework" },
+      cfg,
+      TEST_ENV,
+    );
+
+    expect(existsSync(join(tmpDir, "custom-deploy", "add_users@v1.0.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "custom-revert", "add_users@v1.0.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "custom-verify", "add_users@v1.0.sql"))).toBe(true);
+  });
+
+  it("computes a valid change ID for the reworked change", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+    const cfg = testConfig(tmpDir);
+
+    await runRework(
+      { name: "add_users", note: "rework users" },
+      cfg,
+      TEST_ENV,
+    );
+
+    const planContent = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const plan = parsePlan(planContent);
+
+    // Both changes should have different IDs
+    expect(plan.changes[0]!.change_id).not.toBe(plan.changes[1]!.change_id);
+
+    // The reworked change's ID should be recomputable
+    const reworked = plan.changes[1]!;
+    const recomputed = computeChangeId({
+      project: "myproject",
+      change: "add_users",
+      parent: plan.changes[0]!.change_id,
+      planner_name: reworked.planner_name,
+      planner_email: reworked.planner_email,
+      planned_at: reworked.planned_at,
+      requires: ["add_users@v1.0"],
+      conflicts: [],
+      note: "rework users",
+    });
+    expect(reworked.change_id).toBe(recomputed);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI integration (subprocess)
+// ---------------------------------------------------------------------------
+
+describe("sqlever rework (subprocess)", () => {
+  const CWD = import.meta.dir + "/../..";
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runCli(
+    ...args: string[]
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const proc = Bun.spawn(["bun", "run", join(CWD, "src/cli.ts"), ...args], {
+      cwd: tmpDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        SQLEVER_USER_NAME: "CLI Test",
+        SQLEVER_USER_EMAIL: "cli@test.com",
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("reworks a change via CLI", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+
+    const { stdout, exitCode } = await runCli(
+      "rework", "add_users", "-n", "rework users",
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Reworked");
+    expect(existsSync(join(tmpDir, "deploy", "add_users@v1.0.sql"))).toBe(true);
+  });
+
+  it("exits 1 when no change name is provided", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+
+    const { exitCode, stderr } = await runCli("rework");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("change name is required");
+  });
+
+  it("exits 1 when change does not exist", async () => {
+    setupReworkProject(tmpDir, PLAN_WITH_TAG);
+
+    const { exitCode, stderr } = await runCli("rework", "nonexistent");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unknown change");
+  });
+
+  it("exits 1 when no tag exists after the change", async () => {
+    setupReworkProject(tmpDir, PLAN_NO_TAG);
+
+    const { exitCode, stderr } = await runCli("rework", "add_users");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("no tag exists");
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `sqlever rework <change> [-n note]` command with full Sqitch rework semantics (closes #49)
- Verifies the change exists in the plan and has a tag after its last occurrence, copies current deploy/revert/verify scripts to `<change>@<tag>.sql` backups, creates fresh template scripts for the new version, and appends a reworked entry to the plan with `[change@tag]` dependency
- Wires the command into the CLI dispatcher alongside `init` and `add`
- 28 tests covering: argument parsing (3), plan analysis/findReworkContext (7), runRework integration (14), and CLI subprocess (4)

## Test plan
- [x] All 728 tests pass (0 failures)
- [x] Rework creates @tag backup files with original content
- [x] Fresh scripts contain template content with correct `requires` referencing `change@tag`
- [x] Plan entry appended with correct dependency, parent, and change ID
- [x] Errors on: missing change name, unknown change, no tag after change, missing plan file
- [x] Handles: change not at end of plan, multiple rework rounds, empty note, missing scripts, custom dirs
- [x] CLI subprocess tests verify end-to-end behavior including error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)