### PR TITLE
feat: doctor command, syntax-version validation, SPEC non-goals

### DIFF
--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -140,6 +140,8 @@ In the agentic development era, engineers increasingly have AI assistants writin
 - GUI or web dashboard — CLI only, composable with other tools
 - Cloud-hosted service — out of scope for now
 - Replacing application-level migration frameworks for teams already happy with them
+- Windows support — not a target for v1.x. Unix-like systems (Linux, macOS) only.
+- Declarative schema management — sqlever is an imperative migration tool (deploy/revert scripts). Automatic diff-based schema generation (a la Atlas, Prisma Migrate) is out of scope.
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { parseShowArgs, runShow } from "./commands/show";
 import { runPlan } from "./commands/plan";
 import { runVerify } from "./commands/verify";
 import { parseAnalyzeArgs, runAnalyze } from "./commands/analyze";
+import { runDoctor } from "./commands/doctor";
 
 // ---------------------------------------------------------------------------
 // Command registry — all commands from SPEC R1 plus sqlever extensions
@@ -45,6 +46,7 @@ const COMMANDS: Record<string, string> = {
   review: "Review migrations for issues",
   batch: "Manage batched background data migrations",
   diff: "Show differences between plan states",
+  doctor: "Validate project setup, plan file, and script consistency",
   help: "Show help for a command",
 };
 
