### PR TITLE
S4-6: sqlever plan — display plan contents

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { runRevert } from "./commands/revert";
 import { parseTagArgs, runTag } from "./commands/tag";
 import { parseReworkArgs, runRework } from "./commands/rework";
 import { parseShowArgs, runShow } from "./commands/show";
+import { runPlan } from "./commands/plan";
 
 // ---------------------------------------------------------------------------
 // Command registry — all commands from SPEC R1 plus sqlever extensions
@@ -363,6 +364,11 @@ export function main(argv: string[] = process.argv.slice(2)): void {
       process.stderr.write(`sqlever status: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exit(1);
     });
+    return;
+  }
+
+  if (args.command === "plan") {
+    runPlan(args);
     return;
   }
 

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -1,0 +1,285 @@
+// src/commands/plan.ts — sqlever plan command
+//
+// Displays the contents of a sqitch.plan file in a human-readable
+// format (text table or JSON). Supports optional filters by change
+// name (--change) or tag name (--tag).
+//
+// Implements GitHub issue #48 (S4-6).
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { ParsedArgs } from "../cli";
+import { parsePlan } from "../plan/parser";
+import type { Plan, Change, Tag } from "../plan/types";
+import { info, error, json, table, getConfig } from "../output";
+
+// ---------------------------------------------------------------------------
+// Plan-specific argument parsing
+// ---------------------------------------------------------------------------
+
+export interface PlanOptions {
+  /** Path to the plan file (resolved from --plan-file or default). */
+  planFile: string;
+  /** Filter changes to only those matching this name. */
+  change?: string;
+  /** Filter to show only changes up to and including this tag. */
+  tag?: string;
+}
+
+/**
+ * Parse plan-specific options from the CLI's parsed args.
+ *
+ * Usage: sqlever plan [--change <name>] [--tag <name>] [--plan-file <path>]
+ */
+export function parsePlanArgs(args: ParsedArgs): PlanOptions {
+  const topDir = args.topDir ?? ".";
+  let planFile = args.planFile ?? "sqitch.plan";
+  let change: string | undefined;
+  let tag: string | undefined;
+
+  const rest = args.rest;
+  let i = 0;
+  while (i < rest.length) {
+    const token = rest[i]!;
+
+    if (token === "--change") {
+      change = rest[++i];
+      i++;
+      continue;
+    }
+    if (token === "--tag") {
+      tag = rest[++i];
+      i++;
+      continue;
+    }
+    if (token === "--plan-file") {
+      planFile = rest[++i] ?? planFile;
+      i++;
+      continue;
+    }
+
+    // Unknown tokens are ignored (could be positional in the future)
+    i++;
+  }
+
+  // Resolve plan file relative to top-dir
+  const resolved = resolve(topDir, planFile);
+
+  return { planFile: resolved, change, tag };
+}
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a map from change_id to the tags attached to that change.
+ */
+function buildTagMap(tags: Tag[]): Map<string, Tag[]> {
+  const map = new Map<string, Tag[]>();
+  for (const tag of tags) {
+    const existing = map.get(tag.change_id);
+    if (existing) {
+      existing.push(tag);
+    } else {
+      map.set(tag.change_id, [tag]);
+    }
+  }
+  return map;
+}
+
+/**
+ * Filter plan changes and tags based on --change and --tag options.
+ *
+ * - --change <name>: Show only changes matching `name`.
+ * - --tag <name>: Show all changes up to and including the change
+ *   that the named tag is attached to.
+ *
+ * When both are specified, --tag determines the range and --change
+ * filters within that range.
+ */
+export function filterPlan(
+  plan: Plan,
+  opts: PlanOptions,
+): { changes: Change[]; tags: Tag[] } {
+  let { changes, tags } = plan;
+
+  // --tag: slice changes up to and including the tagged change
+  if (opts.tag) {
+    const matchingTag = tags.find((t) => t.name === opts.tag);
+    if (!matchingTag) {
+      return { changes: [], tags: [] };
+    }
+
+    const cutoffIdx = changes.findIndex(
+      (c) => c.change_id === matchingTag.change_id,
+    );
+    if (cutoffIdx === -1) {
+      return { changes: [], tags: [] };
+    }
+
+    changes = changes.slice(0, cutoffIdx + 1);
+    // Only include tags that reference changes in the sliced range
+    const changeIds = new Set(changes.map((c) => c.change_id));
+    tags = tags.filter((t) => changeIds.has(t.change_id));
+  }
+
+  // --change: filter to only changes with matching name
+  if (opts.change) {
+    changes = changes.filter((c) => c.name === opts.change);
+    // Only include tags attached to the filtered changes
+    const changeIds = new Set(changes.map((c) => c.change_id));
+    tags = tags.filter((t) => changeIds.has(t.change_id));
+  }
+
+  return { changes, tags };
+}
+
+// ---------------------------------------------------------------------------
+// Formatting — text output
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a dependency list for display.
+ * Requires: dep1, dep2
+ * Conflicts: !conflict1
+ */
+export function formatDeps(requires: string[], conflicts: string[]): string {
+  const parts: string[] = [];
+  for (const r of requires) {
+    parts.push(r);
+  }
+  for (const c of conflicts) {
+    parts.push(`!${c}`);
+  }
+  return parts.join(", ");
+}
+
+/**
+ * Format tag names for a given change_id.
+ */
+function formatTags(tagMap: Map<string, Tag[]>, changeId: string): string {
+  const changeTags = tagMap.get(changeId);
+  if (!changeTags || changeTags.length === 0) return "";
+  return changeTags.map((t) => `@${t.name}`).join(", ");
+}
+
+/**
+ * Print plan in text format to stdout.
+ */
+export function printPlanText(
+  plan: Plan,
+  changes: Change[],
+  tags: Tag[],
+): void {
+  const tagMap = buildTagMap(tags);
+
+  // Header: project info
+  info(`Project: ${plan.project.name}`);
+  if (plan.project.uri) {
+    info(`URI:     ${plan.project.uri}`);
+  }
+  info("");
+
+  if (changes.length === 0) {
+    info("No changes.");
+    return;
+  }
+
+  const headers = ["Name", "Deps", "Tags", "Planner", "Date", "Note"];
+  const rows: string[][] = [];
+
+  for (const c of changes) {
+    const deps = formatDeps(c.requires, c.conflicts);
+    const changeTags = formatTags(tagMap, c.change_id);
+    const date = c.planned_at.replace("T", " ").replace("Z", "");
+    const planner = `${c.planner_name} <${c.planner_email}>`;
+
+    rows.push([c.name, deps, changeTags, planner, date, c.note]);
+  }
+
+  table(rows, headers);
+}
+
+// ---------------------------------------------------------------------------
+// Formatting — JSON output
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the JSON-serializable representation of plan contents.
+ */
+export function buildPlanJson(
+  plan: Plan,
+  changes: Change[],
+  tags: Tag[],
+): object {
+  const tagMap = buildTagMap(tags);
+
+  return {
+    project: {
+      name: plan.project.name,
+      uri: plan.project.uri ?? null,
+    },
+    changes: changes.map((c) => ({
+      name: c.name,
+      change_id: c.change_id,
+      planned_at: c.planned_at,
+      planner_name: c.planner_name,
+      planner_email: c.planner_email,
+      note: c.note,
+      requires: c.requires,
+      conflicts: c.conflicts,
+      parent: c.parent ?? null,
+      tags: (tagMap.get(c.change_id) ?? []).map((t) => ({
+        name: t.name,
+        tag_id: t.tag_id,
+      })),
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main plan command
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `plan` command.
+ *
+ * Reads the plan file, applies filters, and displays the result
+ * in text or JSON format.
+ */
+export function runPlan(args: ParsedArgs): void {
+  const opts = parsePlanArgs(args);
+
+  // Read and parse plan file
+  let content: string;
+  try {
+    content = readFileSync(opts.planFile, "utf-8");
+  } catch {
+    error(`Error: cannot read plan file: ${opts.planFile}`);
+    process.exit(1);
+    return; // unreachable, for TypeScript
+  }
+
+  let plan: Plan;
+  try {
+    plan = parsePlan(content);
+  } catch (e) {
+    error(
+      `Error: failed to parse plan file: ${e instanceof Error ? e.message : String(e)}`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  // Apply filters
+  const { changes, tags } = filterPlan(plan, opts);
+
+  // Output
+  const config = getConfig();
+  if (config.format === "json") {
+    json(buildPlanJson(plan, changes, tags));
+  } else {
+    printPlanText(plan, changes, tags);
+  }
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -308,8 +308,8 @@ describe("unknown commands", () => {
 // ---------------------------------------------------------------------------
 
 describe("command stubs", () => {
-  // "help" is handled specially (not a stub), "init", "add", "log", "revert", "tag", "rework", "show", and "status" are implemented — exclude them
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log" && c !== "revert" && c !== "tag" && c !== "rework" && c !== "show" && c !== "status");
+  // "help" is handled specially (not a stub), "init", "add", "log", "revert", "tag", "rework", "show", "status", and "plan" are implemented — exclude them
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log" && c !== "revert" && c !== "tag" && c !== "rework" && c !== "show" && c !== "status" && c !== "plan");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {

--- a/tests/unit/plan-cmd.test.ts
+++ b/tests/unit/plan-cmd.test.ts
@@ -1,0 +1,573 @@
+// tests/unit/plan-cmd.test.ts — Tests for the `sqlever plan` command
+//
+// Validates parsePlanArgs(), filterPlan(), formatDeps(), buildPlanJson(),
+// printPlanText(), and the CLI subprocess integration.
+// Covers: argument parsing, filtering by --change and --tag, text output,
+// JSON output, error handling, and quiet mode.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { ParsedArgs } from "../../src/cli";
+import {
+  parsePlanArgs,
+  filterPlan,
+  formatDeps,
+  buildPlanJson,
+  printPlanText,
+} from "../../src/commands/plan";
+import type { PlanOptions } from "../../src/commands/plan";
+import { parsePlan } from "../../src/plan/parser";
+import type { Plan, Change, Tag } from "../../src/plan/types";
+import { resetConfig, setConfig } from "../../src/output";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CWD = import.meta.dir + "/../..";
+
+/** Build a minimal ParsedArgs, overriding specific fields. */
+function makeArgs(overrides: Partial<ParsedArgs> = {}): ParsedArgs {
+  return {
+    command: "plan",
+    rest: [],
+    help: false,
+    version: false,
+    format: "text",
+    quiet: false,
+    verbose: false,
+    dbUri: undefined,
+    planFile: undefined,
+    topDir: undefined,
+    registry: undefined,
+    target: undefined,
+    ...overrides,
+  };
+}
+
+/** Build a minimal valid plan string. */
+function minimalPlan(lines: string[] = []): string {
+  return [
+    "%syntax-version=1.0.0",
+    "%project=testproject",
+    "",
+    ...lines,
+  ].join("\n");
+}
+
+/** Plan with URI and some changes/tags for filtering tests. */
+function complexPlan(): string {
+  return [
+    "%syntax-version=1.0.0",
+    "%project=myproject",
+    "%uri=https://example.com/",
+    "",
+    "create_schema 2024-01-01T00:00:00Z Dev <dev@example.com> # Create schema",
+    "add_users [create_schema] 2024-01-02T00:00:00Z Dev <dev@example.com> # Add users table",
+    "add_posts [add_users] 2024-01-03T00:00:00Z Dev <dev@example.com> # Add posts table",
+    "@v1.0 2024-01-03T00:01:00Z Dev <dev@example.com> # Version 1.0",
+    "add_users [add_users@v1.0] 2024-02-01T00:00:00Z Dev <dev@example.com> # Rework users with email validation",
+    "@v2.0 2024-02-01T00:01:00Z Dev <dev@example.com> # Version 2.0",
+  ].join("\n");
+}
+
+/** Create a fresh temp directory for each test. */
+async function makeTempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "sqlever-plan-test-"));
+}
+
+/** Spawn the CLI and capture output. */
+async function run(
+  ...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
+    cwd: CWD,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: parsePlanArgs (unit, no filesystem)
+// ---------------------------------------------------------------------------
+
+describe("parsePlanArgs", () => {
+  test("defaults: plan file resolved from cwd/sqitch.plan", () => {
+    const args = makeArgs();
+    const opts = parsePlanArgs(args);
+    expect(opts.planFile).toBe(resolve("sqitch.plan"));
+    expect(opts.change).toBeUndefined();
+    expect(opts.tag).toBeUndefined();
+  });
+
+  test("--change flag parsed from rest", () => {
+    const args = makeArgs({ rest: ["--change", "add_users"] });
+    const opts = parsePlanArgs(args);
+    expect(opts.change).toBe("add_users");
+  });
+
+  test("--tag flag parsed from rest", () => {
+    const args = makeArgs({ rest: ["--tag", "v1.0"] });
+    const opts = parsePlanArgs(args);
+    expect(opts.tag).toBe("v1.0");
+  });
+
+  test("--plan-file in rest overrides global", () => {
+    const args = makeArgs({
+      planFile: "global.plan",
+      rest: ["--plan-file", "local.plan"],
+    });
+    const opts = parsePlanArgs(args);
+    expect(opts.planFile).toContain("local.plan");
+  });
+
+  test("global --plan-file used when not in rest", () => {
+    const args = makeArgs({ planFile: "custom.plan" });
+    const opts = parsePlanArgs(args);
+    expect(opts.planFile).toContain("custom.plan");
+  });
+
+  test("--top-dir affects plan file resolution", () => {
+    const args = makeArgs({ topDir: "/my/project" });
+    const opts = parsePlanArgs(args);
+    expect(opts.planFile).toBe("/my/project/sqitch.plan");
+  });
+
+  test("both --change and --tag can be set", () => {
+    const args = makeArgs({
+      rest: ["--change", "add_users", "--tag", "v1.0"],
+    });
+    const opts = parsePlanArgs(args);
+    expect(opts.change).toBe("add_users");
+    expect(opts.tag).toBe("v1.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: formatDeps (unit)
+// ---------------------------------------------------------------------------
+
+describe("formatDeps", () => {
+  test("empty deps returns empty string", () => {
+    expect(formatDeps([], [])).toBe("");
+  });
+
+  test("requires only", () => {
+    expect(formatDeps(["dep1", "dep2"], [])).toBe("dep1, dep2");
+  });
+
+  test("conflicts only", () => {
+    expect(formatDeps([], ["old_thing"])).toBe("!old_thing");
+  });
+
+  test("mixed requires and conflicts", () => {
+    expect(formatDeps(["dep1"], ["old_thing"])).toBe("dep1, !old_thing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: filterPlan (unit)
+// ---------------------------------------------------------------------------
+
+describe("filterPlan", () => {
+  let plan: Plan;
+
+  beforeEach(() => {
+    plan = parsePlan(complexPlan());
+  });
+
+  test("no filters returns all changes and tags", () => {
+    const opts: PlanOptions = { planFile: "sqitch.plan" };
+    const result = filterPlan(plan, opts);
+    expect(result.changes).toHaveLength(4);
+    expect(result.tags).toHaveLength(2);
+  });
+
+  test("--change filters to matching changes only", () => {
+    const opts: PlanOptions = { planFile: "sqitch.plan", change: "add_users" };
+    const result = filterPlan(plan, opts);
+    // There are two add_users changes (original + rework)
+    expect(result.changes).toHaveLength(2);
+    for (const c of result.changes) {
+      expect(c.name).toBe("add_users");
+    }
+  });
+
+  test("--change with nonexistent name returns empty", () => {
+    const opts: PlanOptions = {
+      planFile: "sqitch.plan",
+      change: "nonexistent",
+    };
+    const result = filterPlan(plan, opts);
+    expect(result.changes).toHaveLength(0);
+    expect(result.tags).toHaveLength(0);
+  });
+
+  test("--tag filters changes up to tagged change", () => {
+    const opts: PlanOptions = { planFile: "sqitch.plan", tag: "v1.0" };
+    const result = filterPlan(plan, opts);
+    // v1.0 is attached to add_posts (3rd change), so should include first 3
+    expect(result.changes).toHaveLength(3);
+    expect(result.changes[0]!.name).toBe("create_schema");
+    expect(result.changes[1]!.name).toBe("add_users");
+    expect(result.changes[2]!.name).toBe("add_posts");
+    // Only v1.0 tag should be included (v2.0 is outside range)
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0]!.name).toBe("v1.0");
+  });
+
+  test("--tag with nonexistent tag returns empty", () => {
+    const opts: PlanOptions = { planFile: "sqitch.plan", tag: "nonexistent" };
+    const result = filterPlan(plan, opts);
+    expect(result.changes).toHaveLength(0);
+    expect(result.tags).toHaveLength(0);
+  });
+
+  test("--tag and --change combined: tag sets range, change filters", () => {
+    const opts: PlanOptions = {
+      planFile: "sqitch.plan",
+      tag: "v1.0",
+      change: "add_users",
+    };
+    const result = filterPlan(plan, opts);
+    // v1.0 limits to first 3 changes, then filter by name "add_users"
+    // Only the original add_users (2nd change) should match
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]!.name).toBe("add_users");
+  });
+
+  test("--change filters tags to only those on matching changes", () => {
+    const opts: PlanOptions = {
+      planFile: "sqitch.plan",
+      change: "create_schema",
+    };
+    const result = filterPlan(plan, opts);
+    expect(result.changes).toHaveLength(1);
+    // create_schema has no tags attached to it
+    expect(result.tags).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildPlanJson (unit)
+// ---------------------------------------------------------------------------
+
+describe("buildPlanJson", () => {
+  test("produces correct JSON structure", () => {
+    const plan = parsePlan(complexPlan());
+    const result = buildPlanJson(plan, plan.changes, plan.tags) as {
+      project: { name: string; uri: string | null };
+      changes: Array<{
+        name: string;
+        change_id: string;
+        tags: Array<{ name: string; tag_id: string }>;
+        requires: string[];
+        conflicts: string[];
+        parent: string | null;
+      }>;
+    };
+
+    expect(result.project.name).toBe("myproject");
+    expect(result.project.uri).toBe("https://example.com/");
+    expect(result.changes).toHaveLength(4);
+
+    // First change has no parent
+    expect(result.changes[0]!.parent).toBeNull();
+    expect(result.changes[0]!.name).toBe("create_schema");
+
+    // Third change (add_posts) has v1.0 tag
+    const addPosts = result.changes[2]!;
+    expect(addPosts.tags).toHaveLength(1);
+    expect(addPosts.tags[0]!.name).toBe("v1.0");
+  });
+
+  test("null uri when project has no URI", () => {
+    const plan = parsePlan(minimalPlan([
+      "first 2024-01-15T10:30:00Z A <a@b.com> # note",
+    ]));
+    const result = buildPlanJson(plan, plan.changes, plan.tags) as {
+      project: { uri: string | null };
+    };
+    expect(result.project.uri).toBeNull();
+  });
+
+  test("includes requires and conflicts in change entries", () => {
+    const plan = parsePlan(complexPlan());
+    const result = buildPlanJson(plan, plan.changes, plan.tags) as {
+      changes: Array<{ requires: string[]; conflicts: string[] }>;
+    };
+
+    // Second change (add_users) requires create_schema
+    expect(result.changes[1]!.requires).toEqual(["create_schema"]);
+    expect(result.changes[1]!.conflicts).toEqual([]);
+  });
+
+  test("empty changes array when no changes", () => {
+    const plan = parsePlan(minimalPlan());
+    const result = buildPlanJson(plan, [], []) as {
+      changes: unknown[];
+    };
+    expect(result.changes).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: printPlanText (unit, capturing stdout)
+// ---------------------------------------------------------------------------
+
+describe("printPlanText", () => {
+  beforeEach(() => {
+    resetConfig();
+  });
+
+  test("prints project header", () => {
+    const plan = parsePlan(complexPlan());
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      chunks.push(String(chunk));
+      return true;
+    };
+
+    try {
+      printPlanText(plan, plan.changes, plan.tags);
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain("Project: myproject");
+    expect(output).toContain("URI:     https://example.com/");
+  });
+
+  test("prints 'No changes.' when changes array is empty", () => {
+    const plan = parsePlan(minimalPlan());
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      chunks.push(String(chunk));
+      return true;
+    };
+
+    try {
+      printPlanText(plan, [], []);
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain("No changes.");
+  });
+
+  test("prints table with change names", () => {
+    const plan = parsePlan(complexPlan());
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      chunks.push(String(chunk));
+      return true;
+    };
+
+    try {
+      printPlanText(plan, plan.changes, plan.tags);
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain("create_schema");
+    expect(output).toContain("add_users");
+    expect(output).toContain("add_posts");
+    // Table headers
+    expect(output).toContain("Name");
+    expect(output).toContain("Deps");
+    expect(output).toContain("Tags");
+  });
+
+  test("quiet mode suppresses all output", () => {
+    setConfig({ quiet: true });
+    const plan = parsePlan(complexPlan());
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      chunks.push(String(chunk));
+      return true;
+    };
+
+    try {
+      printPlanText(plan, plan.changes, plan.tags);
+    } finally {
+      process.stdout.write = origWrite;
+      resetConfig();
+    }
+
+    const output = chunks.join("");
+    expect(output).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: CLI subprocess integration
+// ---------------------------------------------------------------------------
+
+describe("sqlever plan (subprocess)", () => {
+  let tempDir: string;
+  let planPath: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+    planPath = join(tempDir, "sqitch.plan");
+    resetConfig();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("displays plan contents and exits 0", async () => {
+    await writeFile(planPath, complexPlan(), "utf-8");
+
+    const { stdout, exitCode } = await run(
+      "plan",
+      "--plan-file",
+      planPath,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Project: myproject");
+    expect(stdout).toContain("create_schema");
+    expect(stdout).toContain("add_users");
+    expect(stdout).toContain("add_posts");
+  });
+
+  test("--format json outputs valid JSON", async () => {
+    await writeFile(planPath, complexPlan(), "utf-8");
+
+    const { stdout, exitCode } = await run(
+      "--format",
+      "json",
+      "plan",
+      "--plan-file",
+      planPath,
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.project.name).toBe("myproject");
+    expect(data.changes).toHaveLength(4);
+    expect(data.changes[0].name).toBe("create_schema");
+  });
+
+  test("--change filter works via CLI", async () => {
+    await writeFile(planPath, complexPlan(), "utf-8");
+
+    const { stdout, exitCode } = await run(
+      "--format",
+      "json",
+      "plan",
+      "--plan-file",
+      planPath,
+      "--change",
+      "create_schema",
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.changes).toHaveLength(1);
+    expect(data.changes[0].name).toBe("create_schema");
+  });
+
+  test("--tag filter works via CLI", async () => {
+    await writeFile(planPath, complexPlan(), "utf-8");
+
+    const { stdout, exitCode } = await run(
+      "--format",
+      "json",
+      "plan",
+      "--plan-file",
+      planPath,
+      "--tag",
+      "v1.0",
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data.changes).toHaveLength(3);
+  });
+
+  test("nonexistent plan file exits 1 with error", async () => {
+    const { stderr, exitCode } = await run(
+      "plan",
+      "--plan-file",
+      join(tempDir, "nope.plan"),
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("cannot read plan file");
+  });
+
+  test("--quiet suppresses text output", async () => {
+    await writeFile(planPath, complexPlan(), "utf-8");
+
+    const { stdout, exitCode } = await run(
+      "--quiet",
+      "plan",
+      "--plan-file",
+      planPath,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+  });
+
+  test("empty plan shows 'No changes.'", async () => {
+    await writeFile(planPath, minimalPlan(), "utf-8");
+
+    const { stdout, exitCode } = await run(
+      "plan",
+      "--plan-file",
+      planPath,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("No changes.");
+  });
+
+  test("JSON output includes tags on changes", async () => {
+    await writeFile(planPath, complexPlan(), "utf-8");
+
+    const { stdout, exitCode } = await run(
+      "--format",
+      "json",
+      "plan",
+      "--plan-file",
+      planPath,
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    // add_posts (index 2) should have v1.0 tag
+    const addPosts = data.changes[2];
+    expect(addPosts.tags).toHaveLength(1);
+    expect(addPosts.tags[0].name).toBe("v1.0");
+    // reworked add_users (index 3) should have v2.0 tag
+    const reworked = data.changes[3];
+    expect(reworked.tags).toHaveLength(1);
+    expect(reworked.tags[0].name).toBe("v2.0");
+  });
+
+  test("text output shows deps and tags columns", async () => {
+    await writeFile(planPath, complexPlan(), "utf-8");
+
+    const { stdout, exitCode } = await run(
+      "plan",
+      "--plan-file",
+      planPath,
+    );
+    expect(exitCode).toBe(0);
+    // Check that dependency info appears
+    expect(stdout).toContain("create_schema");
+    // Check that tag info appears (the @v1.0 tag)
+    expect(stdout).toContain("@v1.0");
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `sqlever plan` command that reads and displays sqitch.plan file contents in human-readable table format
- Support `--format json` for structured JSON output with project info, changes, deps, tags, and parent links
- Support `--change <name>` filter to show only matching changes and `--tag <name>` filter to show changes up to a tagged point
- Wire the plan command into the CLI dispatcher (no longer a stub)

Closes #48

## Test plan
- [x] 35 tests in `tests/unit/plan-cmd.test.ts` covering:
  - Argument parsing (`parsePlanArgs`): defaults, `--change`, `--tag`, `--plan-file`, `--top-dir`
  - Dependency formatting (`formatDeps`): empty, requires-only, conflicts-only, mixed
  - Filtering (`filterPlan`): no filters, `--change`, `--tag`, combined, nonexistent values
  - JSON output (`buildPlanJson`): structure, null URI, requires/conflicts, empty plan
  - Text output (`printPlanText`): project header, "No changes.", table content, quiet mode
  - CLI subprocess tests: text output, JSON output, `--change` filter, `--tag` filter, missing file error, `--quiet`, empty plan, tag/dep columns
- [x] All 735 existing tests still pass (no regressions)

Generated with [Claude Code](https://claude.com/claude-code)