### PR TITLE
S4-2: sqlever status — show deployment status

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 
 import packageJson from "../package.json";
 import { runInit } from "./commands/init";
+import { runStatus } from "./commands/status";
 import { setConfig, type OutputFormat } from "./output";
 import { parseAddArgs, runAdd } from "./commands/add";
 import { runLogCommand } from "./commands/log";
@@ -354,6 +355,14 @@ export function main(argv: string[] = process.argv.slice(2)): void {
       process.stderr.write(`sqlever show: ${msg}\n`);
       process.exit(1);
     }
+    return;
+  }
+
+  if (args.command === "status") {
+    runStatus(args).catch((err: unknown) => {
+      process.stderr.write(`sqlever status: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
     return;
   }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,331 @@
+// src/commands/status.ts — sqlever status command
+//
+// Shows deployment status: pending count, deployed count, last deployed
+// change, target info, and modified script detection (script_hash comparison).
+//
+// Supports --format json for machine-readable output.
+//
+// Implements S4-2 (GitHub issue #44).
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { loadConfig, type MergedConfig } from "../config/index";
+import { parsePlan } from "../plan/parser";
+import { computeScriptHash, type Plan } from "../plan/types";
+import type { Change as RegistryChange } from "../db/registry";
+import { info, error, json as jsonOut } from "../output";
+import type { ParsedArgs } from "../cli";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A script whose on-disk hash no longer matches the deployed script_hash. */
+export interface ModifiedScript {
+  /** Change name. */
+  change: string;
+  /** Change ID. */
+  change_id: string;
+  /** Hash stored in the registry (from deployment time). */
+  registry_hash: string;
+  /** Current hash of the on-disk deploy script. */
+  current_hash: string;
+}
+
+/** Full status result used for both text and JSON output. */
+export interface StatusResult {
+  /** Project name from the plan. */
+  project: string;
+  /** Target URI or name (if available). */
+  target: string | null;
+  /** Number of changes already deployed. */
+  deployed_count: number;
+  /** Number of changes in the plan not yet deployed. */
+  pending_count: number;
+  /** Names of pending changes, in plan order. */
+  pending_changes: string[];
+  /** Last deployed change info, or null if none deployed. */
+  last_deployed: {
+    change: string;
+    change_id: string;
+    committed_at: string;
+    committer_name: string;
+  } | null;
+  /** Scripts modified since deployment (script_hash mismatch). */
+  modified_scripts: ModifiedScript[];
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface StatusOptions {
+  /** Project root directory. */
+  topDir: string;
+  /** Format: "text" or "json". */
+  format: "text" | "json";
+  /** Database URI override. */
+  dbUri?: string;
+  /** Target name override. */
+  target?: string;
+  /** Plan file override. */
+  planFile?: string;
+}
+
+/**
+ * Parse status-specific options from CLI parsed args.
+ */
+export function parseStatusOptions(args: ParsedArgs): StatusOptions {
+  return {
+    topDir: args.topDir ?? ".",
+    format: args.format,
+    dbUri: args.dbUri,
+    target: args.target,
+    planFile: args.planFile,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core logic (pure, testable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the target URI string from config and CLI overrides.
+ *
+ * Priority:
+ *   1. --db-uri flag
+ *   2. --target flag => look up in config targets
+ *   3. Default engine target from config
+ *   4. null (no target configured)
+ */
+export function resolveTargetUri(
+  config: MergedConfig,
+  dbUri?: string,
+  targetName?: string,
+): string | null {
+  // 1. Explicit --db-uri
+  if (dbUri) return dbUri;
+
+  // 2. Explicit --target => look up in config
+  if (targetName) {
+    const t = config.targets[targetName];
+    if (t?.uri) return t.uri;
+    // Target name might itself be a URI
+    if (targetName.includes("://")) return targetName;
+    return null;
+  }
+
+  // 3. Default engine target
+  const engineName = config.core.engine;
+  if (engineName) {
+    const engine = config.engines[engineName];
+    if (engine?.target) {
+      // engine.target could be a target name or URI
+      const t = config.targets[engine.target];
+      if (t?.uri) return t.uri;
+      if (engine.target.includes("://")) return engine.target;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Compute deployment status by comparing a plan against deployed changes.
+ *
+ * This is the pure, side-effect-free core of the status command.
+ * It takes already-loaded data and returns a StatusResult.
+ */
+export function computeStatus(
+  plan: Plan,
+  deployedChanges: RegistryChange[],
+  targetUri: string | null,
+  deployDir: string,
+): StatusResult {
+  const deployedIds = new Set(deployedChanges.map((c) => c.change_id));
+  const deployedMap = new Map(
+    deployedChanges.map((c) => [c.change_id, c]),
+  );
+
+  // Pending = plan changes not yet deployed
+  const pendingPlanChanges = plan.changes.filter(
+    (c) => !deployedIds.has(c.change_id),
+  );
+
+  // Last deployed change = most recent committed_at among deployed
+  let lastDeployed: StatusResult["last_deployed"] = null;
+  if (deployedChanges.length > 0) {
+    const last = deployedChanges[deployedChanges.length - 1]!;
+    lastDeployed = {
+      change: last.change,
+      change_id: last.change_id,
+      committed_at:
+        last.committed_at instanceof Date
+          ? last.committed_at.toISOString()
+          : String(last.committed_at),
+      committer_name: last.committer_name,
+    };
+  }
+
+  // Modified script detection: compare script_hash for deployed changes
+  const modifiedScripts: ModifiedScript[] = [];
+  for (const planChange of plan.changes) {
+    const deployed = deployedMap.get(planChange.change_id);
+    if (!deployed || !deployed.script_hash) continue;
+
+    const scriptPath = join(deployDir, `${planChange.name}.sql`);
+    if (!existsSync(scriptPath)) continue;
+
+    try {
+      const currentHash = computeScriptHash(scriptPath);
+      if (currentHash !== deployed.script_hash) {
+        modifiedScripts.push({
+          change: planChange.name,
+          change_id: planChange.change_id,
+          registry_hash: deployed.script_hash,
+          current_hash: currentHash,
+        });
+      }
+    } catch {
+      // Can't read file — skip
+    }
+  }
+
+  return {
+    project: plan.project.name,
+    target: targetUri,
+    deployed_count: deployedChanges.length,
+    pending_count: pendingPlanChanges.length,
+    pending_changes: pendingPlanChanges.map((c) => c.name),
+    last_deployed: lastDeployed,
+    modified_scripts: modifiedScripts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Text formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a StatusResult as human-readable text lines.
+ */
+export function formatStatusText(result: StatusResult): string {
+  const lines: string[] = [];
+
+  lines.push(`# Project: ${result.project}`);
+
+  if (result.target) {
+    lines.push(`# Target:  ${result.target}`);
+  }
+
+  lines.push("");
+
+  if (result.last_deployed) {
+    lines.push(`# Last deployed change:`);
+    lines.push(`#   ${result.last_deployed.change}`);
+    lines.push(`#   deployed at: ${result.last_deployed.committed_at}`);
+    lines.push(`#   by: ${result.last_deployed.committer_name}`);
+    lines.push("");
+  }
+
+  lines.push(`Deployed: ${result.deployed_count}`);
+  lines.push(`Pending:  ${result.pending_count}`);
+
+  if (result.pending_changes.length > 0) {
+    lines.push("");
+    lines.push("Pending changes:");
+    for (const name of result.pending_changes) {
+      lines.push(`  * ${name}`);
+    }
+  }
+
+  if (result.modified_scripts.length > 0) {
+    lines.push("");
+    lines.push("Modified scripts (hash mismatch):");
+    for (const mod of result.modified_scripts) {
+      lines.push(`  ! ${mod.change}`);
+    }
+  }
+
+  if (
+    result.pending_count === 0 &&
+    result.modified_scripts.length === 0
+  ) {
+    lines.push("");
+    lines.push("Nothing to deploy. Everything is up-to-date.");
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main command runner (side-effectful: reads files, connects to DB)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the status command.
+ *
+ * Loads plan from disk, connects to the database to read deployed changes,
+ * then computes and prints the status.
+ */
+export async function runStatus(args: ParsedArgs): Promise<void> {
+  const options = parseStatusOptions(args);
+  const topDir = resolve(options.topDir);
+
+  // Load config
+  const config = loadConfig(topDir);
+
+  // Resolve target
+  const targetUri = resolveTargetUri(config, options.dbUri, options.target);
+
+  // Read the plan file
+  const planFilePath = options.planFile
+    ? resolve(options.planFile)
+    : join(topDir, config.core.plan_file);
+
+  if (!existsSync(planFilePath)) {
+    error(`Plan file not found: ${planFilePath}`);
+    error("Run 'sqlever init' to initialize a project.");
+    process.exit(1);
+  }
+
+  const planContent = readFileSync(planFilePath, "utf-8");
+  const plan = parsePlan(planContent);
+
+  // If no target URI, show status without DB info (plan-only mode)
+  if (!targetUri) {
+    const result = computeStatus(plan, [], null, join(topDir, config.core.deploy_dir));
+    if (options.format === "json") {
+      jsonOut(result);
+    } else {
+      info(formatStatusText(result));
+    }
+    return;
+  }
+
+  // Connect to database and read deployed changes
+  const { DatabaseClient } = await import("../db/client");
+  const { Registry } = await import("../db/registry");
+
+  const client = new DatabaseClient(targetUri, {
+    command: "status",
+    project: plan.project.name,
+  });
+  await client.connect();
+
+  try {
+    const registry = new Registry(client);
+    const deployedChanges = await registry.getDeployedChanges(plan.project.name);
+
+    const deployDir = join(topDir, config.core.deploy_dir);
+    const result = computeStatus(plan, deployedChanges, targetUri, deployDir);
+
+    if (options.format === "json") {
+      jsonOut(result);
+    } else {
+      info(formatStatusText(result));
+    }
+  } finally {
+    await client.disconnect();
+  }
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -308,8 +308,8 @@ describe("unknown commands", () => {
 // ---------------------------------------------------------------------------
 
 describe("command stubs", () => {
-  // "help" is handled specially (not a stub), "init", "add", "log", "revert", "tag", "rework", and "show" are implemented — exclude them
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log" && c !== "revert" && c !== "tag" && c !== "rework" && c !== "show");
+  // "help" is handled specially (not a stub), "init", "add", "log", "revert", "tag", "rework", "show", and "status" are implemented — exclude them
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "log" && c !== "revert" && c !== "tag" && c !== "rework" && c !== "show" && c !== "status");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {
@@ -328,25 +328,25 @@ describe("output module integration", () => {
   test("--quiet flag is accepted without error", async () => {
     // --quiet with a stub command should still exit 1 (stub) but not
     // crash due to flag parsing
-    const { stderr, exitCode } = await run("--quiet", "status");
+    const { stderr, exitCode } = await run("--quiet", "deploy");
     expect(exitCode).toBe(1);
     expect(stderr).toContain("not yet implemented");
   });
 
   test("--verbose flag is accepted without error", async () => {
-    const { stderr, exitCode } = await run("--verbose", "status");
+    const { stderr, exitCode } = await run("--verbose", "deploy");
     expect(exitCode).toBe(1);
     expect(stderr).toContain("not yet implemented");
   });
 
   test("--format json is accepted without error", async () => {
-    const { stderr, exitCode } = await run("--format", "json", "status");
+    const { stderr, exitCode } = await run("--format", "json", "deploy");
     expect(exitCode).toBe(1);
     expect(stderr).toContain("not yet implemented");
   });
 
   test("--format invalid value exits 1 with error", async () => {
-    const { stderr, exitCode } = await run("--format", "xml", "status");
+    const { stderr, exitCode } = await run("--format", "xml", "deploy");
     expect(exitCode).toBe(1);
     expect(stderr).toContain("invalid --format");
   });
@@ -361,29 +361,29 @@ describe("global option flags", () => {
     const { stderr, exitCode } = await run(
       "--db-uri",
       "postgresql://localhost/mydb",
-      "status",
+      "deploy",
     );
     expect(exitCode).toBe(1);
     expect(stderr).toContain("not yet implemented");
   });
 
   test("--plan-file is accepted", async () => {
-    const { exitCode } = await run("--plan-file", "my.plan", "status");
+    const { exitCode } = await run("--plan-file", "my.plan", "deploy");
     expect(exitCode).toBe(1);
   });
 
   test("--top-dir is accepted", async () => {
-    const { exitCode } = await run("--top-dir", "/some/path", "status");
+    const { exitCode } = await run("--top-dir", "/some/path", "deploy");
     expect(exitCode).toBe(1);
   });
 
   test("--registry is accepted", async () => {
-    const { exitCode } = await run("--registry", "_sqitch", "status");
+    const { exitCode } = await run("--registry", "_sqitch", "deploy");
     expect(exitCode).toBe(1);
   });
 
   test("--target is accepted", async () => {
-    const { exitCode } = await run("--target", "production", "status");
+    const { exitCode } = await run("--target", "production", "deploy");
     expect(exitCode).toBe(1);
   });
 });

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -1,0 +1,725 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import {
+  computeStatus,
+  formatStatusText,
+  resolveTargetUri,
+  parseStatusOptions,
+  type StatusResult,
+} from "../../src/commands/status";
+import type { Plan } from "../../src/plan/types";
+import type { Change as RegistryChange } from "../../src/db/registry";
+import type { MergedConfig } from "../../src/config/index";
+import type { ParsedArgs } from "../../src/cli";
+import { resetConfig } from "../../src/output";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal ParsedArgs for status, overriding specific fields. */
+function makeArgs(overrides: Partial<ParsedArgs> = {}): ParsedArgs {
+  return {
+    command: "status",
+    rest: [],
+    help: false,
+    version: false,
+    format: "text",
+    quiet: false,
+    verbose: false,
+    dbUri: undefined,
+    planFile: undefined,
+    topDir: undefined,
+    registry: undefined,
+    target: undefined,
+    ...overrides,
+  };
+}
+
+/** Build a minimal plan with the given changes. */
+function makePlan(
+  projectName: string,
+  changes: Array<{ name: string; change_id: string }>,
+): Plan {
+  return {
+    project: { name: projectName },
+    pragmas: new Map([
+      ["syntax-version", "1.0.0"],
+      ["project", projectName],
+    ]),
+    changes: changes.map((c) => ({
+      change_id: c.change_id,
+      name: c.name,
+      project: projectName,
+      note: "",
+      planner_name: "Test",
+      planner_email: "test@test.com",
+      planned_at: "2024-01-01T00:00:00Z",
+      requires: [],
+      conflicts: [],
+    })),
+    tags: [],
+  };
+}
+
+/** Build a minimal registry Change record. */
+function makeRegistryChange(
+  name: string,
+  change_id: string,
+  overrides: Partial<RegistryChange> = {},
+): RegistryChange {
+  return {
+    change_id,
+    script_hash: null,
+    change: name,
+    project: "myproject",
+    note: "",
+    committed_at: new Date("2024-01-15T10:30:00Z"),
+    committer_name: "Deployer",
+    committer_email: "deploy@test.com",
+    planned_at: new Date("2024-01-01T00:00:00Z"),
+    planner_name: "Test",
+    planner_email: "test@test.com",
+    ...overrides,
+  };
+}
+
+/** Build a minimal MergedConfig for resolveTargetUri tests. */
+function makeConfig(overrides: Partial<MergedConfig> = {}): MergedConfig {
+  return {
+    core: {
+      engine: "pg",
+      top_dir: ".",
+      deploy_dir: "deploy",
+      revert_dir: "revert",
+      verify_dir: "verify",
+      plan_file: "sqitch.plan",
+    },
+    deploy: {
+      verify: true,
+      mode: "change",
+      lock_retries: 0,
+      lock_timeout: "5s",
+      idle_in_transaction_session_timeout: "10min",
+    },
+    engines: {},
+    targets: {},
+    analysis: {},
+    sqitchConf: { entries: [], rawLines: [] },
+    sqleverToml: null,
+    ...overrides,
+  };
+}
+
+/** Compute SHA-1 of a buffer (matches computeScriptHash behavior). */
+function sha1(content: string): string {
+  return createHash("sha1").update(Buffer.from(content, "utf-8")).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: parseStatusOptions
+// ---------------------------------------------------------------------------
+
+describe("parseStatusOptions", () => {
+  test("defaults to topDir='.', format='text', no overrides", () => {
+    const opts = parseStatusOptions(makeArgs());
+    expect(opts.topDir).toBe(".");
+    expect(opts.format).toBe("text");
+    expect(opts.dbUri).toBeUndefined();
+    expect(opts.target).toBeUndefined();
+    expect(opts.planFile).toBeUndefined();
+  });
+
+  test("passes through topDir, format, dbUri, target, planFile", () => {
+    const opts = parseStatusOptions(
+      makeArgs({
+        topDir: "/my/project",
+        format: "json",
+        dbUri: "postgresql://host/db",
+        target: "prod",
+        planFile: "custom.plan",
+      }),
+    );
+    expect(opts.topDir).toBe("/my/project");
+    expect(opts.format).toBe("json");
+    expect(opts.dbUri).toBe("postgresql://host/db");
+    expect(opts.target).toBe("prod");
+    expect(opts.planFile).toBe("custom.plan");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: resolveTargetUri
+// ---------------------------------------------------------------------------
+
+describe("resolveTargetUri", () => {
+  test("returns --db-uri when provided", () => {
+    const config = makeConfig();
+    const result = resolveTargetUri(config, "postgresql://host/db");
+    expect(result).toBe("postgresql://host/db");
+  });
+
+  test("--db-uri takes precedence over --target", () => {
+    const config = makeConfig({
+      targets: { prod: { name: "prod", uri: "postgresql://prod/db" } },
+    });
+    const result = resolveTargetUri(
+      config,
+      "postgresql://override/db",
+      "prod",
+    );
+    expect(result).toBe("postgresql://override/db");
+  });
+
+  test("looks up --target name in config targets", () => {
+    const config = makeConfig({
+      targets: { prod: { name: "prod", uri: "postgresql://prod/db" } },
+    });
+    const result = resolveTargetUri(config, undefined, "prod");
+    expect(result).toBe("postgresql://prod/db");
+  });
+
+  test("treats --target as URI if it contains ://", () => {
+    const config = makeConfig();
+    const result = resolveTargetUri(
+      config,
+      undefined,
+      "postgresql://inline/db",
+    );
+    expect(result).toBe("postgresql://inline/db");
+  });
+
+  test("returns null for unknown --target name without ://", () => {
+    const config = makeConfig();
+    const result = resolveTargetUri(config, undefined, "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("falls back to default engine target", () => {
+    const config = makeConfig({
+      engines: { pg: { name: "pg", target: "dev" } },
+      targets: { dev: { name: "dev", uri: "postgresql://dev/db" } },
+    });
+    const result = resolveTargetUri(config);
+    expect(result).toBe("postgresql://dev/db");
+  });
+
+  test("engine target can be a direct URI", () => {
+    const config = makeConfig({
+      engines: { pg: { name: "pg", target: "postgresql://engine-direct/db" } },
+    });
+    const result = resolveTargetUri(config);
+    expect(result).toBe("postgresql://engine-direct/db");
+  });
+
+  test("returns null when no target is configured anywhere", () => {
+    const config = makeConfig();
+    const result = resolveTargetUri(config);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when engine has no target", () => {
+    const config = makeConfig({
+      engines: { pg: { name: "pg" } },
+    });
+    const result = resolveTargetUri(config);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: computeStatus
+// ---------------------------------------------------------------------------
+
+describe("computeStatus", () => {
+  let tempDir: string;
+  let deployDir: string;
+
+  beforeEach(async () => {
+    resetConfig();
+    tempDir = await mkdtemp(join(tmpdir(), "sqlever-status-test-"));
+    deployDir = join(tempDir, "deploy");
+    await mkdir(deployDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns correct counts when all changes are deployed", () => {
+    const plan = makePlan("myproject", [
+      { name: "change_a", change_id: "aaa" },
+      { name: "change_b", change_id: "bbb" },
+    ]);
+    const deployed = [
+      makeRegistryChange("change_a", "aaa"),
+      makeRegistryChange("change_b", "bbb"),
+    ];
+
+    const result = computeStatus(plan, deployed, "pg://host/db", deployDir);
+
+    expect(result.project).toBe("myproject");
+    expect(result.target).toBe("pg://host/db");
+    expect(result.deployed_count).toBe(2);
+    expect(result.pending_count).toBe(0);
+    expect(result.pending_changes).toEqual([]);
+  });
+
+  test("returns correct counts when some changes are pending", () => {
+    const plan = makePlan("myproject", [
+      { name: "change_a", change_id: "aaa" },
+      { name: "change_b", change_id: "bbb" },
+      { name: "change_c", change_id: "ccc" },
+    ]);
+    const deployed = [makeRegistryChange("change_a", "aaa")];
+
+    const result = computeStatus(plan, deployed, null, deployDir);
+
+    expect(result.deployed_count).toBe(1);
+    expect(result.pending_count).toBe(2);
+    expect(result.pending_changes).toEqual(["change_b", "change_c"]);
+  });
+
+  test("returns correct counts when no changes are deployed", () => {
+    const plan = makePlan("myproject", [
+      { name: "change_a", change_id: "aaa" },
+      { name: "change_b", change_id: "bbb" },
+    ]);
+
+    const result = computeStatus(plan, [], null, deployDir);
+
+    expect(result.deployed_count).toBe(0);
+    expect(result.pending_count).toBe(2);
+    expect(result.pending_changes).toEqual(["change_a", "change_b"]);
+    expect(result.last_deployed).toBeNull();
+  });
+
+  test("returns correct counts for empty plan and no deployments", () => {
+    const plan = makePlan("myproject", []);
+
+    const result = computeStatus(plan, [], null, deployDir);
+
+    expect(result.deployed_count).toBe(0);
+    expect(result.pending_count).toBe(0);
+    expect(result.pending_changes).toEqual([]);
+    expect(result.last_deployed).toBeNull();
+  });
+
+  test("populates last_deployed from the last deployed change", () => {
+    const plan = makePlan("myproject", [
+      { name: "change_a", change_id: "aaa" },
+      { name: "change_b", change_id: "bbb" },
+    ]);
+    const deployed = [
+      makeRegistryChange("change_a", "aaa", {
+        committed_at: new Date("2024-01-10T08:00:00Z"),
+        committer_name: "Alice",
+      }),
+      makeRegistryChange("change_b", "bbb", {
+        committed_at: new Date("2024-01-15T10:30:00Z"),
+        committer_name: "Bob",
+      }),
+    ];
+
+    const result = computeStatus(plan, deployed, null, deployDir);
+
+    expect(result.last_deployed).not.toBeNull();
+    expect(result.last_deployed!.change).toBe("change_b");
+    expect(result.last_deployed!.change_id).toBe("bbb");
+    expect(result.last_deployed!.committed_at).toBe(
+      "2024-01-15T10:30:00.000Z",
+    );
+    expect(result.last_deployed!.committer_name).toBe("Bob");
+  });
+
+  test("detects modified scripts via script_hash comparison", async () => {
+    const originalContent = "CREATE TABLE foo (id int);";
+    const originalHash = sha1(originalContent);
+    const modifiedContent = "CREATE TABLE foo (id int, name text);";
+
+    // Write the modified file on disk
+    await writeFile(join(deployDir, "change_a.sql"), modifiedContent);
+
+    const plan = makePlan("myproject", [
+      { name: "change_a", change_id: "aaa" },
+    ]);
+    const deployed = [
+      makeRegistryChange("change_a", "aaa", {
+        script_hash: originalHash,
+      }),
+    ];
+
+    const result = computeStatus(plan, deployed, null, deployDir);
+
+    expect(result.modified_scripts).toHaveLength(1);
+    expect(result.modified_scripts[0]!.change).toBe("change_a");
+    expect(result.modified_scripts[0]!.registry_hash).toBe(originalHash);
+    expect(result.modified_scripts[0]!.current_hash).toBe(
+      sha1(modifiedContent),
+    );
+  });
+
+  test("does not flag unmodified scripts", async () => {
+    const content = "CREATE TABLE bar (id int);";
+    const hash = sha1(content);
+
+    await writeFile(join(deployDir, "change_a.sql"), content);
+
+    const plan = makePlan("myproject", [
+      { name: "change_a", change_id: "aaa" },
+    ]);
+    const deployed = [
+      makeRegistryChange("change_a", "aaa", { script_hash: hash }),
+    ];
+
+    const result = computeStatus(plan, deployed, null, deployDir);
+    expect(result.modified_scripts).toHaveLength(0);
+  });
+
+  test("skips script_hash check when registry has null hash", async () => {
+    await writeFile(join(deployDir, "change_a.sql"), "anything");
+
+    const plan = makePlan("myproject", [
+      { name: "change_a", change_id: "aaa" },
+    ]);
+    const deployed = [
+      makeRegistryChange("change_a", "aaa", { script_hash: null }),
+    ];
+
+    const result = computeStatus(plan, deployed, null, deployDir);
+    expect(result.modified_scripts).toHaveLength(0);
+  });
+
+  test("skips script_hash check when deploy file does not exist", () => {
+    const plan = makePlan("myproject", [
+      { name: "change_a", change_id: "aaa" },
+    ]);
+    const deployed = [
+      makeRegistryChange("change_a", "aaa", {
+        script_hash: "abc123",
+      }),
+    ];
+
+    const result = computeStatus(plan, deployed, null, deployDir);
+    expect(result.modified_scripts).toHaveLength(0);
+  });
+
+  test("preserves pending change order from plan", () => {
+    const plan = makePlan("myproject", [
+      { name: "alpha", change_id: "aaa" },
+      { name: "bravo", change_id: "bbb" },
+      { name: "charlie", change_id: "ccc" },
+      { name: "delta", change_id: "ddd" },
+    ]);
+    // Deploy only alpha and charlie (out of plan order)
+    const deployed = [
+      makeRegistryChange("alpha", "aaa"),
+      makeRegistryChange("charlie", "ccc"),
+    ];
+
+    const result = computeStatus(plan, deployed, null, deployDir);
+    expect(result.pending_changes).toEqual(["bravo", "delta"]);
+  });
+
+  test("includes target in result", () => {
+    const plan = makePlan("myproject", []);
+    const result = computeStatus(
+      plan,
+      [],
+      "postgresql://host/mydb",
+      deployDir,
+    );
+    expect(result.target).toBe("postgresql://host/mydb");
+  });
+
+  test("target is null when not provided", () => {
+    const plan = makePlan("myproject", []);
+    const result = computeStatus(plan, [], null, deployDir);
+    expect(result.target).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: formatStatusText
+// ---------------------------------------------------------------------------
+
+describe("formatStatusText", () => {
+  test("shows project name", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: null,
+      deployed_count: 0,
+      pending_count: 0,
+      pending_changes: [],
+      last_deployed: null,
+      modified_scripts: [],
+    };
+    const text = formatStatusText(result);
+    expect(text).toContain("# Project: myproject");
+  });
+
+  test("shows target when present", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: "postgresql://host/db",
+      deployed_count: 0,
+      pending_count: 0,
+      pending_changes: [],
+      last_deployed: null,
+      modified_scripts: [],
+    };
+    const text = formatStatusText(result);
+    expect(text).toContain("# Target:  postgresql://host/db");
+  });
+
+  test("omits target line when null", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: null,
+      deployed_count: 0,
+      pending_count: 0,
+      pending_changes: [],
+      last_deployed: null,
+      modified_scripts: [],
+    };
+    const text = formatStatusText(result);
+    expect(text).not.toContain("Target:");
+  });
+
+  test("shows deployed and pending counts", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: null,
+      deployed_count: 5,
+      pending_count: 3,
+      pending_changes: ["a", "b", "c"],
+      last_deployed: null,
+      modified_scripts: [],
+    };
+    const text = formatStatusText(result);
+    expect(text).toContain("Deployed: 5");
+    expect(text).toContain("Pending:  3");
+  });
+
+  test("lists pending changes with bullet marker", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: null,
+      deployed_count: 1,
+      pending_count: 2,
+      pending_changes: ["add_users", "add_orders"],
+      last_deployed: null,
+      modified_scripts: [],
+    };
+    const text = formatStatusText(result);
+    expect(text).toContain("  * add_users");
+    expect(text).toContain("  * add_orders");
+  });
+
+  test("shows last deployed change info", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: null,
+      deployed_count: 2,
+      pending_count: 0,
+      pending_changes: [],
+      last_deployed: {
+        change: "create_tables",
+        change_id: "abc123",
+        committed_at: "2024-01-15T10:30:00.000Z",
+        committer_name: "Alice",
+      },
+      modified_scripts: [],
+    };
+    const text = formatStatusText(result);
+    expect(text).toContain("# Last deployed change:");
+    expect(text).toContain("#   create_tables");
+    expect(text).toContain("#   deployed at: 2024-01-15T10:30:00.000Z");
+    expect(text).toContain("#   by: Alice");
+  });
+
+  test("shows modified scripts with warning marker", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: null,
+      deployed_count: 2,
+      pending_count: 0,
+      pending_changes: [],
+      last_deployed: null,
+      modified_scripts: [
+        {
+          change: "add_users",
+          change_id: "aaa",
+          registry_hash: "old_hash",
+          current_hash: "new_hash",
+        },
+      ],
+    };
+    const text = formatStatusText(result);
+    expect(text).toContain("Modified scripts (hash mismatch):");
+    expect(text).toContain("  ! add_users");
+  });
+
+  test("shows up-to-date message when nothing pending and no modifications", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: null,
+      deployed_count: 3,
+      pending_count: 0,
+      pending_changes: [],
+      last_deployed: null,
+      modified_scripts: [],
+    };
+    const text = formatStatusText(result);
+    expect(text).toContain("Nothing to deploy. Everything is up-to-date.");
+  });
+
+  test("does not show up-to-date message when changes are pending", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: null,
+      deployed_count: 1,
+      pending_count: 1,
+      pending_changes: ["change_b"],
+      last_deployed: null,
+      modified_scripts: [],
+    };
+    const text = formatStatusText(result);
+    expect(text).not.toContain("Nothing to deploy");
+  });
+
+  test("does not show up-to-date message when scripts are modified", () => {
+    const result: StatusResult = {
+      project: "myproject",
+      target: null,
+      deployed_count: 1,
+      pending_count: 0,
+      pending_changes: [],
+      last_deployed: null,
+      modified_scripts: [
+        {
+          change: "x",
+          change_id: "id",
+          registry_hash: "a",
+          current_hash: "b",
+        },
+      ],
+    };
+    const text = formatStatusText(result);
+    expect(text).not.toContain("Nothing to deploy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: CLI integration (subprocess)
+// ---------------------------------------------------------------------------
+
+describe("status CLI integration", () => {
+  const CWD = import.meta.dir + "/../..";
+  let tempDir: string;
+
+  beforeEach(async () => {
+    resetConfig();
+    tempDir = await mkdtemp(join(tmpdir(), "sqlever-status-cli-"));
+    await mkdir(join(tempDir, "deploy"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function run(
+    ...args: string[]
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const proc = Bun.spawn(
+      ["bun", "run", "src/cli.ts", ...args],
+      {
+        cwd: CWD,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("exits with error when no plan file exists", async () => {
+    const { stderr, exitCode } = await run(
+      "status",
+      "--top-dir",
+      tempDir,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Plan file not found");
+  });
+
+  test("shows plan-only status (no DB) when plan exists but no target", async () => {
+    // Write a sqitch.conf (no target configured)
+    await writeFile(
+      join(tempDir, "sqitch.conf"),
+      "[core]\n\tengine = pg\n",
+    );
+    // Write a plan file with two changes
+    await writeFile(
+      join(tempDir, "sqitch.plan"),
+      `%syntax-version=1.0.0
+%project=testproj
+
+init_schema 2024-01-01T00:00:00Z Dev <dev@test.com> # first
+add_users 2024-01-02T00:00:00Z Dev <dev@test.com> # second
+`,
+    );
+
+    const { stdout, exitCode } = await run(
+      "status",
+      "--top-dir",
+      tempDir,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("# Project: testproj");
+    expect(stdout).toContain("Deployed: 0");
+    expect(stdout).toContain("Pending:  2");
+    expect(stdout).toContain("  * init_schema");
+    expect(stdout).toContain("  * add_users");
+  });
+
+  test("--format json outputs valid JSON", async () => {
+    await writeFile(
+      join(tempDir, "sqitch.conf"),
+      "[core]\n\tengine = pg\n",
+    );
+    await writeFile(
+      join(tempDir, "sqitch.plan"),
+      `%syntax-version=1.0.0
+%project=jsontest
+
+change_one 2024-01-01T00:00:00Z Dev <dev@test.com> # note
+`,
+    );
+
+    const { stdout, exitCode } = await run(
+      "status",
+      "--top-dir",
+      tempDir,
+      "--format",
+      "json",
+    );
+    expect(exitCode).toBe(0);
+
+    const data = JSON.parse(stdout);
+    expect(data.project).toBe("jsontest");
+    expect(data.deployed_count).toBe(0);
+    expect(data.pending_count).toBe(1);
+    expect(data.pending_changes).toEqual(["change_one"]);
+    expect(data.target).toBeNull();
+    expect(data.last_deployed).toBeNull();
+    expect(data.modified_scripts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `sqlever status` command showing pending count, deployed count, last deployed change, target info, and modified script detection (script_hash comparison)
- Support `--format json` for machine-readable output and plan-only mode (no DB) when no target is configured
- Wire status into CLI dispatch; update existing cli.test.ts to reflect status is no longer a stub

## Test plan
- [x] 36 unit tests covering `parseStatusOptions`, `resolveTargetUri`, `computeStatus`, `formatStatusText`, and CLI integration
- [x] Modified script detection: verifies hash mismatch, unmodified scripts, null hash, missing files
- [x] Pending change ordering preserved from plan
- [x] Target resolution priority: --db-uri > --target lookup > engine default > null
- [x] Text output formatting: project, target, counts, pending list, modified warnings, up-to-date message
- [x] JSON output: valid JSON with all status fields
- [x] CLI subprocess tests: missing plan file error, plan-only mode, --format json
- [x] Full test suite passes (736 tests, 0 failures)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)