### PR TITLE
S5-2: Analysis rules SA001-SA010 — DDL safety rules

### DIFF
--- a/src/analysis/rules/SA001.ts
+++ b/src/analysis/rules/SA001.ts
@@ -1,0 +1,79 @@
+/**
+ * SA001: ADD COLUMN NOT NULL without DEFAULT
+ *
+ * Severity: error
+ * Type: static
+ *
+ * Detects ALTER TABLE ... ADD COLUMN with a NOT NULL constraint but no DEFAULT.
+ * This fails outright on populated tables because existing rows would have NULL
+ * for the new column, violating the NOT NULL constraint.
+ *
+ * Does NOT fire when a DEFAULT is present — that case is covered by SA002/SA002b.
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+export const SA001: Rule = {
+  id: "SA001",
+  severity: "error",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath } = context;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+      if (!stmt?.AlterTableStmt) continue;
+
+      const alterStmt = stmt.AlterTableStmt;
+      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+
+      const cmds = alterStmt.cmds ?? [];
+      for (const cmdEntry of cmds) {
+        const cmd = cmdEntry.AlterTableCmd;
+        if (!cmd || cmd.subtype !== "AT_AddColumn") continue;
+
+        const colDef = cmd.def?.ColumnDef;
+        if (!colDef) continue;
+
+        const constraints = colDef.constraints ?? [];
+        let hasNotNull = false;
+        let hasDefault = false;
+
+        for (const c of constraints) {
+          const constraint = c.Constraint;
+          if (!constraint) continue;
+          if (constraint.contype === "CONSTR_NOTNULL") hasNotNull = true;
+          if (constraint.contype === "CONSTR_DEFAULT") hasDefault = true;
+        }
+
+        if (hasNotNull && !hasDefault) {
+          const location = offsetToLocation(
+            rawSql,
+            stmtEntry.stmt_location ?? 0,
+            filePath,
+          );
+          const tableName = alterStmt.relation?.relname ?? "unknown";
+          const colName = colDef.colname ?? "unknown";
+
+          findings.push({
+            ruleId: "SA001",
+            severity: "error",
+            message: `Adding NOT NULL column "${colName}" to table "${tableName}" without a DEFAULT will fail on populated tables.`,
+            location,
+            suggestion:
+              "Add a DEFAULT value, or add the column as nullable first, backfill, then set NOT NULL.",
+          });
+        }
+      }
+    }
+
+    return findings;
+  },
+};
+
+export default SA001;

--- a/src/analysis/rules/SA002.ts
+++ b/src/analysis/rules/SA002.ts
@@ -1,0 +1,148 @@
+/**
+ * SA002: ADD COLUMN DEFAULT volatile on any PG version
+ *
+ * Severity: error
+ * Type: static
+ *
+ * Detects ALTER TABLE ... ADD COLUMN with a volatile default expression.
+ * Volatile defaults (e.g. random(), gen_random_uuid(), clock_timestamp(),
+ * txid_current()) cause a full table rewrite on ALL PostgreSQL versions,
+ * including PG 11+. The PG 11 optimization only applies to immutable/stable
+ * defaults.
+ *
+ * Note: now() is STABLE (returns transaction start time), not volatile —
+ * DEFAULT now() does NOT cause a rewrite on PG 11+.
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+/**
+ * Known volatile functions that cause table rewrites on all PG versions.
+ * These are checked case-insensitively.
+ */
+const VOLATILE_FUNCTIONS: ReadonlySet<string> = new Set([
+  "random",
+  "gen_random_uuid",
+  "clock_timestamp",
+  "txid_current",
+  "timeofday",
+  "uuid_generate_v1",
+  "uuid_generate_v1mc",
+  "uuid_generate_v4",
+  "statement_timestamp",
+  "setseed",
+  "nextval",
+  "currval",
+  "lastval",
+]);
+
+/**
+ * Recursively check if an AST expression node contains a volatile function call.
+ */
+function containsVolatileFunction(node: any): string | null {
+  if (!node || typeof node !== "object") return null;
+
+  // Direct function call
+  if (node.FuncCall) {
+    const funcNames = node.FuncCall.funcname ?? [];
+    for (const fn of funcNames) {
+      const name = fn?.String?.sval?.toLowerCase();
+      if (name && VOLATILE_FUNCTIONS.has(name)) {
+        return name;
+      }
+    }
+    // Check function arguments recursively
+    const args = node.FuncCall.args ?? [];
+    for (const arg of args) {
+      const result = containsVolatileFunction(arg);
+      if (result) return result;
+    }
+    return null;
+  }
+
+  // TypeCast wrapping a volatile function (e.g. random()::int)
+  if (node.TypeCast) {
+    return containsVolatileFunction(node.TypeCast.arg);
+  }
+
+  // Check nested expressions
+  if (node.A_Expr) {
+    const left = containsVolatileFunction(node.A_Expr.lexpr);
+    if (left) return left;
+    return containsVolatileFunction(node.A_Expr.rexpr);
+  }
+
+  // CoalesceExpr
+  if (node.CoalesceExpr) {
+    for (const arg of node.CoalesceExpr.args ?? []) {
+      const result = containsVolatileFunction(arg);
+      if (result) return result;
+    }
+  }
+
+  return null;
+}
+
+export const SA002: Rule = {
+  id: "SA002",
+  severity: "error",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath } = context;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+      if (!stmt?.AlterTableStmt) continue;
+
+      const alterStmt = stmt.AlterTableStmt;
+      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+
+      const cmds = alterStmt.cmds ?? [];
+      for (const cmdEntry of cmds) {
+        const cmd = cmdEntry.AlterTableCmd;
+        if (!cmd || cmd.subtype !== "AT_AddColumn") continue;
+
+        const colDef = cmd.def?.ColumnDef;
+        if (!colDef) continue;
+
+        const constraints = colDef.constraints ?? [];
+        for (const c of constraints) {
+          const constraint = c.Constraint;
+          if (!constraint || constraint.contype !== "CONSTR_DEFAULT") continue;
+
+          const rawExpr = constraint.raw_expr;
+          if (!rawExpr) continue;
+
+          const volatileFunc = containsVolatileFunction(rawExpr);
+          if (volatileFunc) {
+            const location = offsetToLocation(
+              rawSql,
+              stmtEntry.stmt_location ?? 0,
+              filePath,
+            );
+            const tableName = alterStmt.relation?.relname ?? "unknown";
+            const colName = colDef.colname ?? "unknown";
+
+            findings.push({
+              ruleId: "SA002",
+              severity: "error",
+              message: `Adding column "${colName}" to table "${tableName}" with volatile default ${volatileFunc}() causes a full table rewrite on all PostgreSQL versions.`,
+              location,
+              suggestion:
+                "Add the column without a default, then backfill in batches using UPDATE.",
+            });
+          }
+        }
+      }
+    }
+
+    return findings;
+  },
+};
+
+export default SA002;

--- a/src/analysis/rules/SA002b.ts
+++ b/src/analysis/rules/SA002b.ts
@@ -1,0 +1,141 @@
+/**
+ * SA002b: ADD COLUMN DEFAULT non-volatile on PG < 11
+ *
+ * Severity: warn
+ * Type: static
+ *
+ * Detects ALTER TABLE ... ADD COLUMN with a non-volatile default expression
+ * when targeting PostgreSQL < 11. On PG < 11, ANY default on ADD COLUMN
+ * causes a full table rewrite. On PG 11+, non-volatile (immutable/stable)
+ * defaults are metadata-only operations.
+ *
+ * This rule only fires when pgVersion < 11.
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+// Import volatile function set from SA002 to reuse the detection logic
+const VOLATILE_FUNCTIONS: ReadonlySet<string> = new Set([
+  "random",
+  "gen_random_uuid",
+  "clock_timestamp",
+  "txid_current",
+  "timeofday",
+  "uuid_generate_v1",
+  "uuid_generate_v1mc",
+  "uuid_generate_v4",
+  "statement_timestamp",
+  "setseed",
+  "nextval",
+  "currval",
+  "lastval",
+]);
+
+/**
+ * Check if an expression contains a volatile function call.
+ * Returns true if ANY function in the expression is volatile.
+ */
+function containsVolatileFunction(node: any): boolean {
+  if (!node || typeof node !== "object") return false;
+
+  if (node.FuncCall) {
+    const funcNames = node.FuncCall.funcname ?? [];
+    for (const fn of funcNames) {
+      const name = fn?.String?.sval?.toLowerCase();
+      if (name && VOLATILE_FUNCTIONS.has(name)) {
+        return true;
+      }
+    }
+    // Check function arguments
+    for (const arg of node.FuncCall.args ?? []) {
+      if (containsVolatileFunction(arg)) return true;
+    }
+    return false;
+  }
+
+  if (node.TypeCast) {
+    return containsVolatileFunction(node.TypeCast.arg);
+  }
+
+  if (node.A_Expr) {
+    return (
+      containsVolatileFunction(node.A_Expr.lexpr) ||
+      containsVolatileFunction(node.A_Expr.rexpr)
+    );
+  }
+
+  if (node.CoalesceExpr) {
+    for (const arg of node.CoalesceExpr.args ?? []) {
+      if (containsVolatileFunction(arg)) return true;
+    }
+  }
+
+  return false;
+}
+
+export const SA002b: Rule = {
+  id: "SA002b",
+  severity: "warn",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath, pgVersion } = context;
+
+    // Only fires when targeting PG < 11
+    if (pgVersion >= 11) return findings;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+      if (!stmt?.AlterTableStmt) continue;
+
+      const alterStmt = stmt.AlterTableStmt;
+      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+
+      const cmds = alterStmt.cmds ?? [];
+      for (const cmdEntry of cmds) {
+        const cmd = cmdEntry.AlterTableCmd;
+        if (!cmd || cmd.subtype !== "AT_AddColumn") continue;
+
+        const colDef = cmd.def?.ColumnDef;
+        if (!colDef) continue;
+
+        const constraints = colDef.constraints ?? [];
+        for (const c of constraints) {
+          const constraint = c.Constraint;
+          if (!constraint || constraint.contype !== "CONSTR_DEFAULT") continue;
+
+          const rawExpr = constraint.raw_expr;
+
+          // Skip volatile defaults — those are handled by SA002
+          if (rawExpr && containsVolatileFunction(rawExpr)) continue;
+
+          // This is a non-volatile default on PG < 11
+          const location = offsetToLocation(
+            rawSql,
+            stmtEntry.stmt_location ?? 0,
+            filePath,
+          );
+          const tableName = alterStmt.relation?.relname ?? "unknown";
+          const colName = colDef.colname ?? "unknown";
+
+          findings.push({
+            ruleId: "SA002b",
+            severity: "warn",
+            message: `Adding column "${colName}" to table "${tableName}" with a default causes a full table rewrite on PostgreSQL < 11 (target version: ${pgVersion}).`,
+            location,
+            suggestion:
+              "Upgrade to PostgreSQL 11+ where non-volatile defaults are metadata-only, or add the column without a default and backfill.",
+          });
+        }
+      }
+    }
+
+    return findings;
+  },
+};
+
+export default SA002b;

