### PR TITLE
feat: sqlever show — display change scripts and metadata

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { runLogCommand } from "./commands/log";
 import { runRevert } from "./commands/revert";
 import { parseTagArgs, runTag } from "./commands/tag";
 import { parseReworkArgs, runRework } from "./commands/rework";
+import { parseShowArgs, runShow } from "./commands/show";
 
 // ---------------------------------------------------------------------------
 // Command registry — all commands from SPEC R1 plus sqlever extensions
@@ -339,6 +340,20 @@ export function main(argv: string[] = process.argv.slice(2)): void {
       process.stderr.write(`sqlever rework: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exit(1);
     });
+    return;
+  }
+
+  if (args.command === "show") {
+    const showOpts = parseShowArgs(args.rest);
+    if (args.topDir !== undefined) showOpts.topDir = args.topDir;
+    if (args.planFile !== undefined) showOpts.planFile = args.planFile;
+    try {
+      runShow(showOpts);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`sqlever show: ${msg}\n`);
+      process.exit(1);
+    }
     return;
   }
 

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,0 +1,304 @@
+// src/commands/show.ts — sqlever show command
+//
+// Displays change/tag metadata or deploy/revert/verify script contents.
+//
+// Usage:
+//   sqlever show deploy <name>   — print deploy script
+//   sqlever show revert <name>   — print revert script
+//   sqlever show verify <name>   — print verify script
+//   sqlever show change <name>   — show change metadata from the plan
+//   sqlever show tag <name>      — show tag metadata from the plan
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { loadConfig, type MergedConfig } from "../config/index";
+import { parsePlan } from "../plan/parser";
+import type { Change, Tag } from "../plan/types";
+import { info, error, json, getConfig } from "../output";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Supported show types. */
+export type ShowType = "deploy" | "revert" | "verify" | "change" | "tag";
+
+export interface ShowOptions {
+  /** What to show: deploy, revert, verify, change, or tag. */
+  type: ShowType;
+  /** Name of the change or tag to look up. */
+  name: string;
+  /** Project root directory (from --top-dir or cwd). */
+  topDir?: string;
+  /** Plan file path override. */
+  planFile?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing for the show subcommand
+// ---------------------------------------------------------------------------
+
+const VALID_TYPES = new Set<string>(["deploy", "revert", "verify", "change", "tag"]);
+
+/**
+ * Parse the `rest` array from the CLI into ShowOptions.
+ *
+ * Expected usage:
+ *   sqlever show <type> <name>
+ */
+export function parseShowArgs(rest: string[]): ShowOptions {
+  const opts: ShowOptions = {
+    type: "" as ShowType,
+    name: "",
+  };
+
+  let positionalIndex = 0;
+  let i = 0;
+  while (i < rest.length) {
+    const arg = rest[i]!;
+
+    // Consume known flags
+    if (arg === "--plan-file") {
+      opts.planFile = rest[++i];
+      i++;
+      continue;
+    }
+    if (arg === "--top-dir") {
+      opts.topDir = rest[++i];
+      i++;
+      continue;
+    }
+
+    // Positional arguments
+    if (positionalIndex === 0) {
+      opts.type = arg as ShowType;
+      positionalIndex++;
+    } else if (positionalIndex === 1) {
+      opts.name = arg;
+      positionalIndex++;
+    }
+    i++;
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Script display (deploy / revert / verify)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the path to a script file for the given type and change name.
+ */
+export function resolveScriptPath(
+  topDir: string,
+  scriptDir: string,
+  changeName: string,
+): string {
+  return join(resolve(topDir), scriptDir, `${changeName}.sql`);
+}
+
+/**
+ * Read and return the contents of a script file.
+ * Returns null if the file does not exist.
+ */
+export function readScript(scriptPath: string): string | null {
+  if (!existsSync(scriptPath)) return null;
+  return readFileSync(scriptPath, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Change/tag lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Find a change by name in the parsed plan.
+ * Returns the last occurrence (in case of reworked changes).
+ */
+export function findChange(planPath: string, name: string): Change | null {
+  const content = readFileSync(planPath, "utf-8");
+  const plan = parsePlan(content);
+
+  // Find the last change with this name (handles reworked changes)
+  let found: Change | null = null;
+  for (const change of plan.changes) {
+    if (change.name === name) {
+      found = change;
+    }
+  }
+  return found;
+}
+
+/**
+ * Find a tag by name in the parsed plan.
+ * The name should NOT include the @ prefix.
+ */
+export function findTag(planPath: string, name: string): Tag | null {
+  const content = readFileSync(planPath, "utf-8");
+  const plan = parsePlan(content);
+
+  for (const tag of plan.tags) {
+    if (tag.name === name) {
+      return tag;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+/**
+ * Format change metadata for text output.
+ */
+export function formatChange(change: Change): string {
+  const lines: string[] = [];
+  lines.push(`Change:    ${change.name}`);
+  lines.push(`ID:        ${change.change_id}`);
+  lines.push(`Project:   ${change.project}`);
+  lines.push(`Planner:   ${change.planner_name} <${change.planner_email}>`);
+  lines.push(`Planned:   ${change.planned_at}`);
+  if (change.parent) {
+    lines.push(`Parent:    ${change.parent}`);
+  }
+  if (change.requires.length > 0) {
+    lines.push(`Requires:  ${change.requires.join(", ")}`);
+  }
+  if (change.conflicts.length > 0) {
+    lines.push(`Conflicts: ${change.conflicts.join(", ")}`);
+  }
+  if (change.note) {
+    lines.push(`Note:      ${change.note}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Format tag metadata for text output.
+ */
+export function formatTag(tag: Tag): string {
+  const lines: string[] = [];
+  lines.push(`Tag:       @${tag.name}`);
+  lines.push(`ID:        ${tag.tag_id}`);
+  lines.push(`Project:   ${tag.project}`);
+  lines.push(`Change:    ${tag.change_id}`);
+  lines.push(`Planner:   ${tag.planner_name} <${tag.planner_email}>`);
+  lines.push(`Planned:   ${tag.planned_at}`);
+  if (tag.note) {
+    lines.push(`Note:      ${tag.note}`);
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main show logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `show` command.
+ *
+ * @param opts   - Parsed show options
+ * @param config - Merged configuration (if not provided, loaded from cwd)
+ */
+export function runShow(
+  opts: ShowOptions,
+  config?: MergedConfig,
+): void {
+  // Validate type
+  if (!opts.type || !VALID_TYPES.has(opts.type)) {
+    error(
+      `Error: invalid show type '${opts.type || ""}'. ` +
+      "Expected one of: deploy, revert, verify, change, tag.",
+    );
+    process.exit(1);
+  }
+
+  // Validate name
+  if (!opts.name) {
+    error(
+      "Error: name is required. Usage: sqlever show <type> <name>",
+    );
+    process.exit(1);
+  }
+
+  // Load config if not provided
+  const cfg = config ?? loadConfig(opts.topDir, undefined, undefined);
+  const topDir = resolve(opts.topDir ?? cfg.core.top_dir);
+  const planPath = opts.planFile
+    ? resolve(opts.planFile)
+    : resolve(topDir, cfg.core.plan_file);
+
+  const outputCfg = getConfig();
+
+  // Script types: deploy, revert, verify
+  if (opts.type === "deploy" || opts.type === "revert" || opts.type === "verify") {
+    const dirMap: Record<string, string> = {
+      deploy: cfg.core.deploy_dir,
+      revert: cfg.core.revert_dir,
+      verify: cfg.core.verify_dir,
+    };
+    const scriptDir = dirMap[opts.type]!;
+    const scriptPath = resolveScriptPath(topDir, scriptDir, opts.name);
+    const content = readScript(scriptPath);
+
+    if (content === null) {
+      error(`Error: ${opts.type} script not found at ${scriptPath}`);
+      process.exit(1);
+    }
+
+    if (outputCfg.format === "json") {
+      json({
+        type: opts.type,
+        name: opts.name,
+        path: scriptPath,
+        content,
+      });
+    } else {
+      // Print raw script content to stdout
+      process.stdout.write(content);
+    }
+    return;
+  }
+
+  // Metadata types: change, tag
+  if (opts.type === "change") {
+    if (!existsSync(planPath)) {
+      error(`Error: plan file not found at ${planPath}`);
+      process.exit(1);
+    }
+
+    const change = findChange(planPath, opts.name);
+    if (!change) {
+      error(`Error: change '${opts.name}' not found in plan`);
+      process.exit(1);
+    }
+
+    if (outputCfg.format === "json") {
+      json(change);
+    } else {
+      info(formatChange(change));
+    }
+    return;
+  }
+
+  if (opts.type === "tag") {
+    if (!existsSync(planPath)) {
+      error(`Error: plan file not found at ${planPath}`);
+      process.exit(1);
+    }
+
+    const tag = findTag(planPath, opts.name);
+    if (!tag) {
+      error(`Error: tag '${opts.name}' not found in plan`);
+      process.exit(1);
+    }
+
+    if (outputCfg.format === "json") {
+      json(tag);
+    } else {
+      info(formatTag(tag));
+    }
+    return;
+  }
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -308,8 +308,8 @@ describe("unknown commands", () => {
 // ---------------------------------------------------------------------------
 
 describe("command stubs", () => {
-  // "help" is handled specially (not a stub), "init", "add", "log", "revert", "tag", and "rework" are implemented — exclude them
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log" && c !== "revert" && c !== "tag" && c !== "rework");
+  // "help" is handled specially (not a stub), "init", "add", "log", "revert", "tag", "rework", and "show" are implemented — exclude them
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log" && c !== "revert" && c !== "tag" && c !== "rework" && c !== "show");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {

--- a/tests/unit/show.test.ts
+++ b/tests/unit/show.test.ts
@@ -1,0 +1,733 @@
+// tests/unit/show.test.ts — Tests for sqlever show command
+//
+// Validates show command: argument parsing, script display, change/tag
+// metadata lookup, error handling, and JSON output mode.
+
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { rmSync } from "node:fs";
+
+import {
+  parseShowArgs,
+  runShow,
+  resolveScriptPath,
+  readScript,
+  findChange,
+  findTag,
+  formatChange,
+  formatTag,
+} from "../../src/commands/show";
+import { computeChangeId } from "../../src/plan/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function createTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "sqlever-show-test-"));
+}
+
+/** Plan content with one change and one tag. */
+const PLAN_CONTENT =
+  "%syntax-version=1.0.0\n" +
+  "%project=myproject\n" +
+  "\n" +
+  "create_schema 2024-01-15T10:30:00Z Test User <test@example.com> # Bootstrap schema\n" +
+  "add_users [create_schema] 2024-01-15T10:31:00Z Test User <test@example.com> # Users table\n" +
+  "@v1.0 2024-01-15T10:32:00Z Test User <test@example.com> # First release\n";
+
+/** Create a project directory with plan file and script files. */
+function setupProject(dir: string, planContent?: string): void {
+  const planPath = join(dir, "sqitch.plan");
+  writeFileSync(planPath, planContent ?? PLAN_CONTENT, "utf-8");
+
+  // Create script directories and files
+  for (const sub of ["deploy", "revert", "verify"]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+
+  writeFileSync(
+    join(dir, "deploy", "create_schema.sql"),
+    "-- Deploy create_schema\nBEGIN;\nCREATE SCHEMA app;\nCOMMIT;\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(dir, "revert", "create_schema.sql"),
+    "-- Revert create_schema\nBEGIN;\nDROP SCHEMA app;\nCOMMIT;\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(dir, "verify", "create_schema.sql"),
+    "-- Verify create_schema\nSELECT 1/COUNT(*) FROM information_schema.schemata WHERE schema_name = 'app';\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(dir, "deploy", "add_users.sql"),
+    "-- Deploy add_users\nBEGIN;\nCREATE TABLE app.users (id serial PRIMARY KEY);\nCOMMIT;\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(dir, "revert", "add_users.sql"),
+    "-- Revert add_users\nBEGIN;\nDROP TABLE app.users;\nCOMMIT;\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(dir, "verify", "add_users.sql"),
+    "-- Verify add_users\nSELECT 1/COUNT(*) FROM information_schema.tables WHERE table_name = 'users';\n",
+    "utf-8",
+  );
+}
+
+/** Create a minimal MergedConfig for testing. */
+function testConfig(topDir: string) {
+  return {
+    core: {
+      engine: undefined,
+      top_dir: topDir,
+      deploy_dir: "deploy",
+      revert_dir: "revert",
+      verify_dir: "verify",
+      plan_file: "sqitch.plan",
+    },
+    deploy: {
+      verify: true,
+      mode: "change" as const,
+      lock_retries: 0,
+      lock_timeout: "5s",
+      idle_in_transaction_session_timeout: "10min",
+      search_path: undefined,
+    },
+    engines: {},
+    targets: {},
+    analysis: {},
+    sqitchConf: { entries: [], rawLines: [], sections: new Set<string>() },
+    sqleverToml: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseShowArgs
+// ---------------------------------------------------------------------------
+
+describe("parseShowArgs", () => {
+  it("parses type and name from positional args", () => {
+    const opts = parseShowArgs(["deploy", "create_schema"]);
+    expect(opts.type).toBe("deploy");
+    expect(opts.name).toBe("create_schema");
+  });
+
+  it("parses all valid types", () => {
+    for (const type of ["deploy", "revert", "verify", "change", "tag"] as const) {
+      const opts = parseShowArgs([type, "my_change"]);
+      expect(opts.type).toBe(type);
+      expect(opts.name).toBe("my_change");
+    }
+  });
+
+  it("returns empty type and name when no args", () => {
+    const opts = parseShowArgs([]);
+    expect(opts.type as string).toBe("");
+    expect(opts.name).toBe("");
+  });
+
+  it("returns empty name when only type given", () => {
+    const opts = parseShowArgs(["deploy"]);
+    expect(opts.name).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveScriptPath
+// ---------------------------------------------------------------------------
+
+describe("resolveScriptPath", () => {
+  it("resolves script path under topDir", () => {
+    const path = resolveScriptPath("/project", "deploy", "create_schema");
+    expect(path).toBe("/project/deploy/create_schema.sql");
+  });
+
+  it("handles nested script directories", () => {
+    const path = resolveScriptPath("/project", "migrations/deploy", "add_users");
+    expect(path).toBe("/project/migrations/deploy/add_users.sql");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readScript
+// ---------------------------------------------------------------------------
+
+describe("readScript", () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads an existing script file", () => {
+    const scriptPath = join(tmpDir, "test.sql");
+    writeFileSync(scriptPath, "SELECT 1;\n", "utf-8");
+    const content = readScript(scriptPath);
+    expect(content).toBe("SELECT 1;\n");
+  });
+
+  it("returns null for nonexistent file", () => {
+    const content = readScript(join(tmpDir, "nonexistent.sql"));
+    expect(content).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findChange
+// ---------------------------------------------------------------------------
+
+describe("findChange", () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds a change by name", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(planPath, PLAN_CONTENT, "utf-8");
+    const change = findChange(planPath, "create_schema");
+    expect(change).not.toBeNull();
+    expect(change!.name).toBe("create_schema");
+    expect(change!.planner_name).toBe("Test User");
+    expect(change!.planner_email).toBe("test@example.com");
+    expect(change!.note).toBe("Bootstrap schema");
+  });
+
+  it("finds a change with dependencies", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(planPath, PLAN_CONTENT, "utf-8");
+    const change = findChange(planPath, "add_users");
+    expect(change).not.toBeNull();
+    expect(change!.requires).toEqual(["create_schema"]);
+    expect(change!.note).toBe("Users table");
+  });
+
+  it("returns null for nonexistent change", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(planPath, PLAN_CONTENT, "utf-8");
+    const change = findChange(planPath, "nonexistent");
+    expect(change).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findTag
+// ---------------------------------------------------------------------------
+
+describe("findTag", () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds a tag by name (without @ prefix)", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(planPath, PLAN_CONTENT, "utf-8");
+    const tag = findTag(planPath, "v1.0");
+    expect(tag).not.toBeNull();
+    expect(tag!.name).toBe("v1.0");
+    expect(tag!.planner_name).toBe("Test User");
+    expect(tag!.note).toBe("First release");
+  });
+
+  it("returns null for nonexistent tag", () => {
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(planPath, PLAN_CONTENT, "utf-8");
+    const tag = findTag(planPath, "v2.0");
+    expect(tag).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatChange
+// ---------------------------------------------------------------------------
+
+describe("formatChange", () => {
+  it("formats change metadata with all fields", () => {
+    const firstId = computeChangeId({
+      project: "myproject",
+      change: "create_schema",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T10:30:00Z",
+      requires: [],
+      conflicts: [],
+      note: "Bootstrap schema",
+    });
+
+    const output = formatChange({
+      change_id: firstId,
+      name: "add_users",
+      project: "myproject",
+      note: "Users table",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T10:31:00Z",
+      requires: ["create_schema"],
+      conflicts: ["old_users"],
+      parent: firstId,
+    });
+
+    expect(output).toContain("Change:    add_users");
+    expect(output).toContain(`ID:        ${firstId}`);
+    expect(output).toContain("Project:   myproject");
+    expect(output).toContain("Planner:   Test User <test@example.com>");
+    expect(output).toContain("Planned:   2024-01-15T10:31:00Z");
+    expect(output).toContain(`Parent:    ${firstId}`);
+    expect(output).toContain("Requires:  create_schema");
+    expect(output).toContain("Conflicts: old_users");
+    expect(output).toContain("Note:      Users table");
+  });
+
+  it("omits optional fields when empty", () => {
+    const output = formatChange({
+      change_id: "abc123",
+      name: "first",
+      project: "myproject",
+      note: "",
+      planner_name: "Test",
+      planner_email: "t@t.com",
+      planned_at: "2024-01-01T00:00:00Z",
+      requires: [],
+      conflicts: [],
+    });
+
+    expect(output).not.toContain("Parent:");
+    expect(output).not.toContain("Requires:");
+    expect(output).not.toContain("Conflicts:");
+    expect(output).not.toContain("Note:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatTag
+// ---------------------------------------------------------------------------
+
+describe("formatTag", () => {
+  it("formats tag metadata with all fields", () => {
+    const output = formatTag({
+      tag_id: "tag123",
+      name: "v1.0",
+      project: "myproject",
+      change_id: "change123",
+      note: "First release",
+      planner_name: "Test User",
+      planner_email: "test@example.com",
+      planned_at: "2024-01-15T10:32:00Z",
+    });
+
+    expect(output).toContain("Tag:       @v1.0");
+    expect(output).toContain("ID:        tag123");
+    expect(output).toContain("Project:   myproject");
+    expect(output).toContain("Change:    change123");
+    expect(output).toContain("Planner:   Test User <test@example.com>");
+    expect(output).toContain("Planned:   2024-01-15T10:32:00Z");
+    expect(output).toContain("Note:      First release");
+  });
+
+  it("omits note when empty", () => {
+    const output = formatTag({
+      tag_id: "tag123",
+      name: "v1.0",
+      project: "myproject",
+      change_id: "change123",
+      note: "",
+      planner_name: "Test",
+      planner_email: "t@t.com",
+      planned_at: "2024-01-01T00:00:00Z",
+    });
+
+    expect(output).not.toContain("Note:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runShow — integration tests
+// ---------------------------------------------------------------------------
+
+describe("runShow", () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("errors on invalid show type", () => {
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      runShow({ type: "invalid" as any, name: "foo" });
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors when no name is provided", () => {
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      runShow({ type: "deploy", name: "" });
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors when deploy script not found", () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      runShow({ type: "deploy", name: "nonexistent", topDir: tmpDir }, cfg);
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors when change not found in plan", () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      runShow({ type: "change", name: "nonexistent", topDir: tmpDir }, cfg);
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("errors when tag not found in plan", () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+
+    try {
+      runShow({ type: "tag", name: "nonexistent", topDir: tmpDir }, cfg);
+    } catch {
+      // Expected
+    } finally {
+      process.exit = origExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("prints deploy script to stdout", () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    // Capture stdout
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      runShow(
+        { type: "deploy", name: "create_schema", topDir: tmpDir },
+        cfg,
+      );
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain("-- Deploy create_schema");
+    expect(output).toContain("CREATE SCHEMA app;");
+  });
+
+  it("prints revert script to stdout", () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      runShow(
+        { type: "revert", name: "create_schema", topDir: tmpDir },
+        cfg,
+      );
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain("-- Revert create_schema");
+    expect(output).toContain("DROP SCHEMA app;");
+  });
+
+  it("prints verify script to stdout", () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      runShow(
+        { type: "verify", name: "create_schema", topDir: tmpDir },
+        cfg,
+      );
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain("-- Verify create_schema");
+    expect(output).toContain("schema_name = 'app'");
+  });
+
+  it("prints change metadata to stdout", () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      runShow(
+        { type: "change", name: "add_users", topDir: tmpDir },
+        cfg,
+      );
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain("Change:    add_users");
+    expect(output).toContain("Requires:  create_schema");
+    expect(output).toContain("Note:      Users table");
+  });
+
+  it("prints tag metadata to stdout", () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      runShow(
+        { type: "tag", name: "v1.0", topDir: tmpDir },
+        cfg,
+      );
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain("Tag:       @v1.0");
+    expect(output).toContain("Note:      First release");
+    expect(output).toContain("Planner:   Test User <test@example.com>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI integration (subprocess)
+// ---------------------------------------------------------------------------
+
+describe("sqlever show (subprocess)", () => {
+  const CWD = import.meta.dir + "/../..";
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runCli(
+    ...args: string[]
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const proc = Bun.spawn(["bun", "run", join(CWD, "src/cli.ts"), ...args], {
+      cwd: tmpDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        SQLEVER_USER_NAME: "CLI Test",
+        SQLEVER_USER_EMAIL: "cli@test.com",
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("displays deploy script via CLI", async () => {
+    setupProject(tmpDir);
+    const { stdout, exitCode } = await runCli(
+      "show", "deploy", "create_schema",
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("-- Deploy create_schema");
+    expect(stdout).toContain("CREATE SCHEMA app;");
+  });
+
+  it("displays change metadata via CLI", async () => {
+    setupProject(tmpDir);
+    const { stdout, exitCode } = await runCli(
+      "show", "change", "add_users",
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Change:    add_users");
+    expect(stdout).toContain("Requires:  create_schema");
+  });
+
+  it("displays tag metadata via CLI", async () => {
+    setupProject(tmpDir);
+    const { stdout, exitCode } = await runCli(
+      "show", "tag", "v1.0",
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Tag:       @v1.0");
+    expect(stdout).toContain("First release");
+  });
+
+  it("exits 1 for missing script", async () => {
+    setupProject(tmpDir);
+    const { exitCode, stderr } = await runCli(
+      "show", "deploy", "nonexistent",
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("script not found");
+  });
+
+  it("exits 1 for missing change", async () => {
+    setupProject(tmpDir);
+    const { exitCode, stderr } = await runCli(
+      "show", "change", "nonexistent",
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("not found in plan");
+  });
+
+  it("exits 1 when no type is given", async () => {
+    setupProject(tmpDir);
+    const { exitCode, stderr } = await runCli("show");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("invalid show type");
+  });
+
+  it("exits 1 when no name is given", async () => {
+    setupProject(tmpDir);
+    const { exitCode, stderr } = await runCli("show", "deploy");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("name is required");
+  });
+
+  it("outputs JSON with --format json for deploy script", async () => {
+    setupProject(tmpDir);
+    const { stdout, exitCode } = await runCli(
+      "--format", "json", "show", "deploy", "create_schema",
+    );
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.type).toBe("deploy");
+    expect(parsed.name).toBe("create_schema");
+    expect(parsed.content).toContain("CREATE SCHEMA app;");
+    expect(parsed.path).toBeTruthy();
+  });
+
+  it("outputs JSON with --format json for change metadata", async () => {
+    setupProject(tmpDir);
+    const { stdout, exitCode } = await runCli(
+      "--format", "json", "show", "change", "add_users",
+    );
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.name).toBe("add_users");
+    expect(parsed.change_id).toBeTruthy();
+    expect(parsed.requires).toEqual(["create_schema"]);
+    expect(parsed.note).toBe("Users table");
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `sqlever show <type> <name>` where type is `deploy|revert|verify|change|tag`
- For script types (deploy/revert/verify), reads and prints the `.sql` file content
- For metadata types (change/tag), parses the plan and displays structured info (ID, planner, timestamps, dependencies, notes)
- Supports `--format json` for machine-readable output
- Wired into CLI dispatch; `show` is no longer a stub command

Closes #47

## Test plan
- [x] 36 tests in `tests/unit/show.test.ts` covering:
  - Argument parsing (type + name positional args, empty args)
  - Script path resolution and file reading
  - Change and tag lookup from parsed plan
  - Text formatters for change and tag metadata
  - Error handling (invalid type, missing name, missing script, missing change/tag)
  - Full integration: deploy/revert/verify script display, change/tag metadata display
  - CLI subprocess tests for all types plus error cases
  - JSON output mode for scripts and change metadata
- [x] Existing CLI tests updated (`show` removed from stub list)
- [x] Full test suite passes (736 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)