### PR TITLE
B3: Distribution — release workflow, Dockerfile, npm packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: bun-linux-x64
+            artifact: sqlever-linux-amd64
+          - os: ubuntu-latest
+            target: bun-linux-arm64
+            artifact: sqlever-linux-arm64
+          - os: macos-latest
+            target: bun-darwin-x64
+            artifact: sqlever-macos-amd64
+          - os: macos-latest
+            target: bun-darwin-arm64
+            artifact: sqlever-macos-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - name: Build binary
+        run: bun build src/cli.ts --compile --target=${{ matrix.target }} --outfile dist/${{ matrix.artifact }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+tests/
+spec/
+.github/
+.claude/
+docker-compose.yml
+Dockerfile
+tsconfig.json
+bun.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache postgresql-client
+
+COPY dist/sqlever-linux-amd64 /usr/local/bin/sqlever
+
+ENTRYPOINT ["sqlever"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@
 #   docker compose down -v      # stop PG and remove data volume
 #
 # Port 5417 avoids conflicts with any local PostgreSQL on the default 5432.
+#
+# Production image: see Dockerfile at the repo root. Build with:
+#   bun run build  # produces dist/sqlever-linux-amd64
+#   docker build -t sqlever .
 
 services:
   postgres:


### PR DESCRIPTION
## Summary
- **GitHub Releases workflow** (`.github/workflows/release.yml`): triggers on `v*` tag push, builds compiled binaries for linux-amd64, linux-arm64, macos-amd64, macos-arm64 using `bun build --compile --target=...`, creates a GitHub Release with all 4 binaries attached, and publishes to npm
- **Dockerfile**: Alpine-based image with `postgresql-client` (psql) and the compiled sqlever binary as entrypoint
- **`.npmignore`**: excludes tests/, spec/, .github/, .claude/, Dockerfile, docker-compose.yml, tsconfig.json, bun.lock from the npm package
- **`docker-compose.yml`**: added comment pointing to the production Dockerfile

Closes #80

## Test plan
- [ ] Push a `v*` tag and verify the release workflow builds all 4 platform binaries
- [ ] Verify the GitHub Release is created with binaries attached
- [ ] Verify npm publish step runs (requires `NPM_TOKEN` secret)
- [ ] Build Docker image locally: `bun run build && docker build -t sqlever .`
- [ ] Run `docker run sqlever --version` to verify the image works
- [ ] Run `npm pack --dry-run` and confirm excluded files are not included

🤖 Generated with [Claude Code](https://claude.com/claude-code)