@@ -418,6 +420,12 @@ export function main(argv: string[] = process.argv.slice(2)): void {
     runAnalyze(analyzeOpts)
       .then((result) => { if (result.exitCode !== 0) process.exit(result.exitCode); })
       .catch((err: unknown) => { process.stderr.write(`sqlever analyze: ${err instanceof Error ? err.message : String(err)}\n`); process.exit(1); });
+    return;
+  }
+
+  if (args.command === "doctor") {
+    const exitCode = runDoctor(args);
+    if (exitCode !== 0) process.exit(exitCode);
     return;
   }
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,474 @@
+// src/commands/doctor.ts — sqlever doctor command
+//
+// Validates the project setup and reports potential issues:
+//   1. Plan file parsing — can the plan file be parsed without errors?
+//   2. Change ID consistency — do recomputed IDs match the parent chain?
+//   3. Script file presence — do deploy/revert/verify scripts exist for each change?
+//   4. psql metacommand detection — do any deploy/revert scripts contain psql metacommands?
+//   5. Syntax version check — is %syntax-version set and supported?
+//
+// Exit codes:
+//   0 — all checks passed
+//   1 — one or more checks failed
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import type { ParsedArgs } from "../cli";
+import { parsePlan, PlanParseError } from "../plan/parser";
+import type { Plan } from "../plan/types";
+import { loadConfig } from "../config/index";
+import { info, error as logError, verbose, json as jsonOut, getConfig } from "../output";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DoctorOptions {
+  /** Project root directory. */
+  topDir: string;
+  /** Plan file path override. */
+  planFile?: string;
+  /** Output format override. */
+  format?: "text" | "json";
+}
+
+export type CheckSeverity = "ok" | "warn" | "error";
+
+export interface CheckResult {
+  /** Name of the check. */
+  check: string;
+  /** Severity: ok, warn, or error. */
+  severity: CheckSeverity;
+  /** Human-readable message. */
+  message: string;
+  /** Optional list of details (e.g. missing files, metacommand locations). */
+  details?: string[];
+}
+
+export interface DoctorReport {
+  /** All check results. */
+  checks: CheckResult[];
+  /** Summary counts. */
+  summary: {
+    ok: number;
+    warn: number;
+    error: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+export function parseDoctorArgs(args: ParsedArgs): DoctorOptions {
+  const opts: DoctorOptions = {
+    topDir: args.topDir ?? ".",
+    planFile: args.planFile,
+  };
+
+  const rest = args.rest;
+  let i = 0;
+  while (i < rest.length) {
+    const token = rest[i]!;
+
+    if (token === "--format") {
+      const val = rest[++i];
+      if (val === "json" || val === "text") {
+        opts.format = val;
+      }
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// psql metacommand detection (reuses the same regex from preprocessor)
+// ---------------------------------------------------------------------------
+
+const METACOMMAND_RE = /^\\(?:[a-zA-Z_]\w*|!)(?:\b|\s|$).*$/;
+
+/**
+ * Scan a SQL file for psql metacommand lines.
+ * Returns an array of "line N: <content>" strings for each metacommand found.
+ */
+function detectMetacommands(content: string): string[] {
+  const lines = content.split("\n");
+  const found: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i]!.trimStart();
+    if (METACOMMAND_RE.test(trimmed)) {
+      found.push(`line ${i + 1}: ${trimmed.slice(0, 80)}`);
+    }
+  }
+
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Check 1: Can the plan file be parsed?
+ */
+function checkPlanParsing(planPath: string): CheckResult & { plan?: Plan } {
+  if (!existsSync(planPath)) {
+    return {
+      check: "plan-file",
+      severity: "error",
+      message: `Plan file not found: ${planPath}`,
+    };
+  }
+
+  try {
+    const content = readFileSync(planPath, "utf-8");
+    const plan = parsePlan(content);
+    return {
+      check: "plan-file",
+      severity: "ok",
+      message: `Plan file parsed successfully: ${plan.changes.length} change(s), ${plan.tags.length} tag(s).`,
+      plan,
+    };
+  } catch (err) {
+    const msg = err instanceof PlanParseError
+      ? err.message
+      : (err instanceof Error ? err.message : String(err));
+    return {
+      check: "plan-file",
+      severity: "error",
+      message: `Plan file parse error: ${msg}`,
+    };
+  }
+}
+
+/**
+ * Check 2: Syntax version validation.
+ */
+function checkSyntaxVersion(plan: Plan): CheckResult {
+  const version = plan.pragmas.get("syntax-version");
+
+  if (version === undefined) {
+    return {
+      check: "syntax-version",
+      severity: "warn",
+      message: "No %syntax-version pragma found. Recommend adding %syntax-version=1.0.0.",
+    };
+  }
+
+  const major = parseInt(version.split(".")[0] ?? "", 10);
+  if (isNaN(major) || major !== 1) {
+    return {
+      check: "syntax-version",
+      severity: "error",
+      message: `Unsupported %syntax-version '${version}'. Only syntax-version 1.x is supported.`,
+    };
+  }
+
+  return {
+    check: "syntax-version",
+    severity: "ok",
+    message: `%syntax-version=${version} (supported).`,
+  };
+}
+
+/**
+ * Check 3: Change ID parent chain consistency.
+ *
+ * Verifies that each change's parent field correctly references
+ * the preceding change's change_id.
+ */
+function checkChangeIdChain(plan: Plan): CheckResult {
+  const issues: string[] = [];
+
+  for (let i = 0; i < plan.changes.length; i++) {
+    const change = plan.changes[i]!;
+
+    if (i === 0) {
+      if (change.parent !== undefined) {
+        issues.push(`Change '${change.name}' is the first change but has a parent set.`);
+      }
+    } else {
+      const expectedParent = plan.changes[i - 1]!.change_id;
+      if (change.parent !== expectedParent) {
+        issues.push(
+          `Change '${change.name}' (index ${i}): expected parent ${expectedParent.slice(0, 8)}..., got ${(change.parent ?? "none").slice(0, 8)}...`,
+        );
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    return {
+      check: "change-id-chain",
+      severity: "error",
+      message: `${issues.length} change ID chain issue(s) found.`,
+      details: issues,
+    };
+  }
+
+  return {
+    check: "change-id-chain",
+    severity: "ok",
+    message: `Change ID parent chain is consistent across ${plan.changes.length} change(s).`,
+  };
+}
+
+/**
+ * Check 4: Script file presence.
+ *
+ * For each change, verifies that deploy and revert SQL files exist.
+ * Verify scripts are optional (warn if missing).
+ */
+function checkScriptFiles(
+  plan: Plan,
+  topDir: string,
+  deployDir: string,
+  revertDir: string,
+  verifyDir: string,
+): CheckResult {
+  const missingDeploy: string[] = [];
+  const missingRevert: string[] = [];
+  const missingVerify: string[] = [];
+
+  // Deduplicate by change name (reworked changes share script names)
+  const seen = new Set<string>();
+
+  for (const change of plan.changes) {
+    if (seen.has(change.name)) continue;
+    seen.add(change.name);
+
+    const deployPath = join(topDir, deployDir, `${change.name}.sql`);
+    const revertPath = join(topDir, revertDir, `${change.name}.sql`);
+    const verifyPath = join(topDir, verifyDir, `${change.name}.sql`);
+
+    if (!existsSync(deployPath)) missingDeploy.push(change.name);
+    if (!existsSync(revertPath)) missingRevert.push(change.name);
+    if (!existsSync(verifyPath)) missingVerify.push(change.name);
+  }
+
+  const details: string[] = [];
+  if (missingDeploy.length > 0) {
+    details.push(`Missing deploy scripts (${missingDeploy.length}): ${missingDeploy.slice(0, 5).join(", ")}${missingDeploy.length > 5 ? `, ... and ${missingDeploy.length - 5} more` : ""}`);
+  }
+  if (missingRevert.length > 0) {
+    details.push(`Missing revert scripts (${missingRevert.length}): ${missingRevert.slice(0, 5).join(", ")}${missingRevert.length > 5 ? `, ... and ${missingRevert.length - 5} more` : ""}`);
+  }
+  if (missingVerify.length > 0) {
+    details.push(`Missing verify scripts (${missingVerify.length}): ${missingVerify.slice(0, 5).join(", ")}${missingVerify.length > 5 ? `, ... and ${missingVerify.length - 5} more` : ""}`);
+  }
+
+  if (missingDeploy.length > 0 || missingRevert.length > 0) {
+    return {
+      check: "script-files",
+      severity: "error",
+      message: `Missing deploy/revert script files detected.`,
+      details,
+    };
+  }
+
+  if (missingVerify.length > 0) {
+    return {
+      check: "script-files",
+      severity: "warn",
+      message: `All deploy/revert scripts present. ${missingVerify.length} verify script(s) missing.`,
+      details,
+    };
+  }
+
+  return {
+    check: "script-files",
+    severity: "ok",
+    message: `All script files present for ${seen.size} unique change(s).`,
+  };
+}
+
+/**
+ * Check 5: psql metacommand usage in deploy/revert scripts.
+ *
+ * Detects psql-specific commands (\i, \set, \echo, etc.) that may cause
+ * compatibility issues or require psql as the execution client.
+ */
+function checkPsqlMetacommands(
+  plan: Plan,
+  topDir: string,
+  deployDir: string,
+  revertDir: string,
+): CheckResult {
+  const findings: string[] = [];
+  const seen = new Set<string>();
+
+  for (const change of plan.changes) {
+    if (seen.has(change.name)) continue;
+    seen.add(change.name);
+
+    for (const [dir, label] of [[deployDir, "deploy"], [revertDir, "revert"]] as const) {
+      const scriptPath = join(topDir, dir, `${change.name}.sql`);
+      if (!existsSync(scriptPath)) continue;
+
+      try {
+        const content = readFileSync(scriptPath, "utf-8");
+        const metacmds = detectMetacommands(content);
+        if (metacmds.length > 0) {
+          findings.push(`${label}/${change.name}.sql: ${metacmds.length} metacommand(s)`);
+          for (const m of metacmds.slice(0, 3)) {
+            findings.push(`  ${m}`);
+          }
+          if (metacmds.length > 3) {
+            findings.push(`  ... and ${metacmds.length - 3} more`);
+          }
+        }
+      } catch {
+        // Skip unreadable files
+      }
+    }
+  }
+
+  if (findings.length > 0) {
+    return {
+      check: "psql-metacommands",
+      severity: "warn",
+      message: `psql metacommands detected in script files. These require psql as the execution client.`,
+      details: findings,
+    };
+  }
+
+  return {
+    check: "psql-metacommands",
+    severity: "ok",
+    message: "No psql metacommands detected in deploy/revert scripts.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main doctor logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all doctor checks and produce a report.
+ */
+export function runDoctorChecks(opts: DoctorOptions): DoctorReport {
+  const topDir = resolve(opts.topDir);
+  const checks: CheckResult[] = [];
+
+  // Load config to get directory settings
+  let deployDir = "deploy";
+  let revertDir = "revert";
+  let verifyDir = "verify";
+  let planFile = opts.planFile ?? "sqitch.plan";
+
+  try {
+    const config = loadConfig(topDir);
+    deployDir = config.core.deploy_dir;
+    revertDir = config.core.revert_dir;
+    verifyDir = config.core.verify_dir;
+    if (!opts.planFile) {
+      planFile = config.core.plan_file;
+    }
+  } catch {
+    // Config loading may fail (no sqitch.conf). Use defaults.
+    verbose("Could not load config, using defaults.");
+  }
+
+  const planPath = resolve(topDir, planFile);
+
+  // Check 1: Plan file parsing
+  const planResult = checkPlanParsing(planPath);
+  checks.push({
+    check: planResult.check,
+    severity: planResult.severity,
+    message: planResult.message,
+    ...(planResult.details ? { details: planResult.details } : {}),
+  });
+
+  // Remaining checks require a successfully parsed plan
+  if (planResult.plan) {
+    const plan = planResult.plan;
+
+    // Check 2: Syntax version
+    checks.push(checkSyntaxVersion(plan));
+
+    // Check 3: Change ID chain
+    checks.push(checkChangeIdChain(plan));
+
+    // Check 4: Script files
+    checks.push(checkScriptFiles(plan, topDir, deployDir, revertDir, verifyDir));
+
+    // Check 5: psql metacommands
+    checks.push(checkPsqlMetacommands(plan, topDir, deployDir, revertDir));
+  }
+
+  // Build summary
+  const summary = { ok: 0, warn: 0, error: 0 };
+  for (const c of checks) {
+    summary[c.severity]++;
+  }
+
+  return { checks, summary };
+}
+
+// ---------------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------------
+
+const SEVERITY_SYMBOLS: Record<CheckSeverity, string> = {
+  ok: "[ok]",
+  warn: "[warn]",
+  error: "[ERROR]",
+};
+
+function printReportText(report: DoctorReport): void {
+  info("sqlever doctor\n");
+
+  for (const check of report.checks) {
+    const symbol = SEVERITY_SYMBOLS[check.severity];
+    info(`  ${symbol} ${check.check}: ${check.message}`);
+    if (check.details) {
+      for (const detail of check.details) {
+        info(`    ${detail}`);
+      }
+    }
+  }
+
+  info("");
+  const { ok, warn, error: errCount } = report.summary;
+  const parts: string[] = [];
+  if (ok > 0) parts.push(`${ok} passed`);
+  if (warn > 0) parts.push(`${warn} warning(s)`);
+  if (errCount > 0) parts.push(`${errCount} error(s)`);
+  info(`Summary: ${parts.join(", ")}`);
+}
+
+function printReportJson(report: DoctorReport): void {
+  jsonOut(report);
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `doctor` command.
+ *
+ * @returns exit code: 0 if all checks pass (no errors), 1 if any errors.
+ */
+export function runDoctor(args: ParsedArgs): number {
+  const opts = parseDoctorArgs(args);
+  const report = runDoctorChecks(opts);
+
+  const config = getConfig();
+  const format = opts.format ?? config.format;
+
+  if (format === "json") {
+    printReportJson(report);
+  } else {
+    printReportText(report);
+  }
+
+  return report.summary.error > 0 ? 1 : 0;
+}

--- a/src/plan/parser.ts
+++ b/src/plan/parser.ts
@@ -230,6 +230,20 @@ export function parsePlan(content: string): Plan {
     }
   }
 
+  // Validate %syntax-version pragma
+  const syntaxVersion = pragmas.get("syntax-version");
+  if (syntaxVersion !== undefined) {
+    // Extract major version: "1" or "1.0.0" -> major = 1
+    const major = parseInt(syntaxVersion.split(".")[0] ?? "", 10);
+    if (isNaN(major) || major !== 1) {
+      throw new PlanParseError(
+        `Unsupported %syntax-version '${syntaxVersion}'. Only syntax-version 1.x is supported.`,
+        0,
+        `%syntax-version=${syntaxVersion}`,
+      );
+    }
+  }
+
   // Build project from pragmas
   const projectName = pragmas.get("project");
   if (!projectName) {

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,0 +1,278 @@
+// tests/unit/doctor.test.ts — Tests for the sqlever doctor command
+//
+// Validates runDoctorChecks() with various project configurations.
+
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { runDoctorChecks, type DoctorReport } from "../../src/commands/doctor";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTempProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "sqlever-doctor-test-"));
+  return dir;
+}
+
+function writePlan(dir: string, content: string): void {
+  writeFileSync(join(dir, "sqitch.plan"), content);
+}
+
+function writeConf(dir: string, content: string): void {
+  writeFileSync(join(dir, "sqitch.conf"), content);
+}
+
+function writeScript(dir: string, subdir: string, name: string, content: string): void {
+  const scriptDir = join(dir, subdir);
+  mkdirSync(scriptDir, { recursive: true });
+  writeFileSync(join(scriptDir, `${name}.sql`), content);
+}
+
+function minimalPlan(lines: string[] = []): string {
+  return [
+    "%syntax-version=1.0.0",
+    "%project=testproject",
+    "",
+    ...lines,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("doctor — plan file parsing", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempProject();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports error when plan file is missing", () => {
+    const report = runDoctorChecks({ topDir: tempDir });
+    const planCheck = report.checks.find((c) => c.check === "plan-file");
+    expect(planCheck).toBeDefined();
+    expect(planCheck!.severity).toBe("error");
+    expect(planCheck!.message).toContain("not found");
+    expect(report.summary.error).toBeGreaterThan(0);
+  });
+
+  it("reports ok when plan file parses successfully", () => {
+    writePlan(tempDir, minimalPlan([
+      "first_change 2024-01-15T10:30:00Z A <a@b.com> # first",
+    ]));
+    const report = runDoctorChecks({ topDir: tempDir });
+    const planCheck = report.checks.find((c) => c.check === "plan-file");
+    expect(planCheck).toBeDefined();
+    expect(planCheck!.severity).toBe("ok");
+    expect(planCheck!.message).toContain("1 change(s)");
+  });
+
+  it("reports error when plan file has parse errors", () => {
+    writePlan(tempDir, "not a valid plan");
+    const report = runDoctorChecks({ topDir: tempDir });
+    const planCheck = report.checks.find((c) => c.check === "plan-file");
+    expect(planCheck).toBeDefined();
+    expect(planCheck!.severity).toBe("error");
+    expect(planCheck!.message).toContain("parse error");
+  });
+});
+
+describe("doctor — syntax version check", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempProject();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports ok for syntax-version 1.0.0", () => {
+    writePlan(tempDir, minimalPlan());
+    const report = runDoctorChecks({ topDir: tempDir });
+    const check = report.checks.find((c) => c.check === "syntax-version");
+    expect(check).toBeDefined();
+    expect(check!.severity).toBe("ok");
+  });
+
+  it("reports warn when syntax-version is missing", () => {
+    writePlan(tempDir, "%project=testproject\n");
+    const report = runDoctorChecks({ topDir: tempDir });
+    const check = report.checks.find((c) => c.check === "syntax-version");
+    expect(check).toBeDefined();
+    expect(check!.severity).toBe("warn");
+    expect(check!.message).toContain("No %syntax-version");
+  });
+});
+
+describe("doctor — change ID chain", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempProject();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports ok for a valid chain", () => {
+    writePlan(tempDir, minimalPlan([
+      "first 2024-01-15T10:30:00Z A <a@b.com> # 1",
+      "second 2024-01-15T10:31:00Z A <a@b.com> # 2",
+      "third 2024-01-15T10:32:00Z A <a@b.com> # 3",
+    ]));
+    const report = runDoctorChecks({ topDir: tempDir });
+    const check = report.checks.find((c) => c.check === "change-id-chain");
+    expect(check).toBeDefined();
+    expect(check!.severity).toBe("ok");
+    expect(check!.message).toContain("3 change(s)");
+  });
+
+  it("reports ok for empty plan (no changes)", () => {
+    writePlan(tempDir, minimalPlan());
+    const report = runDoctorChecks({ topDir: tempDir });
+    const check = report.checks.find((c) => c.check === "change-id-chain");
+    expect(check).toBeDefined();
+    expect(check!.severity).toBe("ok");
+  });
+});
+
+describe("doctor — script files", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempProject();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports error when deploy scripts are missing", () => {
+    writePlan(tempDir, minimalPlan([
+      "my_change 2024-01-15T10:30:00Z A <a@b.com> # change",
+    ]));
+    // Only create revert script, not deploy
+    writeScript(tempDir, "revert", "my_change", "-- revert");
+    const report = runDoctorChecks({ topDir: tempDir });
+    const check = report.checks.find((c) => c.check === "script-files");
+    expect(check).toBeDefined();
+    expect(check!.severity).toBe("error");
+    expect(check!.details).toBeDefined();
+    expect(check!.details!.some((d) => d.includes("deploy"))).toBe(true);
+  });
+
+  it("reports warn when only verify scripts are missing", () => {
+    writePlan(tempDir, minimalPlan([
+      "my_change 2024-01-15T10:30:00Z A <a@b.com> # change",
+    ]));
+    writeScript(tempDir, "deploy", "my_change", "-- deploy");
+    writeScript(tempDir, "revert", "my_change", "-- revert");
+    const report = runDoctorChecks({ topDir: tempDir });
+    const check = report.checks.find((c) => c.check === "script-files");
+    expect(check).toBeDefined();
+    expect(check!.severity).toBe("warn");
+  });
+
+  it("reports ok when all scripts exist", () => {
+    writePlan(tempDir, minimalPlan([
+      "my_change 2024-01-15T10:30:00Z A <a@b.com> # change",
+    ]));
+    writeScript(tempDir, "deploy", "my_change", "-- deploy");
+    writeScript(tempDir, "revert", "my_change", "-- revert");
+    writeScript(tempDir, "verify", "my_change", "-- verify");
+    const report = runDoctorChecks({ topDir: tempDir });
+    const check = report.checks.find((c) => c.check === "script-files");
+    expect(check).toBeDefined();
+    expect(check!.severity).toBe("ok");
+  });
+});
+
+describe("doctor — psql metacommand detection", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempProject();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports warn when metacommands found in deploy scripts", () => {
+    writePlan(tempDir, minimalPlan([
+      "my_change 2024-01-15T10:30:00Z A <a@b.com> # change",
+    ]));
+    writeScript(tempDir, "deploy", "my_change", "\\set ON_ERROR_STOP on\nCREATE TABLE t();\n");
+    writeScript(tempDir, "revert", "my_change", "DROP TABLE t;\n");
+    const report = runDoctorChecks({ topDir: tempDir });
+    const check = report.checks.find((c) => c.check === "psql-metacommands");
+    expect(check).toBeDefined();
+    expect(check!.severity).toBe("warn");
+    expect(check!.details).toBeDefined();
+    expect(check!.details!.some((d) => d.includes("deploy/my_change.sql"))).toBe(true);
+  });
+
+  it("reports ok when no metacommands found", () => {
+    writePlan(tempDir, minimalPlan([
+      "my_change 2024-01-15T10:30:00Z A <a@b.com> # change",
+    ]));
+    writeScript(tempDir, "deploy", "my_change", "CREATE TABLE t (id int);\n");
+    writeScript(tempDir, "revert", "my_change", "DROP TABLE t;\n");
+    const report = runDoctorChecks({ topDir: tempDir });
+    const check = report.checks.find((c) => c.check === "psql-metacommands");
+    expect(check).toBeDefined();
+    expect(check!.severity).toBe("ok");
+  });
+});
+
+describe("doctor — summary", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempProject();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("produces correct summary counts", () => {
+    writePlan(tempDir, minimalPlan([
+      "my_change 2024-01-15T10:30:00Z A <a@b.com> # change",
+    ]));
+    writeScript(tempDir, "deploy", "my_change", "CREATE TABLE t (id int);\n");
+    writeScript(tempDir, "revert", "my_change", "DROP TABLE t;\n");
+    writeScript(tempDir, "verify", "my_change", "SELECT 1;\n");
+
+    const report = runDoctorChecks({ topDir: tempDir });
+    expect(report.summary.ok + report.summary.warn + report.summary.error).toBe(
+      report.checks.length,
+    );
+  });
+
+  it("all checks pass for a well-formed project", () => {
+    writePlan(tempDir, minimalPlan([
+      "my_change 2024-01-15T10:30:00Z A <a@b.com> # change",
+    ]));
+    writeScript(tempDir, "deploy", "my_change", "CREATE TABLE t (id int);\n");
+    writeScript(tempDir, "revert", "my_change", "DROP TABLE t;\n");
+    writeScript(tempDir, "verify", "my_change", "SELECT 1;\n");
+
+    const report = runDoctorChecks({ topDir: tempDir });
+    expect(report.summary.error).toBe(0);
+    expect(report.summary.warn).toBe(0);
+    expect(report.summary.ok).toBe(report.checks.length);
+  });
+});