--- a/src/analysis/rules/SA003.ts
+++ b/src/analysis/rules/SA003.ts
@@ -1,0 +1,121 @@
+/**
+ * SA003: ALTER COLUMN TYPE non-trivial cast
+ *
+ * Severity: error
+ * Type: static
+ *
+ * Detects ALTER TABLE ... ALTER COLUMN ... TYPE that would cause a full table
+ * rewrite and AccessExclusiveLock. Uses a safe cast allowlist for type changes
+ * known to be binary-compatible (no rewrite needed).
+ *
+ * When a USING clause is present, SA003 ALWAYS fires regardless of the safe
+ * cast allowlist — PostgreSQL rewrites the table to evaluate the expression.
+ *
+ * Safe cast allowlist:
+ * - varchar(N) to varchar(M) where M > N (widening)
+ * - varchar(N) to varchar (removing limit)
+ * - varchar to text
+ * - char(N) to varchar or text
+ * - numeric(P,S) to numeric(P2,S) where P2 > P (widening precision)
+ * - numeric(P,S) to unconstrained numeric (removing precision/scale)
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation, displayTypeName } from "../types.js";
+
+/**
+ * Check if a type change is in the safe cast allowlist.
+ * Returns true if the cast is safe (no table rewrite).
+ *
+ * Note: This function does NOT know the source type from the AST alone —
+ * ALTER COLUMN TYPE only specifies the target type. We check if the target
+ * type is in a family known to have safe widening casts. Without a DB
+ * connection, we can only check the target type; the actual safety depends
+ * on the source type. For full accuracy, connected mode would consult pg_cast.
+ *
+ * For static analysis, we flag all type changes as potentially unsafe
+ * UNLESS the target is clearly a widening/removal of constraint within the
+ * same type family. Since we don't have the source type from the AST, we
+ * must be conservative and flag all changes.
+ */
+function isSafeCast(_targetTypeName: any): boolean {
+  // Without knowing the source type, we cannot determine if the cast is safe.
+  // The analysis engine with DB connection can refine this.
+  // For static analysis, we flag all type changes (conservative approach).
+  return false;
+}
+
+export const SA003: Rule = {
+  id: "SA003",
+  severity: "error",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath } = context;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+      if (!stmt?.AlterTableStmt) continue;
+
+      const alterStmt = stmt.AlterTableStmt;
+      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+
+      const cmds = alterStmt.cmds ?? [];
+      for (const cmdEntry of cmds) {
+        const cmd = cmdEntry.AlterTableCmd;
+        if (!cmd || cmd.subtype !== "AT_AlterColumnType") continue;
+
+        const colDef = cmd.def?.ColumnDef;
+        if (!colDef) continue;
+
+        const hasUsing = !!colDef.raw_default;
+        const targetType = colDef.typeName;
+        const targetTypeDisplay = displayTypeName(targetType);
+        const colName = cmd.name ?? "unknown";
+        const tableName = alterStmt.relation?.relname ?? "unknown";
+
+        // USING clause always triggers — PG rewrites to evaluate the expression
+        if (hasUsing) {
+          const location = offsetToLocation(
+            rawSql,
+            stmtEntry.stmt_location ?? 0,
+            filePath,
+          );
+          findings.push({
+            ruleId: "SA003",
+            severity: "error",
+            message: `Changing type of column "${colName}" on table "${tableName}" to ${targetTypeDisplay} with USING clause causes a full table rewrite with AccessExclusiveLock.`,
+            location,
+            suggestion:
+              "Consider the expand/contract pattern: add a new column, backfill in batches, then swap.",
+          });
+          continue;
+        }
+
+        // Check safe cast allowlist (static mode: conservative)
+        if (!isSafeCast(targetType)) {
+          const location = offsetToLocation(
+            rawSql,
+            stmtEntry.stmt_location ?? 0,
+            filePath,
+          );
+          findings.push({
+            ruleId: "SA003",
+            severity: "error",
+            message: `Changing type of column "${colName}" on table "${tableName}" to ${targetTypeDisplay} may cause a full table rewrite with AccessExclusiveLock.`,
+            location,
+            suggestion:
+              "Consider the expand/contract pattern: add a new column with the new type, backfill in batches, then swap. Safe casts (varchar widening, numeric precision widening) can be suppressed with -- sqlever:disable SA003.",
+          });
+        }
+      }
+    }
+
+    return findings;
+  },
+};
+
+export default SA003;

--- a/src/analysis/rules/SA004.ts
+++ b/src/analysis/rules/SA004.ts
@@ -1,0 +1,58 @@
+/**
+ * SA004: CREATE INDEX without CONCURRENTLY
+ *
+ * Severity: warn
+ * Type: static
+ *
+ * Detects CREATE INDEX statements that do not use the CONCURRENTLY option.
+ * Without CONCURRENTLY, CREATE INDEX takes a ShareLock on the table, blocking
+ * INSERT/UPDATE/DELETE for the duration of the index build.
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+export const SA004: Rule = {
+  id: "SA004",
+  severity: "warn",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath } = context;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+      if (!stmt?.IndexStmt) continue;
+
+      const indexStmt = stmt.IndexStmt;
+
+      // Skip if CONCURRENTLY is already used
+      if (indexStmt.concurrent) continue;
+
+      const location = offsetToLocation(
+        rawSql,
+        stmtEntry.stmt_location ?? 0,
+        filePath,
+      );
+
+      const idxName = indexStmt.idxname ?? "unnamed";
+      const tableName = indexStmt.relation?.relname ?? "unknown";
+
+      findings.push({
+        ruleId: "SA004",
+        severity: "warn",
+        message: `CREATE INDEX "${idxName}" on table "${tableName}" without CONCURRENTLY takes a ShareLock, blocking writes for the duration.`,
+        location,
+        suggestion:
+          "Use CREATE INDEX CONCURRENTLY to avoid blocking writes. Note: CONCURRENTLY cannot run inside a transaction block.",
+      });
+    }
+
+    return findings;
+  },
+};
+
+export default SA004;

--- a/src/analysis/rules/SA005.ts
+++ b/src/analysis/rules/SA005.ts
@@ -1,0 +1,70 @@
+/**
+ * SA005: DROP INDEX without CONCURRENTLY
+ *
+ * Severity: warn
+ * Type: static
+ *
+ * Detects DROP INDEX statements that do not use the CONCURRENTLY option.
+ * Without CONCURRENTLY, DROP INDEX takes an AccessExclusiveLock on the table.
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+export const SA005: Rule = {
+  id: "SA005",
+  severity: "warn",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath } = context;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+      if (!stmt?.DropStmt) continue;
+
+      const dropStmt = stmt.DropStmt;
+
+      // Only care about DROP INDEX
+      if (dropStmt.removeType !== "OBJECT_INDEX") continue;
+
+      // Skip if CONCURRENTLY is already used
+      if (dropStmt.concurrent) continue;
+
+      const location = offsetToLocation(
+        rawSql,
+        stmtEntry.stmt_location ?? 0,
+        filePath,
+      );
+
+      // Extract index name(s) from the objects list
+      const indexNames: string[] = [];
+      for (const obj of dropStmt.objects ?? []) {
+        if (obj?.List?.items) {
+          const names = obj.List.items
+            .map((item: any) => item?.String?.sval)
+            .filter(Boolean);
+          indexNames.push(names.join("."));
+        }
+      }
+
+      const nameStr = indexNames.length > 0 ? indexNames.join(", ") : "unnamed";
+
+      findings.push({
+        ruleId: "SA005",
+        severity: "warn",
+        message: `DROP INDEX ${nameStr} without CONCURRENTLY takes an AccessExclusiveLock.`,
+        location,
+        suggestion:
+          "Use DROP INDEX CONCURRENTLY to avoid blocking reads and writes. Note: CONCURRENTLY cannot run inside a transaction block.",
+      });
+    }
+
+    return findings;
+  },
+};
+
+export default SA005;

--- a/src/analysis/rules/SA006.ts
+++ b/src/analysis/rules/SA006.ts
@@ -1,0 +1,63 @@
+/**
+ * SA006: DROP COLUMN
+ *
+ * Severity: warn
+ * Type: static
+ *
+ * Detects ALTER TABLE ... DROP COLUMN statements. Dropping a column is
+ * irreversible data loss. While PostgreSQL marks the column as dropped
+ * (metadata-only, no rewrite), the data is gone and cannot be recovered
+ * without a backup.
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+export const SA006: Rule = {
+  id: "SA006",
+  severity: "warn",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath } = context;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+      if (!stmt?.AlterTableStmt) continue;
+
+      const alterStmt = stmt.AlterTableStmt;
+      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+
+      const cmds = alterStmt.cmds ?? [];
+      for (const cmdEntry of cmds) {
+        const cmd = cmdEntry.AlterTableCmd;
+        if (!cmd || cmd.subtype !== "AT_DropColumn") continue;
+
+        const location = offsetToLocation(
+          rawSql,
+          stmtEntry.stmt_location ?? 0,
+          filePath,
+        );
+
+        const tableName = alterStmt.relation?.relname ?? "unknown";
+        const colName = cmd.name ?? "unknown";
+
+        findings.push({
+          ruleId: "SA006",
+          severity: "warn",
+          message: `Dropping column "${colName}" from table "${tableName}" causes irreversible data loss.`,
+          location,
+          suggestion:
+            "Ensure a backup exists and that no application code depends on this column. Consider a deprecation period before dropping.",
+        });
+      }
+    }
+
+    return findings;
+  },
+};
+
+export default SA006;

--- a/src/analysis/rules/SA007.ts
+++ b/src/analysis/rules/SA007.ts
@@ -1,0 +1,73 @@
+/**
+ * SA007: DROP TABLE in non-revert context
+ *
+ * Severity: error
+ * Type: static
+ *
+ * Detects DROP TABLE statements outside of revert scripts. Dropping a table
+ * is irreversible data loss. In sqitch project context, files under revert/
+ * are exempt since DROP TABLE is expected in revert scripts. In standalone
+ * mode, always fires.
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+export const SA007: Rule = {
+  id: "SA007",
+  severity: "error",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath, isRevertContext } = context;
+
+    // In revert context, DROP TABLE is expected and exempt
+    if (isRevertContext) return findings;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+      if (!stmt?.DropStmt) continue;
+
+      const dropStmt = stmt.DropStmt;
+
+      // Only care about DROP TABLE
+      if (dropStmt.removeType !== "OBJECT_TABLE") continue;
+
+      const location = offsetToLocation(
+        rawSql,
+        stmtEntry.stmt_location ?? 0,
+        filePath,
+      );
+
+      // Extract table name(s) from the objects list
+      const tableNames: string[] = [];
+      for (const obj of dropStmt.objects ?? []) {
+        if (obj?.List?.items) {
+          const names = obj.List.items
+            .map((item: any) => item?.String?.sval)
+            .filter(Boolean);
+          tableNames.push(names.join("."));
+        }
+      }
+
+      const nameStr =
+        tableNames.length > 0 ? tableNames.join(", ") : "unknown";
+
+      findings.push({
+        ruleId: "SA007",
+        severity: "error",
+        message: `DROP TABLE ${nameStr} causes irreversible data loss.`,
+        location,
+        suggestion:
+          "Ensure a backup exists. In a sqitch project, DROP TABLE is expected only in revert/ scripts.",
+      });
+    }
+
+    return findings;
+  },
+};
+
+export default SA007;

--- a/src/analysis/rules/SA008.ts
+++ b/src/analysis/rules/SA008.ts
@@ -1,0 +1,73 @@
+/**
+ * SA008: TRUNCATE
+ *
+ * Severity: warn
+ * Type: static
+ *
+ * Detects TRUNCATE statements. TRUNCATE removes all rows from a table and
+ * is effectively irreversible without a backup. It also takes an
+ * AccessExclusiveLock.
+ *
+ * PL/pgSQL body exclusion: TRUNCATE inside CREATE FUNCTION, CREATE PROCEDURE,
+ * and DO blocks is excluded — these define function bodies, not direct
+ * migration operations.
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+export const SA008: Rule = {
+  id: "SA008",
+  severity: "warn",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath } = context;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+
+      // Skip PL/pgSQL bodies (CREATE FUNCTION, CREATE PROCEDURE, DO blocks)
+      if (stmt?.CreateFunctionStmt || stmt?.DoStmt) continue;
+
+      if (!stmt?.TruncateStmt) continue;
+
+      const truncateStmt = stmt.TruncateStmt;
+
+      const location = offsetToLocation(
+        rawSql,
+        stmtEntry.stmt_location ?? 0,
+        filePath,
+      );
+
+      // Extract table names
+      const tableNames: string[] = [];
+      for (const rel of truncateStmt.relations ?? []) {
+        const rv = rel.RangeVar;
+        if (rv?.relname) {
+          const schema = rv.schemaname ? `${rv.schemaname}.` : "";
+          tableNames.push(`${schema}${rv.relname}`);
+        }
+      }
+
+      const nameStr =
+        tableNames.length > 0 ? tableNames.join(", ") : "unknown";
+
+      findings.push({
+        ruleId: "SA008",
+        severity: "warn",
+        message: `TRUNCATE on ${nameStr} removes all data and takes an AccessExclusiveLock.`,
+        location,
+        suggestion:
+          "Ensure this is intentional. Use DELETE with a WHERE clause for partial removal, or ensure a backup exists.",
+      });
+    }
+
+    return findings;
+  },
+};
+
+export default SA008;

--- a/src/analysis/rules/SA009.ts
+++ b/src/analysis/rules/SA009.ts
@@ -1,0 +1,90 @@
+/**
+ * SA009: ADD FOREIGN KEY without NOT VALID
+ *
+ * Severity: warn
+ * Type: hybrid (static check for NOT VALID, connected check for index)
+ *
+ * Static: Detects ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY without
+ * NOT VALID. Without NOT VALID, the constraint takes a ShareRowExclusiveLock
+ * on both referencing and referenced tables and validates all existing rows
+ * before completing.
+ *
+ * Connected: Also checks for a missing index on the referencing column(s)
+ * (ongoing performance concern). This portion only runs when a DB connection
+ * is available.
+ *
+ * Recommended pattern:
+ *   ALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (c) REFERENCES t2(id) NOT VALID;
+ *   ALTER TABLE t VALIDATE CONSTRAINT fk;  -- takes ShareUpdateExclusiveLock only
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+export const SA009: Rule = {
+  id: "SA009",
+  severity: "warn",
+  type: "hybrid",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath } = context;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+      if (!stmt?.AlterTableStmt) continue;
+
+      const alterStmt = stmt.AlterTableStmt;
+      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+
+      const cmds = alterStmt.cmds ?? [];
+      for (const cmdEntry of cmds) {
+        const cmd = cmdEntry.AlterTableCmd;
+        if (!cmd || cmd.subtype !== "AT_AddConstraint") continue;
+
+        const constraint = cmd.def?.Constraint;
+        if (!constraint || constraint.contype !== "CONSTR_FOREIGN") continue;
+
+        // Check for NOT VALID: in the AST, skip_validation = true means NOT VALID was used
+        const hasNotValid = constraint.skip_validation === true;
+
+        if (!hasNotValid) {
+          const location = offsetToLocation(
+            rawSql,
+            stmtEntry.stmt_location ?? 0,
+            filePath,
+          );
+
+          const tableName = alterStmt.relation?.relname ?? "unknown";
+          const constraintName = constraint.conname ?? "unnamed";
+          const refTable = constraint.pktable?.relname ?? "unknown";
+
+          // Extract FK column names
+          const fkCols = (constraint.fk_attrs ?? [])
+            .map((attr: any) => attr?.String?.sval)
+            .filter(Boolean)
+            .join(", ");
+
+          findings.push({
+            ruleId: "SA009",
+            severity: "warn",
+            message: `Adding foreign key "${constraintName}" on ${tableName}(${fkCols}) referencing ${refTable} without NOT VALID takes a ShareRowExclusiveLock and validates all existing rows.`,
+            location,
+            suggestion:
+              "Use ADD CONSTRAINT ... NOT VALID, then VALIDATE CONSTRAINT in a separate statement (takes only ShareUpdateExclusiveLock, does not block writes).",
+          });
+        }
+
+        // Connected check: index on referencing columns
+        // This would run when context.db is available
+        // Left as a stub for the analysis engine integration
+      }
+    }
+
+    return findings;
+  },
+};
+
+export default SA009;

--- a/src/analysis/rules/SA010.ts
+++ b/src/analysis/rules/SA010.ts
@@ -1,0 +1,87 @@
+/**
+ * SA010: UPDATE/DELETE without WHERE
+ *
+ * Severity: warn
+ * Type: static
+ *
+ * Detects UPDATE or DELETE statements that have no WHERE clause. Full-table
+ * DML can be intentional in migrations (backfills, cleanups), so this is a
+ * warning rather than an error. Use inline suppression for acknowledged cases.
+ *
+ * PL/pgSQL body exclusion: DML inside CREATE FUNCTION, CREATE PROCEDURE,
+ * and DO blocks is excluded — these define function bodies, not direct
+ * migration operations.
+ */
+
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation } from "../types.js";
+
+export const SA010: Rule = {
+  id: "SA010",
+  severity: "warn",
+  type: "static",
+
+  check(context: AnalysisContext): Finding[] {
+    const findings: Finding[] = [];
+    const { ast, rawSql, filePath } = context;
+
+    if (!ast?.stmts) return findings;
+
+    for (const stmtEntry of ast.stmts) {
+      const stmt = stmtEntry.stmt;
+
+      // Skip PL/pgSQL bodies (CREATE FUNCTION, CREATE PROCEDURE, DO blocks)
+      if (stmt?.CreateFunctionStmt || stmt?.DoStmt) continue;
+
+      // Check UPDATE without WHERE
+      if (stmt?.UpdateStmt) {
+        const updateStmt = stmt.UpdateStmt;
+        if (!updateStmt.whereClause) {
+          const location = offsetToLocation(
+            rawSql,
+            stmtEntry.stmt_location ?? 0,
+            filePath,
+          );
+
+          const tableName = updateStmt.relation?.relname ?? "unknown";
+
+          findings.push({
+            ruleId: "SA010",
+            severity: "warn",
+            message: `UPDATE on table "${tableName}" without a WHERE clause affects all rows.`,
+            location,
+            suggestion:
+              "Add a WHERE clause to limit the scope, or suppress this warning with -- sqlever:disable SA010 if the full-table update is intentional.",
+          });
+        }
+      }
+
+      // Check DELETE without WHERE
+      if (stmt?.DeleteStmt) {
+        const deleteStmt = stmt.DeleteStmt;
+        if (!deleteStmt.whereClause) {
+          const location = offsetToLocation(
+            rawSql,
+            stmtEntry.stmt_location ?? 0,
+            filePath,
+          );
+
+          const tableName = deleteStmt.relation?.relname ?? "unknown";
+
+          findings.push({
+            ruleId: "SA010",
+            severity: "warn",
+            message: `DELETE on table "${tableName}" without a WHERE clause affects all rows.`,
+            location,
+            suggestion:
+              "Add a WHERE clause to limit the scope, or suppress this warning with -- sqlever:disable SA010 if the full-table delete is intentional.",
+          });
+        }
+      }
+    }
+
+    return findings;
+  },
+};
+
+export default SA010;

--- a/src/analysis/rules/index.ts
+++ b/src/analysis/rules/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Analysis rules registry.
+ *
+ * Each rule is imported from its own file and re-exported here.
+ * The analysis engine (issue #50) will use this registry to discover
+ * and invoke rules.
+ */
+
+export { SA001 } from "./SA001.js";
+export { SA002 } from "./SA002.js";
+export { SA002b } from "./SA002b.js";
+export { SA003 } from "./SA003.js";
+export { SA004 } from "./SA004.js";
+export { SA005 } from "./SA005.js";
+export { SA006 } from "./SA006.js";
+export { SA007 } from "./SA007.js";
+export { SA008 } from "./SA008.js";
+export { SA009 } from "./SA009.js";
+export { SA010 } from "./SA010.js";
+
+import { SA001 } from "./SA001.js";
+import { SA002 } from "./SA002.js";
+import { SA002b } from "./SA002b.js";
+import { SA003 } from "./SA003.js";
+import { SA004 } from "./SA004.js";
+import { SA005 } from "./SA005.js";
+import { SA006 } from "./SA006.js";
+import { SA007 } from "./SA007.js";
+import { SA008 } from "./SA008.js";
+import { SA009 } from "./SA009.js";
+import { SA010 } from "./SA010.js";
+
+import type { Rule } from "../types.js";
+
+/** All registered analysis rules */
+export const allRules: Rule[] = [
+  SA001,
+  SA002,
+  SA002b,
+  SA003,
+  SA004,
+  SA005,
+  SA006,
+  SA007,
+  SA008,
+  SA009,
+  SA010,
+];
+
+/** Look up a rule by ID */
+export function getRule(id: string): Rule | undefined {
+  return allRules.find((r) => r.id === id);
+}

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -24,6 +24,9 @@ export interface FindingLocation {
   endColumn?: number;
 }
 
+/** Alias for FindingLocation — used by rule implementations. */
+export type Location = FindingLocation;
+
 /** A single finding produced by a rule. */
 export interface Finding {
   ruleId: string;
@@ -98,6 +101,8 @@ export interface AnalysisContext {
   config: AnalysisConfig;
   /** Database client, present only for connected/hybrid rules with active connection. */
   db?: DatabaseClient;
+  /** Whether this file is in a revert context (e.g. under revert/ in a sqitch project). */
+  isRevertContext?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -139,4 +144,80 @@ export interface AnalyzeOptions {
   pgVersion?: number;
   /** Whether to treat the file as a revert script (affects SA007 etc.). */
   isRevert?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a byte offset in the source SQL to a 1-based line and column.
+ */
+export function offsetToLocation(
+  rawSql: string,
+  byteOffset: number,
+  filePath: string,
+): Location {
+  let line = 1;
+  let col = 1;
+  const len = Math.min(byteOffset, rawSql.length);
+  for (let i = 0; i < len; i++) {
+    if (rawSql[i] === "\n") {
+      line++;
+      col = 1;
+    } else {
+      col++;
+    }
+  }
+  return { file: filePath, line, column: col };
+}
+
+/**
+ * Extract the type name string from a libpg-query TypeName node.
+ * Returns the last name part (e.g. "varchar", "int4", "text").
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function extractTypeName(typeName: any): string | null {
+  if (!typeName?.names) return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const names = typeName.names as any[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const last = names[names.length - 1];
+  return last?.String?.sval ?? null;
+}
+
+/**
+ * Extract type modifiers (e.g. length for varchar, precision/scale for numeric).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function extractTypeMods(typeName: any): number[] {
+  if (!typeName?.typmods) return [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (typeName.typmods as any[])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((m: any) => m?.A_Const?.ival?.ival)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((v: any): v is number => typeof v === "number");
+}
+
+/**
+ * Get the fully-qualified type name for display purposes.
+ * Skips "pg_catalog" schema prefix.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function displayTypeName(typeName: any): string {
+  if (!typeName?.names) return "unknown";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const names = (typeName.names as any[])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((n: any) => n?.String?.sval)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((s: any): s is string => !!s)
+    .filter((s: string) => s !== "pg_catalog");
+  const base = names.join(".");
+  const mods = extractTypeMods(typeName);
+  if (mods.length > 0) {
+    return `${base}(${mods.join(",")})`;
+  }
+  return base;
 }

--- a/tests/fixtures/analysis/SA001/no_trigger/add_column_no_constraints.sql
+++ b/tests/fixtures/analysis/SA001/no_trigger/add_column_no_constraints.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN bio text;

--- a/tests/fixtures/analysis/SA001/no_trigger/add_column_not_null_with_default.sql
+++ b/tests/fixtures/analysis/SA001/no_trigger/add_column_not_null_with_default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN status text NOT NULL DEFAULT 'active';

--- a/tests/fixtures/analysis/SA001/no_trigger/add_column_not_null_with_default_int.sql
+++ b/tests/fixtures/analysis/SA001/no_trigger/add_column_not_null_with_default_int.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD COLUMN quantity integer NOT NULL DEFAULT 0;

--- a/tests/fixtures/analysis/SA001/no_trigger/add_column_nullable.sql
+++ b/tests/fixtures/analysis/SA001/no_trigger/add_column_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN email text;

--- a/tests/fixtures/analysis/SA001/no_trigger/add_column_with_default_only.sql
+++ b/tests/fixtures/analysis/SA001/no_trigger/add_column_with_default_only.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN score integer DEFAULT 100;

--- a/tests/fixtures/analysis/SA001/no_trigger/create_table_not_null.sql
+++ b/tests/fixtures/analysis/SA001/no_trigger/create_table_not_null.sql
@@ -1,0 +1,7 @@
+-- CREATE TABLE with NOT NULL columns should not trigger SA001
+-- SA001 only cares about ADD COLUMN on existing tables
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  email text NOT NULL,
+  name text NOT NULL
+);

--- a/tests/fixtures/analysis/SA001/trigger/add_column_not_null_integer.sql
+++ b/tests/fixtures/analysis/SA001/trigger/add_column_not_null_integer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD COLUMN total integer NOT NULL;

--- a/tests/fixtures/analysis/SA001/trigger/add_column_not_null_no_default.sql
+++ b/tests/fixtures/analysis/SA001/trigger/add_column_not_null_no_default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN email text NOT NULL;

--- a/tests/fixtures/analysis/SA001/trigger/add_column_not_null_timestamptz.sql
+++ b/tests/fixtures/analysis/SA001/trigger/add_column_not_null_timestamptz.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN created_at timestamptz NOT NULL;

--- a/tests/fixtures/analysis/SA002/no_trigger/add_column_default_integer.sql
+++ b/tests/fixtures/analysis/SA002/no_trigger/add_column_default_integer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD COLUMN quantity integer DEFAULT 0;

--- a/tests/fixtures/analysis/SA002/no_trigger/add_column_default_literal.sql
+++ b/tests/fixtures/analysis/SA002/no_trigger/add_column_default_literal.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN status text DEFAULT 'active';

--- a/tests/fixtures/analysis/SA002/no_trigger/add_column_default_now.sql
+++ b/tests/fixtures/analysis/SA002/no_trigger/add_column_default_now.sql
@@ -1,0 +1,2 @@
+-- now() is STABLE, not volatile — safe on PG 11+
+ALTER TABLE events ADD COLUMN created_at timestamptz DEFAULT now();

--- a/tests/fixtures/analysis/SA002/no_trigger/add_column_default_true.sql
+++ b/tests/fixtures/analysis/SA002/no_trigger/add_column_default_true.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN is_active boolean DEFAULT true;

--- a/tests/fixtures/analysis/SA002/no_trigger/add_column_no_default.sql
+++ b/tests/fixtures/analysis/SA002/no_trigger/add_column_no_default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN bio text;

--- a/tests/fixtures/analysis/SA002/trigger/add_column_default_clock_timestamp.sql
+++ b/tests/fixtures/analysis/SA002/trigger/add_column_default_clock_timestamp.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN recorded_at timestamptz DEFAULT clock_timestamp();

--- a/tests/fixtures/analysis/SA002/trigger/add_column_default_gen_random_uuid.sql
+++ b/tests/fixtures/analysis/SA002/trigger/add_column_default_gen_random_uuid.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN id uuid DEFAULT gen_random_uuid();

--- a/tests/fixtures/analysis/SA002/trigger/add_column_default_random.sql
+++ b/tests/fixtures/analysis/SA002/trigger/add_column_default_random.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD COLUMN sort_key double precision DEFAULT random();

--- a/tests/fixtures/analysis/SA002/trigger/add_column_default_random_cast.sql
+++ b/tests/fixtures/analysis/SA002/trigger/add_column_default_random_cast.sql
@@ -1,0 +1,2 @@
+-- random() wrapped in a type cast is still volatile
+ALTER TABLE orders ADD COLUMN priority int DEFAULT random()::int;

--- a/tests/fixtures/analysis/SA002/trigger/add_column_default_txid_current.sql
+++ b/tests/fixtures/analysis/SA002/trigger/add_column_default_txid_current.sql
@@ -1,0 +1,1 @@
+ALTER TABLE audit_log ADD COLUMN txid bigint DEFAULT txid_current();

--- a/tests/fixtures/analysis/SA002b/no_trigger/add_column_default_boolean_pg14.sql
+++ b/tests/fixtures/analysis/SA002b/no_trigger/add_column_default_boolean_pg14.sql
@@ -1,0 +1,2 @@
+-- Non-volatile default on PG >= 11 should not fire
+ALTER TABLE users ADD COLUMN is_active boolean DEFAULT false;

--- a/tests/fixtures/analysis/SA002b/no_trigger/add_column_default_literal_pg17.sql
+++ b/tests/fixtures/analysis/SA002b/no_trigger/add_column_default_literal_pg17.sql
@@ -1,0 +1,2 @@
+-- On PG >= 11, non-volatile defaults are metadata-only
+ALTER TABLE users ADD COLUMN status text DEFAULT 'active';

--- a/tests/fixtures/analysis/SA002b/no_trigger/add_column_default_now_pg17.sql
+++ b/tests/fixtures/analysis/SA002b/no_trigger/add_column_default_now_pg17.sql
@@ -1,0 +1,2 @@
+-- now() is STABLE, safe on PG 11+
+ALTER TABLE events ADD COLUMN created_at timestamptz DEFAULT now();

--- a/tests/fixtures/analysis/SA002b/no_trigger/add_column_no_default.sql
+++ b/tests/fixtures/analysis/SA002b/no_trigger/add_column_no_default.sql
@@ -1,0 +1,2 @@
+-- No default at all — SA002b should not fire
+ALTER TABLE users ADD COLUMN bio text;

--- a/tests/fixtures/analysis/SA002b/no_trigger/add_column_volatile_default_pg10.sql
+++ b/tests/fixtures/analysis/SA002b/no_trigger/add_column_volatile_default_pg10.sql
@@ -1,0 +1,2 @@
+-- Volatile defaults are handled by SA002, not SA002b
+ALTER TABLE users ADD COLUMN id uuid DEFAULT gen_random_uuid();

--- a/tests/fixtures/analysis/SA002b/trigger/add_column_default_integer_pg10.sql
+++ b/tests/fixtures/analysis/SA002b/trigger/add_column_default_integer_pg10.sql
@@ -1,0 +1,1 @@
+ALTER TABLE counters ADD COLUMN count integer DEFAULT 0;

--- a/tests/fixtures/analysis/SA002b/trigger/add_column_default_literal_pg10.sql
+++ b/tests/fixtures/analysis/SA002b/trigger/add_column_default_literal_pg10.sql
@@ -1,0 +1,2 @@
+-- On PG < 11, even non-volatile defaults cause a table rewrite
+ALTER TABLE users ADD COLUMN status text DEFAULT 'active';

--- a/tests/fixtures/analysis/SA002b/trigger/add_column_default_now_pg10.sql
+++ b/tests/fixtures/analysis/SA002b/trigger/add_column_default_now_pg10.sql
@@ -1,0 +1,2 @@
+-- now() is STABLE, not volatile, but on PG < 11 all defaults cause rewrite
+ALTER TABLE events ADD COLUMN created_at timestamptz DEFAULT now();

--- a/tests/fixtures/analysis/SA003/no_trigger/add_column.sql
+++ b/tests/fixtures/analysis/SA003/no_trigger/add_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN bio text;

--- a/tests/fixtures/analysis/SA003/no_trigger/create_table.sql
+++ b/tests/fixtures/analysis/SA003/no_trigger/create_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  email text NOT NULL
+);

--- a/tests/fixtures/analysis/SA003/no_trigger/drop_column.sql
+++ b/tests/fixtures/analysis/SA003/no_trigger/drop_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN old_field;

--- a/tests/fixtures/analysis/SA003/no_trigger/rename_column.sql
+++ b/tests/fixtures/analysis/SA003/no_trigger/rename_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users RENAME COLUMN name TO full_name;

--- a/tests/fixtures/analysis/SA003/no_trigger/select_statement.sql
+++ b/tests/fixtures/analysis/SA003/no_trigger/select_statement.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users;

--- a/tests/fixtures/analysis/SA003/trigger/alter_column_type_int_to_bigint.sql
+++ b/tests/fixtures/analysis/SA003/trigger/alter_column_type_int_to_bigint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ALTER COLUMN id TYPE bigint;

--- a/tests/fixtures/analysis/SA003/trigger/alter_column_type_text_to_integer.sql
+++ b/tests/fixtures/analysis/SA003/trigger/alter_column_type_text_to_integer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE config ALTER COLUMN value TYPE integer USING value::integer;

--- a/tests/fixtures/analysis/SA003/trigger/alter_column_type_timestamp_to_timestamptz.sql
+++ b/tests/fixtures/analysis/SA003/trigger/alter_column_type_timestamp_to_timestamptz.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ALTER COLUMN created_at TYPE timestamptz;

--- a/tests/fixtures/analysis/SA003/trigger/alter_column_type_varchar_to_int.sql
+++ b/tests/fixtures/analysis/SA003/trigger/alter_column_type_varchar_to_int.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ALTER COLUMN code TYPE integer;

--- a/tests/fixtures/analysis/SA003/trigger/alter_column_type_with_using.sql
+++ b/tests/fixtures/analysis/SA003/trigger/alter_column_type_with_using.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ALTER COLUMN name TYPE text USING name::text;

--- a/tests/fixtures/analysis/SA004/no_trigger/create_index_concurrently.sql
+++ b/tests/fixtures/analysis/SA004/no_trigger/create_index_concurrently.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY idx_users_email ON users (email);

--- a/tests/fixtures/analysis/SA004/no_trigger/create_index_concurrently_partial.sql
+++ b/tests/fixtures/analysis/SA004/no_trigger/create_index_concurrently_partial.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY idx_orders_status ON orders (status) WHERE status = 'pending';

--- a/tests/fixtures/analysis/SA004/no_trigger/create_table.sql
+++ b/tests/fixtures/analysis/SA004/no_trigger/create_table.sql
@@ -1,0 +1,5 @@
+-- CREATE TABLE with inline index should not trigger SA004
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  email text UNIQUE
+);

--- a/tests/fixtures/analysis/SA004/no_trigger/create_unique_index_concurrently.sql
+++ b/tests/fixtures/analysis/SA004/no_trigger/create_unique_index_concurrently.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX CONCURRENTLY idx_users_email_unique ON users (email);

--- a/tests/fixtures/analysis/SA004/no_trigger/drop_index.sql
+++ b/tests/fixtures/analysis/SA004/no_trigger/drop_index.sql
@@ -1,0 +1,2 @@
+-- DROP INDEX is SA005, not SA004
+DROP INDEX idx_users_email;

--- a/tests/fixtures/analysis/SA004/trigger/create_index_no_concurrently.sql
+++ b/tests/fixtures/analysis/SA004/trigger/create_index_no_concurrently.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_users_email ON users (email);

--- a/tests/fixtures/analysis/SA004/trigger/create_index_partial.sql
+++ b/tests/fixtures/analysis/SA004/trigger/create_index_partial.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_orders_status ON orders (status) WHERE status = 'pending';

--- a/tests/fixtures/analysis/SA004/trigger/create_unique_index.sql
+++ b/tests/fixtures/analysis/SA004/trigger/create_unique_index.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX idx_users_email_unique ON users (email);

--- a/tests/fixtures/analysis/SA005/no_trigger/create_index.sql
+++ b/tests/fixtures/analysis/SA005/no_trigger/create_index.sql
@@ -1,0 +1,2 @@
+-- CREATE INDEX is SA004, not SA005
+CREATE INDEX idx_users_email ON users (email);

--- a/tests/fixtures/analysis/SA005/no_trigger/drop_index_concurrently.sql
+++ b/tests/fixtures/analysis/SA005/no_trigger/drop_index_concurrently.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY idx_users_email;

--- a/tests/fixtures/analysis/SA005/no_trigger/drop_index_concurrently_if_exists.sql
+++ b/tests/fixtures/analysis/SA005/no_trigger/drop_index_concurrently_if_exists.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_orders_status;

--- a/tests/fixtures/analysis/SA005/no_trigger/drop_table.sql
+++ b/tests/fixtures/analysis/SA005/no_trigger/drop_table.sql
@@ -1,0 +1,2 @@
+-- DROP TABLE is SA007, not SA005
+DROP TABLE users;

--- a/tests/fixtures/analysis/SA005/no_trigger/select_statement.sql
+++ b/tests/fixtures/analysis/SA005/no_trigger/select_statement.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users WHERE email = 'test@example.com';

--- a/tests/fixtures/analysis/SA005/trigger/drop_index_if_exists.sql
+++ b/tests/fixtures/analysis/SA005/trigger/drop_index_if_exists.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_orders_status;

--- a/tests/fixtures/analysis/SA005/trigger/drop_index_no_concurrently.sql
+++ b/tests/fixtures/analysis/SA005/trigger/drop_index_no_concurrently.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_users_email;

--- a/tests/fixtures/analysis/SA005/trigger/drop_index_schema_qualified.sql
+++ b/tests/fixtures/analysis/SA005/trigger/drop_index_schema_qualified.sql
@@ -1,0 +1,1 @@
+DROP INDEX public.idx_users_email;

--- a/tests/fixtures/analysis/SA006/no_trigger/add_column.sql
+++ b/tests/fixtures/analysis/SA006/no_trigger/add_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN bio text;

--- a/tests/fixtures/analysis/SA006/no_trigger/alter_column_type.sql
+++ b/tests/fixtures/analysis/SA006/no_trigger/alter_column_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ALTER COLUMN name TYPE text;

--- a/tests/fixtures/analysis/SA006/no_trigger/drop_table.sql
+++ b/tests/fixtures/analysis/SA006/no_trigger/drop_table.sql
@@ -1,0 +1,2 @@
+-- DROP TABLE is SA007, not SA006
+DROP TABLE users;

--- a/tests/fixtures/analysis/SA006/no_trigger/rename_column.sql
+++ b/tests/fixtures/analysis/SA006/no_trigger/rename_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users RENAME COLUMN name TO full_name;

--- a/tests/fixtures/analysis/SA006/no_trigger/select_statement.sql
+++ b/tests/fixtures/analysis/SA006/no_trigger/select_statement.sql
@@ -1,0 +1,1 @@
+SELECT id, email FROM users;

--- a/tests/fixtures/analysis/SA006/trigger/drop_column.sql
+++ b/tests/fixtures/analysis/SA006/trigger/drop_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN email;

--- a/tests/fixtures/analysis/SA006/trigger/drop_column_cascade.sql
+++ b/tests/fixtures/analysis/SA006/trigger/drop_column_cascade.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders DROP COLUMN customer_id CASCADE;

--- a/tests/fixtures/analysis/SA006/trigger/drop_column_if_exists.sql
+++ b/tests/fixtures/analysis/SA006/trigger/drop_column_if_exists.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN IF EXISTS old_field;

--- a/tests/fixtures/analysis/SA007/no_trigger/alter_table.sql
+++ b/tests/fixtures/analysis/SA007/no_trigger/alter_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN bio text;

--- a/tests/fixtures/analysis/SA007/no_trigger/create_table.sql
+++ b/tests/fixtures/analysis/SA007/no_trigger/create_table.sql
@@ -1,0 +1,1 @@
+CREATE TABLE users (id bigint PRIMARY KEY, email text NOT NULL);

--- a/tests/fixtures/analysis/SA007/no_trigger/drop_index.sql
+++ b/tests/fixtures/analysis/SA007/no_trigger/drop_index.sql
@@ -1,0 +1,2 @@
+-- DROP INDEX is SA005, not SA007
+DROP INDEX idx_users_email;

--- a/tests/fixtures/analysis/SA007/no_trigger/drop_table_in_revert.sql
+++ b/tests/fixtures/analysis/SA007/no_trigger/drop_table_in_revert.sql
@@ -1,0 +1,2 @@
+-- In revert context, DROP TABLE is expected
+DROP TABLE users;

--- a/tests/fixtures/analysis/SA007/no_trigger/select_statement.sql
+++ b/tests/fixtures/analysis/SA007/no_trigger/select_statement.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users;

--- a/tests/fixtures/analysis/SA007/trigger/drop_table.sql
+++ b/tests/fixtures/analysis/SA007/trigger/drop_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE users;

--- a/tests/fixtures/analysis/SA007/trigger/drop_table_cascade.sql
+++ b/tests/fixtures/analysis/SA007/trigger/drop_table_cascade.sql
@@ -1,0 +1,1 @@
+DROP TABLE orders CASCADE;

--- a/tests/fixtures/analysis/SA007/trigger/drop_table_if_exists.sql
+++ b/tests/fixtures/analysis/SA007/trigger/drop_table_if_exists.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/tests/fixtures/analysis/SA008/no_trigger/delete_with_where.sql
+++ b/tests/fixtures/analysis/SA008/no_trigger/delete_with_where.sql
@@ -1,0 +1,1 @@
+DELETE FROM users WHERE id = 1;

--- a/tests/fixtures/analysis/SA008/no_trigger/drop_table.sql
+++ b/tests/fixtures/analysis/SA008/no_trigger/drop_table.sql
@@ -1,0 +1,2 @@
+-- DROP TABLE is SA007, not SA008
+DROP TABLE users;

--- a/tests/fixtures/analysis/SA008/no_trigger/select_statement.sql
+++ b/tests/fixtures/analysis/SA008/no_trigger/select_statement.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users;

--- a/tests/fixtures/analysis/SA008/no_trigger/truncate_in_do_block.sql
+++ b/tests/fixtures/analysis/SA008/no_trigger/truncate_in_do_block.sql
@@ -1,0 +1,6 @@
+-- TRUNCATE inside a DO block is excluded from SA008
+DO $$
+BEGIN
+  TRUNCATE old_data;
+END;
+$$;

--- a/tests/fixtures/analysis/SA008/no_trigger/truncate_in_function.sql
+++ b/tests/fixtures/analysis/SA008/no_trigger/truncate_in_function.sql
@@ -1,0 +1,6 @@
+-- TRUNCATE inside a function body is excluded from SA008
+CREATE FUNCTION reset_data() RETURNS void AS $$
+BEGIN
+  TRUNCATE users;
+END;
+$$ LANGUAGE plpgsql;

--- a/tests/fixtures/analysis/SA008/trigger/truncate_cascade.sql
+++ b/tests/fixtures/analysis/SA008/trigger/truncate_cascade.sql
@@ -1,0 +1,1 @@
+TRUNCATE orders CASCADE;

--- a/tests/fixtures/analysis/SA008/trigger/truncate_multiple_tables.sql
+++ b/tests/fixtures/analysis/SA008/trigger/truncate_multiple_tables.sql
@@ -1,0 +1,1 @@
+TRUNCATE users, orders, events;

--- a/tests/fixtures/analysis/SA008/trigger/truncate_table.sql
+++ b/tests/fixtures/analysis/SA008/trigger/truncate_table.sql
@@ -1,0 +1,1 @@
+TRUNCATE users;

--- a/tests/fixtures/analysis/SA009/no_trigger/add_check_constraint.sql
+++ b/tests/fixtures/analysis/SA009/no_trigger/add_check_constraint.sql
@@ -1,0 +1,2 @@
+-- CHECK constraint is not a foreign key
+ALTER TABLE users ADD CONSTRAINT check_email CHECK (email IS NOT NULL);

--- a/tests/fixtures/analysis/SA009/no_trigger/add_fk_not_valid.sql
+++ b/tests/fixtures/analysis/SA009/no_trigger/add_fk_not_valid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders ADD CONSTRAINT fk_orders_user
+  FOREIGN KEY (user_id) REFERENCES users(id) NOT VALID;

--- a/tests/fixtures/analysis/SA009/no_trigger/add_unique_constraint.sql
+++ b/tests/fixtures/analysis/SA009/no_trigger/add_unique_constraint.sql
@@ -1,0 +1,2 @@
+-- UNIQUE constraint is not a foreign key
+ALTER TABLE users ADD CONSTRAINT unique_email UNIQUE (email);

--- a/tests/fixtures/analysis/SA009/no_trigger/create_table_with_fk.sql
+++ b/tests/fixtures/analysis/SA009/no_trigger/create_table_with_fk.sql
@@ -1,0 +1,5 @@
+-- FK in CREATE TABLE is not the same as ALTER TABLE ADD
+CREATE TABLE orders (
+  id bigint PRIMARY KEY,
+  user_id bigint REFERENCES users(id)
+);

--- a/tests/fixtures/analysis/SA009/no_trigger/validate_constraint.sql
+++ b/tests/fixtures/analysis/SA009/no_trigger/validate_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders VALIDATE CONSTRAINT fk_orders_user;

--- a/tests/fixtures/analysis/SA009/trigger/add_fk_composite_no_not_valid.sql
+++ b/tests/fixtures/analysis/SA009/trigger/add_fk_composite_no_not_valid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE order_items ADD CONSTRAINT fk_order_items
+  FOREIGN KEY (order_id, product_id) REFERENCES orders(id, product_id);

--- a/tests/fixtures/analysis/SA009/trigger/add_fk_no_not_valid.sql
+++ b/tests/fixtures/analysis/SA009/trigger/add_fk_no_not_valid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders ADD CONSTRAINT fk_orders_user
+  FOREIGN KEY (user_id) REFERENCES users(id);

--- a/tests/fixtures/analysis/SA009/trigger/add_fk_on_delete_cascade.sql
+++ b/tests/fixtures/analysis/SA009/trigger/add_fk_on_delete_cascade.sql
@@ -1,0 +1,2 @@
+ALTER TABLE comments ADD CONSTRAINT fk_comments_post
+  FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE;

--- a/tests/fixtures/analysis/SA010/no_trigger/delete_in_do_block.sql
+++ b/tests/fixtures/analysis/SA010/no_trigger/delete_in_do_block.sql
@@ -1,0 +1,6 @@
+-- DELETE inside a DO block is excluded from SA010
+DO $$
+BEGIN
+  DELETE FROM temp_data;
+END;
+$$;

--- a/tests/fixtures/analysis/SA010/no_trigger/delete_with_where.sql
+++ b/tests/fixtures/analysis/SA010/no_trigger/delete_with_where.sql
@@ -1,0 +1,1 @@
+DELETE FROM audit_log WHERE created_at < '2024-01-01';

--- a/tests/fixtures/analysis/SA010/no_trigger/insert_statement.sql
+++ b/tests/fixtures/analysis/SA010/no_trigger/insert_statement.sql
@@ -1,0 +1,1 @@
+INSERT INTO users (email, name) VALUES ('test@example.com', 'Test User');

--- a/tests/fixtures/analysis/SA010/no_trigger/select_statement.sql
+++ b/tests/fixtures/analysis/SA010/no_trigger/select_statement.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users;

--- a/tests/fixtures/analysis/SA010/no_trigger/update_in_function.sql
+++ b/tests/fixtures/analysis/SA010/no_trigger/update_in_function.sql
@@ -1,0 +1,6 @@
+-- UPDATE inside a function body is excluded from SA010
+CREATE FUNCTION reset_users() RETURNS void AS $$
+BEGIN
+  UPDATE users SET status = 'inactive';
+END;
+$$ LANGUAGE plpgsql;

--- a/tests/fixtures/analysis/SA010/no_trigger/update_with_where.sql
+++ b/tests/fixtures/analysis/SA010/no_trigger/update_with_where.sql
@@ -1,0 +1,1 @@
+UPDATE users SET status = 'inactive' WHERE last_login < '2024-01-01';

--- a/tests/fixtures/analysis/SA010/trigger/delete_no_where.sql
+++ b/tests/fixtures/analysis/SA010/trigger/delete_no_where.sql
@@ -1,0 +1,1 @@
+DELETE FROM audit_log;

--- a/tests/fixtures/analysis/SA010/trigger/update_multiple_columns_no_where.sql
+++ b/tests/fixtures/analysis/SA010/trigger/update_multiple_columns_no_where.sql
@@ -1,0 +1,1 @@
+UPDATE orders SET status = 'cancelled', updated_at = now();

--- a/tests/fixtures/analysis/SA010/trigger/update_no_where.sql
+++ b/tests/fixtures/analysis/SA010/trigger/update_no_where.sql
@@ -1,0 +1,1 @@
+UPDATE users SET status = 'inactive';

--- a/tests/unit/analysis-rules.test.ts
+++ b/tests/unit/analysis-rules.test.ts
@@ -1,0 +1,1080 @@
+/**
+ * Tests for analysis rules SA001-SA010.
+ *
+ * Uses libpg-query to parse SQL fixtures and verifies that each rule
+ * triggers (or does not trigger) on the appropriate SQL patterns.
+ *
+ * Test structure per rule:
+ * - trigger/ fixtures: must produce at least one finding with the rule ID
+ * - no_trigger/ fixtures: must produce zero findings for that rule
+ * - Additional inline tests for edge cases and specific behaviors
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { parseSync, loadModule } from "libpg-query";
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+import { SA001 } from "../../src/analysis/rules/SA001.js";
+import { SA002 } from "../../src/analysis/rules/SA002.js";
+import { SA002b } from "../../src/analysis/rules/SA002b.js";
+import { SA003 } from "../../src/analysis/rules/SA003.js";
+import { SA004 } from "../../src/analysis/rules/SA004.js";
+import { SA005 } from "../../src/analysis/rules/SA005.js";
+import { SA006 } from "../../src/analysis/rules/SA006.js";
+import { SA007 } from "../../src/analysis/rules/SA007.js";
+import { SA008 } from "../../src/analysis/rules/SA008.js";
+import { SA009 } from "../../src/analysis/rules/SA009.js";
+import { SA010 } from "../../src/analysis/rules/SA010.js";
+import { allRules, getRule } from "../../src/analysis/rules/index.js";
+import type { AnalysisContext } from "../../src/analysis/types.js";
+
+const FIXTURES_DIR = join(import.meta.dir, "..", "fixtures", "analysis");
+
+/**
+ * Build an AnalysisContext from raw SQL text.
+ */
+function makeContext(
+  sql: string,
+  overrides: Partial<AnalysisContext> = {},
+): AnalysisContext {
+  const ast = parseSync(sql);
+  return {
+    ast,
+    rawSql: sql,
+    filePath: overrides.filePath ?? "test.sql",
+    pgVersion: overrides.pgVersion ?? 17,
+    config: overrides.config ?? {},
+    isRevertContext: overrides.isRevertContext ?? false,
+    ...overrides,
+  };
+}
+
+/**
+ * Load a fixture file and build a context.
+ */
+function loadFixture(
+  ruleId: string,
+  category: "trigger" | "no_trigger",
+  fileName: string,
+  overrides: Partial<AnalysisContext> = {},
+): AnalysisContext {
+  const filePath = join(FIXTURES_DIR, ruleId, category, fileName);
+  const sql = readFileSync(filePath, "utf-8");
+  return makeContext(sql, { filePath, ...overrides });
+}
+
+/**
+ * Get all fixture files in a directory.
+ */
+function getFixtureFiles(
+  ruleId: string,
+  category: "trigger" | "no_trigger",
+): string[] {
+  const dir = join(FIXTURES_DIR, ruleId, category);
+  try {
+    return readdirSync(dir).filter((f) => f.endsWith(".sql"));
+  } catch {
+    return [];
+  }
+}
+
+// Load WASM module before all tests
+beforeAll(async () => {
+  await loadModule();
+});
+
+// ─── Registry ────────────────────────────────────────────────────────
+
+describe("rule registry", () => {
+  test("allRules contains 11 rules", () => {
+    expect(allRules).toHaveLength(11);
+  });
+
+  test("getRule returns rules by ID", () => {
+    expect(getRule("SA001")?.id).toBe("SA001");
+    expect(getRule("SA002")?.id).toBe("SA002");
+    expect(getRule("SA002b")?.id).toBe("SA002b");
+    expect(getRule("SA010")?.id).toBe("SA010");
+  });
+
+  test("getRule returns undefined for unknown ID", () => {
+    expect(getRule("SA999")).toBeUndefined();
+  });
+
+  test("all rules have correct interface fields", () => {
+    for (const rule of allRules) {
+      expect(rule.id).toMatch(/^SA\d{3}b?$/);
+      expect(["error", "warn", "info"]).toContain(rule.severity);
+      expect(["static", "connected", "hybrid"]).toContain(rule.type);
+      expect(typeof rule.check).toBe("function");
+    }
+  });
+});
+
+// ─── SA001: ADD COLUMN NOT NULL without DEFAULT ──────────────────────
+
+describe("SA001: ADD COLUMN NOT NULL without DEFAULT", () => {
+  test("metadata", () => {
+    expect(SA001.id).toBe("SA001");
+    expect(SA001.severity).toBe("error");
+    expect(SA001.type).toBe("static");
+  });
+
+  // Trigger fixtures
+  for (const file of getFixtureFiles("SA001", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA001", "trigger", file);
+      const findings = SA001.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA001");
+      expect(findings[0]!.severity).toBe("error");
+    });
+  }
+
+  // No-trigger fixtures
+  for (const file of getFixtureFiles("SA001", "no_trigger")) {
+    test(`does not trigger on ${file}`, () => {
+      const ctx = loadFixture("SA001", "no_trigger", file);
+      const findings = SA001.check(ctx);
+      expect(findings).toHaveLength(0);
+    });
+  }
+
+  test("finding includes table and column names", () => {
+    const ctx = makeContext("ALTER TABLE users ADD COLUMN email text NOT NULL;");
+    const findings = SA001.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("email");
+    expect(findings[0]!.message).toContain("users");
+  });
+
+  test("finding includes suggestion", () => {
+    const ctx = makeContext(
+      "ALTER TABLE users ADD COLUMN email text NOT NULL;",
+    );
+    const findings = SA001.check(ctx);
+    expect(findings[0]!.suggestion).toBeDefined();
+    expect(findings[0]!.suggestion).toContain("DEFAULT");
+  });
+
+  test("finding has valid location", () => {
+    const ctx = makeContext(
+      "ALTER TABLE users ADD COLUMN email text NOT NULL;",
+    );
+    const findings = SA001.check(ctx);
+    expect(findings[0]!.location.line).toBe(1);
+    expect(findings[0]!.location.column).toBe(1);
+  });
+
+  test("handles multiple ADD COLUMN in one statement", () => {
+    const sql = `ALTER TABLE t ADD COLUMN a int NOT NULL, ADD COLUMN b int NOT NULL;`;
+    const ctx = makeContext(sql);
+    const findings = SA001.check(ctx);
+    expect(findings).toHaveLength(2);
+  });
+
+  test("does not fire on ADD COLUMN with NOT NULL and DEFAULT", () => {
+    const ctx = makeContext(
+      "ALTER TABLE users ADD COLUMN status text NOT NULL DEFAULT 'active';",
+    );
+    const findings = SA001.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("empty SQL produces no findings", () => {
+    const ctx = makeContext("SELECT 1;");
+    const findings = SA001.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+});
+
+// ─── SA002: ADD COLUMN DEFAULT volatile ──────────────────────────────
+
+describe("SA002: ADD COLUMN DEFAULT volatile", () => {
+  test("metadata", () => {
+    expect(SA002.id).toBe("SA002");
+    expect(SA002.severity).toBe("error");
+    expect(SA002.type).toBe("static");
+  });
+
+  for (const file of getFixtureFiles("SA002", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA002", "trigger", file);
+      const findings = SA002.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA002");
+      expect(findings[0]!.severity).toBe("error");
+    });
+  }
+
+  for (const file of getFixtureFiles("SA002", "no_trigger")) {
+    test(`does not trigger on ${file}`, () => {
+      const ctx = loadFixture("SA002", "no_trigger", file);
+      const findings = SA002.check(ctx);
+      expect(findings).toHaveLength(0);
+    });
+  }
+
+  test("detects gen_random_uuid()", () => {
+    const ctx = makeContext(
+      "ALTER TABLE users ADD COLUMN id uuid DEFAULT gen_random_uuid();",
+    );
+    const findings = SA002.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("gen_random_uuid");
+  });
+
+  test("detects random()", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD COLUMN sort_key float DEFAULT random();",
+    );
+    const findings = SA002.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("random");
+  });
+
+  test("detects clock_timestamp()", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD COLUMN ts timestamptz DEFAULT clock_timestamp();",
+    );
+    const findings = SA002.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("clock_timestamp");
+  });
+
+  test("detects txid_current()", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD COLUMN txid bigint DEFAULT txid_current();",
+    );
+    const findings = SA002.check(ctx);
+    expect(findings).toHaveLength(1);
+  });
+
+  test("detects volatile function inside type cast", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD COLUMN priority int DEFAULT random()::int;",
+    );
+    const findings = SA002.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("random");
+  });
+
+  test("does not fire on now() — it is STABLE", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD COLUMN created_at timestamptz DEFAULT now();",
+    );
+    const findings = SA002.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not fire on literal defaults", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD COLUMN status text DEFAULT 'active';",
+    );
+    const findings = SA002.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not fire on integer defaults", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD COLUMN count integer DEFAULT 0;",
+    );
+    const findings = SA002.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+});
+
+// ─── SA002b: ADD COLUMN DEFAULT non-volatile on PG < 11 ─────────────
+
+describe("SA002b: ADD COLUMN DEFAULT non-volatile on PG < 11", () => {
+  test("metadata", () => {
+    expect(SA002b.id).toBe("SA002b");
+    expect(SA002b.severity).toBe("warn");
+    expect(SA002b.type).toBe("static");
+  });
+
+  test("triggers on non-volatile default with pgVersion=10", () => {
+    const ctx = loadFixture(
+      "SA002b",
+      "trigger",
+      "add_column_default_literal_pg10.sql",
+      { pgVersion: 10 },
+    );
+    const findings = SA002b.check(ctx);
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+    expect(findings[0]!.ruleId).toBe("SA002b");
+    expect(findings[0]!.severity).toBe("warn");
+  });
+
+  test("triggers on now() default with pgVersion=10", () => {
+    const ctx = loadFixture(
+      "SA002b",
+      "trigger",
+      "add_column_default_now_pg10.sql",
+      { pgVersion: 10 },
+    );
+    const findings = SA002b.check(ctx);
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("triggers on integer default with pgVersion=10", () => {
+    const ctx = loadFixture(
+      "SA002b",
+      "trigger",
+      "add_column_default_integer_pg10.sql",
+      { pgVersion: 10 },
+    );
+    const findings = SA002b.check(ctx);
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("does not trigger on pgVersion=17", () => {
+    const ctx = loadFixture(
+      "SA002b",
+      "no_trigger",
+      "add_column_default_literal_pg17.sql",
+      { pgVersion: 17 },
+    );
+    const findings = SA002b.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not trigger on pgVersion=14", () => {
+    const ctx = loadFixture(
+      "SA002b",
+      "no_trigger",
+      "add_column_default_boolean_pg14.sql",
+      { pgVersion: 14 },
+    );
+    const findings = SA002b.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not trigger when no default is present", () => {
+    const ctx = loadFixture("SA002b", "no_trigger", "add_column_no_default.sql", {
+      pgVersion: 10,
+    });
+    const findings = SA002b.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not trigger on volatile defaults (handled by SA002)", () => {
+    const ctx = loadFixture(
+      "SA002b",
+      "no_trigger",
+      "add_column_volatile_default_pg10.sql",
+      { pgVersion: 10 },
+    );
+    const findings = SA002b.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not trigger on pgVersion=11 (boundary)", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD COLUMN status text DEFAULT 'active';",
+      { pgVersion: 11 },
+    );
+    const findings = SA002b.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("finding includes pg version in message", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD COLUMN status text DEFAULT 'active';",
+      { pgVersion: 10 },
+    );
+    const findings = SA002b.check(ctx);
+    expect(findings[0]!.message).toContain("10");
+  });
+});
+
+// ─── SA003: ALTER COLUMN TYPE non-trivial cast ───────────────────────
+
+describe("SA003: ALTER COLUMN TYPE", () => {
+  test("metadata", () => {
+    expect(SA003.id).toBe("SA003");
+    expect(SA003.severity).toBe("error");
+    expect(SA003.type).toBe("static");
+  });
+
+  for (const file of getFixtureFiles("SA003", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA003", "trigger", file);
+      const findings = SA003.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA003");
+      expect(findings[0]!.severity).toBe("error");
+    });
+  }
+
+  for (const file of getFixtureFiles("SA003", "no_trigger")) {
+    test(`does not trigger on ${file}`, () => {
+      const ctx = loadFixture("SA003", "no_trigger", file);
+      const findings = SA003.check(ctx);
+      expect(findings).toHaveLength(0);
+    });
+  }
+
+  test("fires on int to bigint", () => {
+    const ctx = makeContext("ALTER TABLE t ALTER COLUMN id TYPE bigint;");
+    const findings = SA003.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("id");
+  });
+
+  test("fires on timestamp to timestamptz", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ALTER COLUMN ts TYPE timestamptz;",
+    );
+    const findings = SA003.check(ctx);
+    expect(findings).toHaveLength(1);
+  });
+
+  test("fires on USING clause even for trivial types", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ALTER COLUMN name TYPE text USING name::text;",
+    );
+    const findings = SA003.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("USING");
+  });
+
+  test("includes target type in message", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ALTER COLUMN id TYPE bigint;",
+    );
+    const findings = SA003.check(ctx);
+    expect(findings[0]!.message).toMatch(/bigint|int8/);
+  });
+
+  test("includes column name in message", () => {
+    const ctx = makeContext(
+      "ALTER TABLE users ALTER COLUMN email TYPE varchar(255);",
+    );
+    const findings = SA003.check(ctx);
+    expect(findings[0]!.message).toContain("email");
+    expect(findings[0]!.message).toContain("users");
+  });
+});
+
+// ─── SA004: CREATE INDEX without CONCURRENTLY ────────────────────────
+
+describe("SA004: CREATE INDEX without CONCURRENTLY", () => {
+  test("metadata", () => {
+    expect(SA004.id).toBe("SA004");
+    expect(SA004.severity).toBe("warn");
+    expect(SA004.type).toBe("static");
+  });
+
+  for (const file of getFixtureFiles("SA004", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA004", "trigger", file);
+      const findings = SA004.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA004");
+      expect(findings[0]!.severity).toBe("warn");
+    });
+  }
+
+  for (const file of getFixtureFiles("SA004", "no_trigger")) {
+    test(`does not trigger on ${file}`, () => {
+      const ctx = loadFixture("SA004", "no_trigger", file);
+      const findings = SA004.check(ctx);
+      expect(findings).toHaveLength(0);
+    });
+  }
+
+  test("fires on CREATE INDEX", () => {
+    const ctx = makeContext("CREATE INDEX idx ON users (email);");
+    const findings = SA004.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("idx");
+    expect(findings[0]!.message).toContain("users");
+  });
+
+  test("does not fire on CREATE INDEX CONCURRENTLY", () => {
+    const ctx = makeContext(
+      "CREATE INDEX CONCURRENTLY idx ON users (email);",
+    );
+    const findings = SA004.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("fires on CREATE UNIQUE INDEX without CONCURRENTLY", () => {
+    const ctx = makeContext(
+      "CREATE UNIQUE INDEX idx ON users (email);",
+    );
+    const findings = SA004.check(ctx);
+    expect(findings).toHaveLength(1);
+  });
+
+  test("includes suggestion about CONCURRENTLY", () => {
+    const ctx = makeContext("CREATE INDEX idx ON users (email);");
+    const findings = SA004.check(ctx);
+    expect(findings[0]!.suggestion).toContain("CONCURRENTLY");
+  });
+});
+
+// ─── SA005: DROP INDEX without CONCURRENTLY ──────────────────────────
+
+describe("SA005: DROP INDEX without CONCURRENTLY", () => {
+  test("metadata", () => {
+    expect(SA005.id).toBe("SA005");
+    expect(SA005.severity).toBe("warn");
+    expect(SA005.type).toBe("static");
+  });
+
+  for (const file of getFixtureFiles("SA005", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA005", "trigger", file);
+      const findings = SA005.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA005");
+      expect(findings[0]!.severity).toBe("warn");
+    });
+  }
+
+  for (const file of getFixtureFiles("SA005", "no_trigger")) {
+    test(`does not trigger on ${file}`, () => {
+      const ctx = loadFixture("SA005", "no_trigger", file);
+      const findings = SA005.check(ctx);
+      expect(findings).toHaveLength(0);
+    });
+  }
+
+  test("fires on DROP INDEX", () => {
+    const ctx = makeContext("DROP INDEX idx_users_email;");
+    const findings = SA005.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("idx_users_email");
+  });
+
+  test("does not fire on DROP INDEX CONCURRENTLY", () => {
+    const ctx = makeContext("DROP INDEX CONCURRENTLY idx_users_email;");
+    const findings = SA005.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not fire on DROP TABLE (different rule)", () => {
+    const ctx = makeContext("DROP TABLE users;");
+    const findings = SA005.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("includes AccessExclusiveLock in message", () => {
+    const ctx = makeContext("DROP INDEX idx;");
+    const findings = SA005.check(ctx);
+    expect(findings[0]!.message).toContain("AccessExclusiveLock");
+  });
+
+  test("includes suggestion about CONCURRENTLY", () => {
+    const ctx = makeContext("DROP INDEX idx;");
+    const findings = SA005.check(ctx);
+    expect(findings[0]!.suggestion).toContain("CONCURRENTLY");
+  });
+});
+
+// ─── SA006: DROP COLUMN ──────────────────────────────────────────────
+
+describe("SA006: DROP COLUMN", () => {
+  test("metadata", () => {
+    expect(SA006.id).toBe("SA006");
+    expect(SA006.severity).toBe("warn");
+    expect(SA006.type).toBe("static");
+  });
+
+  for (const file of getFixtureFiles("SA006", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA006", "trigger", file);
+      const findings = SA006.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA006");
+      expect(findings[0]!.severity).toBe("warn");
+    });
+  }
+
+  for (const file of getFixtureFiles("SA006", "no_trigger")) {
+    test(`does not trigger on ${file}`, () => {
+      const ctx = loadFixture("SA006", "no_trigger", file);
+      const findings = SA006.check(ctx);
+      expect(findings).toHaveLength(0);
+    });
+  }
+
+  test("fires on DROP COLUMN", () => {
+    const ctx = makeContext("ALTER TABLE users DROP COLUMN email;");
+    const findings = SA006.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("email");
+    expect(findings[0]!.message).toContain("users");
+  });
+
+  test("fires on DROP COLUMN IF EXISTS", () => {
+    const ctx = makeContext(
+      "ALTER TABLE users DROP COLUMN IF EXISTS old_field;",
+    );
+    const findings = SA006.check(ctx);
+    expect(findings).toHaveLength(1);
+  });
+
+  test("fires on DROP COLUMN CASCADE", () => {
+    const ctx = makeContext("ALTER TABLE t DROP COLUMN c CASCADE;");
+    const findings = SA006.check(ctx);
+    expect(findings).toHaveLength(1);
+  });
+
+  test("does not fire on ADD COLUMN", () => {
+    const ctx = makeContext("ALTER TABLE users ADD COLUMN bio text;");
+    const findings = SA006.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("includes data loss in message", () => {
+    const ctx = makeContext("ALTER TABLE t DROP COLUMN c;");
+    const findings = SA006.check(ctx);
+    expect(findings[0]!.message).toContain("data loss");
+  });
+});
+
+// ─── SA007: DROP TABLE ───────────────────────────────────────────────
+
+describe("SA007: DROP TABLE in non-revert context", () => {
+  test("metadata", () => {
+    expect(SA007.id).toBe("SA007");
+    expect(SA007.severity).toBe("error");
+    expect(SA007.type).toBe("static");
+  });
+
+  for (const file of getFixtureFiles("SA007", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA007", "trigger", file);
+      const findings = SA007.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA007");
+      expect(findings[0]!.severity).toBe("error");
+    });
+  }
+
+  // Special handling for no_trigger: some need isRevertContext
+  test("does not trigger in revert context", () => {
+    const ctx = loadFixture(
+      "SA007",
+      "no_trigger",
+      "drop_table_in_revert.sql",
+      { isRevertContext: true },
+    );
+    const findings = SA007.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not trigger on DROP INDEX", () => {
+    const ctx = loadFixture("SA007", "no_trigger", "drop_index.sql");
+    const findings = SA007.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not trigger on CREATE TABLE", () => {
+    const ctx = loadFixture("SA007", "no_trigger", "create_table.sql");
+    const findings = SA007.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not trigger on ALTER TABLE", () => {
+    const ctx = loadFixture("SA007", "no_trigger", "alter_table.sql");
+    const findings = SA007.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not trigger on SELECT", () => {
+    const ctx = loadFixture("SA007", "no_trigger", "select_statement.sql");
+    const findings = SA007.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("fires on DROP TABLE", () => {
+    const ctx = makeContext("DROP TABLE users;");
+    const findings = SA007.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("users");
+  });
+
+  test("fires on DROP TABLE IF EXISTS", () => {
+    const ctx = makeContext("DROP TABLE IF EXISTS users;");
+    const findings = SA007.check(ctx);
+    expect(findings).toHaveLength(1);
+  });
+
+  test("fires on DROP TABLE CASCADE", () => {
+    const ctx = makeContext("DROP TABLE orders CASCADE;");
+    const findings = SA007.check(ctx);
+    expect(findings).toHaveLength(1);
+  });
+
+  test("exempt in revert context", () => {
+    const ctx = makeContext("DROP TABLE users;", { isRevertContext: true });
+    const findings = SA007.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("includes data loss in message", () => {
+    const ctx = makeContext("DROP TABLE t;");
+    const findings = SA007.check(ctx);
+    expect(findings[0]!.message).toContain("data loss");
+  });
+});
+
+// ─── SA008: TRUNCATE ─────────────────────────────────────────────────
+
+describe("SA008: TRUNCATE", () => {
+  test("metadata", () => {
+    expect(SA008.id).toBe("SA008");
+    expect(SA008.severity).toBe("warn");
+    expect(SA008.type).toBe("static");
+  });
+
+  for (const file of getFixtureFiles("SA008", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA008", "trigger", file);
+      const findings = SA008.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA008");
+      expect(findings[0]!.severity).toBe("warn");
+    });
+  }
+
+  for (const file of getFixtureFiles("SA008", "no_trigger")) {
+    test(`does not trigger on ${file}`, () => {
+      const ctx = loadFixture("SA008", "no_trigger", file);
+      const findings = SA008.check(ctx);
+      expect(findings).toHaveLength(0);
+    });
+  }
+
+  test("fires on TRUNCATE", () => {
+    const ctx = makeContext("TRUNCATE users;");
+    const findings = SA008.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("users");
+  });
+
+  test("fires on TRUNCATE CASCADE", () => {
+    const ctx = makeContext("TRUNCATE orders CASCADE;");
+    const findings = SA008.check(ctx);
+    expect(findings).toHaveLength(1);
+  });
+
+  test("fires on TRUNCATE multiple tables", () => {
+    const ctx = makeContext("TRUNCATE users, orders;");
+    const findings = SA008.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("users");
+    expect(findings[0]!.message).toContain("orders");
+  });
+
+  test("excludes TRUNCATE inside CREATE FUNCTION", () => {
+    const sql = `
+      CREATE FUNCTION reset() RETURNS void AS $$
+      BEGIN
+        TRUNCATE users;
+      END;
+      $$ LANGUAGE plpgsql;
+    `;
+    const ctx = makeContext(sql);
+    const findings = SA008.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("excludes TRUNCATE inside DO block", () => {
+    const sql = `
+      DO $$
+      BEGIN
+        TRUNCATE old_data;
+      END;
+      $$;
+    `;
+    const ctx = makeContext(sql);
+    const findings = SA008.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("includes AccessExclusiveLock in message", () => {
+    const ctx = makeContext("TRUNCATE t;");
+    const findings = SA008.check(ctx);
+    expect(findings[0]!.message).toContain("AccessExclusiveLock");
+  });
+});
+
+// ─── SA009: ADD FOREIGN KEY without NOT VALID ────────────────────────
+
+describe("SA009: ADD FOREIGN KEY without NOT VALID", () => {
+  test("metadata", () => {
+    expect(SA009.id).toBe("SA009");
+    expect(SA009.severity).toBe("warn");
+    expect(SA009.type).toBe("hybrid");
+  });
+
+  for (const file of getFixtureFiles("SA009", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA009", "trigger", file);
+      const findings = SA009.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA009");
+      expect(findings[0]!.severity).toBe("warn");
+    });
+  }
+
+  for (const file of getFixtureFiles("SA009", "no_trigger")) {
+    test(`does not trigger on ${file}`, () => {
+      const ctx = loadFixture("SA009", "no_trigger", file);
+      const findings = SA009.check(ctx);
+      expect(findings).toHaveLength(0);
+    });
+  }
+
+  test("fires on ADD FOREIGN KEY without NOT VALID", () => {
+    const ctx = makeContext(
+      "ALTER TABLE orders ADD CONSTRAINT fk FOREIGN KEY (user_id) REFERENCES users(id);",
+    );
+    const findings = SA009.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("fk");
+    expect(findings[0]!.message).toContain("user_id");
+  });
+
+  test("does not fire on ADD FOREIGN KEY with NOT VALID", () => {
+    const ctx = makeContext(
+      "ALTER TABLE orders ADD CONSTRAINT fk FOREIGN KEY (user_id) REFERENCES users(id) NOT VALID;",
+    );
+    const findings = SA009.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not fire on CHECK constraint", () => {
+    const ctx = makeContext(
+      "ALTER TABLE users ADD CONSTRAINT chk CHECK (age > 0);",
+    );
+    const findings = SA009.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not fire on UNIQUE constraint", () => {
+    const ctx = makeContext(
+      "ALTER TABLE users ADD CONSTRAINT uniq UNIQUE (email);",
+    );
+    const findings = SA009.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("includes suggestion about NOT VALID + VALIDATE", () => {
+    const ctx = makeContext(
+      "ALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (c) REFERENCES t2(id);",
+    );
+    const findings = SA009.check(ctx);
+    expect(findings[0]!.suggestion).toContain("NOT VALID");
+    expect(findings[0]!.suggestion).toContain("VALIDATE CONSTRAINT");
+  });
+
+  test("includes referenced table in message", () => {
+    const ctx = makeContext(
+      "ALTER TABLE orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id);",
+    );
+    const findings = SA009.check(ctx);
+    expect(findings[0]!.message).toContain("users");
+  });
+});
+
+// ─── SA010: UPDATE/DELETE without WHERE ──────────────────────────────
+
+describe("SA010: UPDATE/DELETE without WHERE", () => {
+  test("metadata", () => {
+    expect(SA010.id).toBe("SA010");
+    expect(SA010.severity).toBe("warn");
+    expect(SA010.type).toBe("static");
+  });
+
+  for (const file of getFixtureFiles("SA010", "trigger")) {
+    test(`triggers on ${file}`, () => {
+      const ctx = loadFixture("SA010", "trigger", file);
+      const findings = SA010.check(ctx);
+      expect(findings.length).toBeGreaterThanOrEqual(1);
+      expect(findings[0]!.ruleId).toBe("SA010");
+      expect(findings[0]!.severity).toBe("warn");
+    });
+  }
+
+  for (const file of getFixtureFiles("SA010", "no_trigger")) {
+    test(`does not trigger on ${file}`, () => {
+      const ctx = loadFixture("SA010", "no_trigger", file);
+      const findings = SA010.check(ctx);
+      expect(findings).toHaveLength(0);
+    });
+  }
+
+  test("fires on UPDATE without WHERE", () => {
+    const ctx = makeContext("UPDATE users SET status = 'inactive';");
+    const findings = SA010.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("users");
+    expect(findings[0]!.message).toContain("UPDATE");
+  });
+
+  test("fires on DELETE without WHERE", () => {
+    const ctx = makeContext("DELETE FROM audit_log;");
+    const findings = SA010.check(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toContain("audit_log");
+    expect(findings[0]!.message).toContain("DELETE");
+  });
+
+  test("does not fire on UPDATE with WHERE", () => {
+    const ctx = makeContext("UPDATE users SET status = 'x' WHERE id = 1;");
+    const findings = SA010.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not fire on DELETE with WHERE", () => {
+    const ctx = makeContext("DELETE FROM t WHERE id = 1;");
+    const findings = SA010.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("excludes UPDATE inside CREATE FUNCTION", () => {
+    const sql = `
+      CREATE FUNCTION reset() RETURNS void AS $$
+      BEGIN
+        UPDATE users SET status = 'inactive';
+      END;
+      $$ LANGUAGE plpgsql;
+    `;
+    const ctx = makeContext(sql);
+    const findings = SA010.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("excludes DELETE inside DO block", () => {
+    const sql = `
+      DO $$
+      BEGIN
+        DELETE FROM temp_data;
+      END;
+      $$;
+    `;
+    const ctx = makeContext(sql);
+    const findings = SA010.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("fires on both UPDATE and DELETE in same file", () => {
+    const sql = `
+      UPDATE users SET status = 'inactive';
+      DELETE FROM audit_log;
+    `;
+    const ctx = makeContext(sql);
+    const findings = SA010.check(ctx);
+    expect(findings).toHaveLength(2);
+  });
+
+  test("does not fire on INSERT", () => {
+    const ctx = makeContext(
+      "INSERT INTO users (email) VALUES ('test@example.com');",
+    );
+    const findings = SA010.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("does not fire on SELECT", () => {
+    const ctx = makeContext("SELECT * FROM users;");
+    const findings = SA010.check(ctx);
+    expect(findings).toHaveLength(0);
+  });
+});
+
+// ─── Cross-cutting tests ─────────────────────────────────────────────
+
+describe("cross-cutting: location and message quality", () => {
+  test("stmt_location 0 for first statement maps to line 1", () => {
+    // libpg-query's protobuf sets stmt_location=0 for the first statement
+    // (protobuf3 zero-value omission), regardless of leading comments.
+    // More precise location mapping will be done in analysis/parser.ts.
+    const sql = `-- comment line 1
+-- comment line 2
+ALTER TABLE users ADD COLUMN email text NOT NULL;
+`;
+    const ctx = makeContext(sql);
+    const findings = SA001.check(ctx);
+    expect(findings).toHaveLength(1);
+    // stmt_location is 0 -> line 1 (parser.ts will refine this later)
+    expect(findings[0]!.location.line).toBe(1);
+  });
+
+  test("multiple statements in same file are detected", () => {
+    const sql = `ALTER TABLE a ADD COLUMN x int NOT NULL;
+ALTER TABLE b ADD COLUMN y int NOT NULL;`;
+    const ctx = makeContext(sql);
+    const findings = SA001.check(ctx);
+    expect(findings).toHaveLength(2);
+    // Both findings have valid locations
+    expect(findings[0]!.location.line).toBeGreaterThanOrEqual(1);
+    expect(findings[1]!.location.line).toBeGreaterThanOrEqual(1);
+    // Second statement should be at same or later line
+    expect(findings[1]!.location.line).toBeGreaterThanOrEqual(
+      findings[0]!.location.line,
+    );
+  });
+
+  test("all findings have required fields", () => {
+    const sql = `
+ALTER TABLE t ADD COLUMN c int NOT NULL;
+ALTER TABLE t ADD COLUMN d uuid DEFAULT gen_random_uuid();
+CREATE INDEX idx ON t (c);
+DROP INDEX old_idx;
+ALTER TABLE t DROP COLUMN old;
+DROP TABLE old_table;
+TRUNCATE cleanup;
+ALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (c) REFERENCES t2(id);
+UPDATE t SET c = 1;
+DELETE FROM t;
+`;
+    const ctx = makeContext(sql);
+
+    for (const rule of allRules) {
+      // Skip SA002b (needs pgVersion < 11) and SA003 (needs ALTER TYPE)
+      if (rule.id === "SA002b") continue;
+      const findings = rule.check(ctx);
+      for (const f of findings) {
+        expect(f.ruleId).toBe(rule.id);
+        expect(f.severity).toBeDefined();
+        expect(f.message).toBeTruthy();
+        expect(f.location).toBeDefined();
+        expect(f.location.file).toBeDefined();
+        expect(f.location.line).toBeGreaterThan(0);
+        expect(f.location.column).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("cross-cutting: empty/edge-case inputs", () => {
+  test("empty SQL produces no findings for any rule", () => {
+    const ctx = makeContext("SELECT 1;");
+    for (const rule of allRules) {
+      const findings = rule.check(ctx);
+      expect(findings).toHaveLength(0);
+    }
+  });
+
+  test("null AST produces no findings", () => {
+    const ctx: AnalysisContext = {
+      ast: { stmts: [] },
+      rawSql: "",
+      filePath: "test.sql",
+      pgVersion: 17,
+      config: {},
+    };
+    for (const rule of allRules) {
+      const findings = rule.check(ctx);
+      expect(findings).toHaveLength(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Implement 11 analysis rules (SA001-SA010) per SPEC Section 5.1, one file per rule in `src/analysis/rules/`
- Add shared types (`Rule`, `Finding`, `AnalysisContext`, `offsetToLocation`) in `src/analysis/types.ts`
- Add rule registry with `allRules` array and `getRule()` lookup in `src/analysis/rules/index.ts`
- 89 SQL fixture files across 11 rule directories in `tests/fixtures/analysis/SA00X/{trigger,no_trigger}/`
- 174 tests covering trigger cases, no-trigger cases, edge cases, PL/pgSQL body exclusion, version-aware behavior, and message/location quality

### Rules implemented

| Rule | Severity | Type | Trigger |
|------|----------|------|---------|
| SA001 | error | static | ADD COLUMN NOT NULL without DEFAULT |
| SA002 | error | static | ADD COLUMN DEFAULT volatile (any PG) |
| SA002b | warn | static | ADD COLUMN DEFAULT non-volatile (PG < 11) |
| SA003 | error | static | ALTER COLUMN TYPE (unsafe cast / USING) |
| SA004 | warn | static | CREATE INDEX without CONCURRENTLY |
| SA005 | warn | static | DROP INDEX without CONCURRENTLY |
| SA006 | warn | static | DROP COLUMN |
| SA007 | error | static | DROP TABLE (non-revert context) |
| SA008 | warn | static | TRUNCATE |
| SA009 | warn | hybrid | ADD FOREIGN KEY without NOT VALID |
| SA010 | warn | static | UPDATE/DELETE without WHERE |

### Design notes

- Each rule is a standalone function that takes a parsed AST and returns `Finding[]`, ready for integration with the analysis engine (issue #50)
- Uses `libpg-query` WASM module for SQL parsing in tests
- SA002 detects volatile functions (`random()`, `gen_random_uuid()`, `clock_timestamp()`, `txid_current()`, etc.) recursively through type casts and expressions
- SA002b is version-aware: only fires when `pgVersion < 11`
- SA003 fires on all type changes in static mode (conservative); USING clause always triggers
- SA007 respects `isRevertContext` flag for sqitch revert script exemption
- SA008/SA010 implement PL/pgSQL body exclusion per spec
- SA009 is typed as hybrid with static NOT VALID check implemented; connected index check is stubbed for DB integration

## Test plan

- [x] 174 tests pass (`bun test tests/unit/analysis-rules.test.ts`)
- [x] Full suite passes (875 tests, 0 failures)
- [x] Zero new TypeScript errors in source files
- [x] Each rule has >= 5 no-trigger fixtures
- [x] Trigger fixtures verify ruleId, severity, and message content
- [x] Cross-cutting tests verify location, field completeness, and edge cases

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)