--- a/tests/unit/plan-parser.test.ts
+++ b/tests/unit/plan-parser.test.ts
@@ -134,6 +134,41 @@ describe("parsePlan — pragmas", () => {
     const plan = parsePlan(minimalPlan());
     expect(plan.project.uri).toBeUndefined();
   });
+
+  it("accepts %syntax-version=1.0.0", () => {
+    const plan = parsePlan(minimalPlan());
+    expect(plan.pragmas.get("syntax-version")).toBe("1.0.0");
+  });
+
+  it("accepts %syntax-version=1", () => {
+    const content = "%syntax-version=1\n%project=testproject\n";
+    const plan = parsePlan(content);
+    expect(plan.pragmas.get("syntax-version")).toBe("1");
+  });
+
+  it("accepts %syntax-version=1.1.0", () => {
+    const content = "%syntax-version=1.1.0\n%project=testproject\n";
+    const plan = parsePlan(content);
+    expect(plan.pragmas.get("syntax-version")).toBe("1.1.0");
+  });
+
+  it("rejects %syntax-version=2.0.0", () => {
+    const content = "%syntax-version=2.0.0\n%project=testproject\n";
+    expect(() => parsePlan(content)).toThrow(PlanParseError);
+    expect(() => parsePlan(content)).toThrow("Unsupported %syntax-version '2.0.0'");
+  });
+
+  it("rejects %syntax-version=0.9", () => {
+    const content = "%syntax-version=0.9\n%project=testproject\n";
+    expect(() => parsePlan(content)).toThrow(PlanParseError);
+    expect(() => parsePlan(content)).toThrow("Unsupported %syntax-version '0.9'");
+  });
+
+  it("rejects %syntax-version with non-numeric value", () => {
+    const content = "%syntax-version=abc\n%project=testproject\n";
+    expect(() => parsePlan(content)).toThrow(PlanParseError);
+    expect(() => parsePlan(content)).toThrow("Unsupported %syntax-version 'abc'");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Applies key expert review recommendations from #78:

- **`sqlever doctor` command** (`src/commands/doctor.ts`): Validates project setup with 5 checks: plan file parsing, `%syntax-version` support, change ID parent chain consistency, deploy/revert/verify script presence, and psql metacommand detection. Supports `--format json` output.
- **`%syntax-version` validation** (`src/plan/parser.ts`): Rejects plans with syntax-version != 1.x at parse time with a clear error message, preventing silent misinterpretation of future plan formats.
- **SPEC non-goals** (`spec/SPEC.md`): Adds Windows support and declarative schema management as explicit non-goals.

## What was already done (no changes needed)

- `log` command already has `--event`, `--limit`, `--offset`, `--reverse` flags
- `revert` already requires `-y` for non-TTY stdin

## Test plan

- [x] 14 new doctor tests covering all 5 checks (missing plan, parse errors, syntax version, change chain, script presence, metacommand detection)
- [x] 6 new syntax-version validation tests (accepts 1.x, rejects 0.x/2.x/non-numeric)
- [x] All 1607 existing unit tests still pass
- [x] Compile test passes

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)