### PR TITLE
G3: DBLab integration — test deploy against production clone

### DIFF
--- a/src/commands/deploy-dblab.ts
+++ b/src/commands/deploy-dblab.ts
@@ -1,0 +1,434 @@
+// src/commands/deploy-dblab.ts — DBLab integration for sqlever deploy
+//
+// Test deploy+verify against a full-size production clone before touching prod.
+// See SPEC Section 5.8 and issue #108.
+//
+// Flow:
+//   1. Provision a thin clone of production via DBLab API (POST /clone)
+//   2. Get the clone's connection URI from the response
+//   3. Run deploy+verify against the clone
+//   4. If success: report "Clone test passed, safe to deploy to production"
+//   5. If failure: report errors, do NOT touch production
+//   6. Destroy the clone (DELETE /clone/<id>) in a finally block
+
+import type { ParsedArgs } from "../cli";
+import { info, error as logError, verbose } from "../output";
+
+// ---------------------------------------------------------------------------
+// DBLab API types
+// ---------------------------------------------------------------------------
+
+/** Request body for POST /clone. */
+export interface DblabCreateCloneRequest {
+  id?: string;
+  protected?: boolean;
+  db?: {
+    username?: string;
+    password?: string;
+    db_name?: string;
+  };
+}
+
+/** Response from POST /clone — subset of fields we use. */
+export interface DblabCloneResponse {
+  id: string;
+  status: {
+    code: string;
+    message: string;
+  };
+  db: {
+    connStr: string;
+    host: string;
+    port: string;
+    username: string;
+    password?: string;
+    db_name: string;
+  };
+}
+
+/** Status response used when polling clone readiness. */
+export interface DblabCloneStatus {
+  id: string;
+  status: {
+    code: string;
+    message: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DBLab client
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal DBLab API client.
+ *
+ * Uses fetch() (globally available in Bun / Node 18+).
+ * The `fetchFn` parameter enables dependency injection for testing.
+ */
+export class DblabClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(
+    baseUrl: string,
+    token: string,
+    fetchFn: typeof fetch = globalThis.fetch,
+  ) {
+    // Strip trailing slash for consistency
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.token = token;
+    this.fetchFn = fetchFn;
+  }
+
+  /**
+   * Create a thin clone via POST /clone.
+   *
+   * @returns The clone metadata including connection URI.
+   * @throws Error if the API returns a non-2xx status.
+   */
+  async createClone(
+    request?: DblabCreateCloneRequest,
+  ): Promise<DblabCloneResponse> {
+    const url = `${this.baseUrl}/clone`;
+    const body = request ?? {};
+
+    const response = await this.fetchFn(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Verification-Token": this.token,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `DBLab API error: POST /clone returned ${response.status}${text ? ` — ${text}` : ""}`,
+      );
+    }
+
+    return (await response.json()) as DblabCloneResponse;
+  }
+
+  /**
+   * Get clone status via GET /clone/<id>.
+   */
+  async getCloneStatus(cloneId: string): Promise<DblabCloneStatus> {
+    const url = `${this.baseUrl}/clone/${encodeURIComponent(cloneId)}`;
+
+    const response = await this.fetchFn(url, {
+      method: "GET",
+      headers: {
+        "Verification-Token": this.token,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `DBLab API error: GET /clone/${cloneId} returned ${response.status}${text ? ` — ${text}` : ""}`,
+      );
+    }
+
+    return (await response.json()) as DblabCloneStatus;
+  }
+
+  /**
+   * Destroy a clone via DELETE /clone/<id>.
+   *
+   * This is called in a finally block and should not throw on best-effort
+   * cleanup failures.
+   */
+  async destroyClone(cloneId: string): Promise<void> {
+    const url = `${this.baseUrl}/clone/${encodeURIComponent(cloneId)}`;
+
+    const response = await this.fetchFn(url, {
+      method: "DELETE",
+      headers: {
+        "Verification-Token": this.token,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `DBLab API error: DELETE /clone/${cloneId} returned ${response.status}${text ? ` — ${text}` : ""}`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DBLab deploy options
+// ---------------------------------------------------------------------------
+
+export interface DblabDeployOptions {
+  /** DBLab instance URL. */
+  dblabUrl: string;
+  /** DBLab authentication token. */
+  dblabToken: string;
+  /** Remaining deploy args to forward. */
+  deployArgs: ParsedArgs;
+}
+
+/**
+ * Parse --dblab-url and --dblab-token from the deploy command's rest args.
+ *
+ * Returns null if neither flag is present (regular deploy).
+ * Throws if only one of the two required flags is provided.
+ */
+export function parseDblabOptions(
+  args: ParsedArgs,
+): DblabDeployOptions | null {
+  let dblabUrl: string | undefined;
+  let dblabToken: string | undefined;
+  const filteredRest: string[] = [];
+
+  const rest = args.rest;
+  let i = 0;
+  while (i < rest.length) {
+    const token = rest[i]!;
+
+    if (token === "--dblab-url") {
+      const val = rest[++i];
+      if (!val || val.startsWith("-")) {
+        throw new Error("--dblab-url requires a URL value");
+      }
+      dblabUrl = val;
+      i++;
+      continue;
+    }
+
+    if (token === "--dblab-token") {
+      const val = rest[++i];
+      if (!val || val.startsWith("-")) {
+        throw new Error("--dblab-token requires a token value");
+      }
+      dblabToken = val;
+      i++;
+      continue;
+    }
+
+    filteredRest.push(token);
+    i++;
+  }
+
+  // Also check environment variables
+  if (!dblabUrl) {
+    dblabUrl = process.env.DBLAB_URL;
+  }
+  if (!dblabToken) {
+    dblabToken = process.env.DBLAB_TOKEN;
+  }
+
+  // Neither specified — this is a regular deploy, not DBLab
+  if (!dblabUrl && !dblabToken) {
+    return null;
+  }
+
+  // One specified without the other
+  if (!dblabUrl) {
+    throw new Error(
+      "--dblab-url is required when --dblab-token is specified (or set DBLAB_URL env var)",
+    );
+  }
+  if (!dblabToken) {
+    throw new Error(
+      "--dblab-token is required when --dblab-url is specified (or set DBLAB_TOKEN env var)",
+    );
+  }
+
+  return {
+    dblabUrl,
+    dblabToken,
+    deployArgs: { ...args, rest: filteredRest },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DBLab deploy result
+// ---------------------------------------------------------------------------
+
+export interface DblabDeployResult {
+  /** Whether the clone test passed. */
+  success: boolean;
+  /** Clone ID that was provisioned. */
+  cloneId?: string;
+  /** Connection URI used for the clone. */
+  cloneUri?: string;
+  /** Number of changes deployed to the clone. */
+  deployed: number;
+  /** Error message if the test failed. */
+  error?: string;
+  /** Time taken for clone provisioning (ms). */
+  cloneProvisionMs?: number;
+  /** Time taken for deploy+verify on the clone (ms). */
+  deployMs?: number;
+  /** Whether the clone was successfully destroyed. */
+  cloneDestroyed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Core DBLab deploy logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a PostgreSQL connection URI from DBLab clone response.
+ */
+export function buildCloneUri(clone: DblabCloneResponse): string {
+  const { host, port, username, password, db_name } = clone.db;
+  if (clone.db.connStr) {
+    return clone.db.connStr;
+  }
+  const userPart = password
+    ? `${encodeURIComponent(username)}:${encodeURIComponent(password)}`
+    : encodeURIComponent(username);
+  return `postgresql://${userPart}@${host}:${port}/${db_name}`;
+}
+
+/**
+ * Execute the DBLab deploy workflow.
+ *
+ * 1. Provision a thin clone
+ * 2. Run deploy+verify against it
+ * 3. Report results
+ * 4. Destroy the clone (always, in finally block)
+ *
+ * The `deployFn` parameter allows dependency injection for testing.
+ */
+export async function executeDblabDeploy(
+  options: DblabDeployOptions,
+  deps: {
+    client: DblabClient;
+    deployFn: (args: ParsedArgs) => Promise<number>;
+  },
+): Promise<DblabDeployResult> {
+  const { client, deployFn } = deps;
+
+  // Mutable result object — updated throughout the function and in finally.
+  // We never spread-copy this; the same object reference is returned.
+  const result: DblabDeployResult = {
+    success: false,
+    deployed: 0,
+    cloneDestroyed: false,
+  };
+
+  try {
+    // Step 1: Provision clone
+    info("Provisioning DBLab thin clone...");
+    const provisionStart = Date.now();
+
+    let clone: DblabCloneResponse;
+    try {
+      clone = await client.createClone({
+        id: `sqlever-test-${Date.now()}`,
+        protected: false,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logError(`Failed to provision DBLab clone: ${msg}`);
+      result.error = `Clone provisioning failed: ${msg}`;
+      return result;
+    }
+
+    result.cloneId = clone.id;
+    result.cloneProvisionMs = Date.now() - provisionStart;
+
+    // Check clone status
+    if (clone.status.code !== "OK" && clone.status.code !== "CREATING") {
+      logError(`DBLab clone status: ${clone.status.code} — ${clone.status.message}`);
+      result.error = `Clone not ready: ${clone.status.code} — ${clone.status.message}`;
+      return result;
+    }
+
+    // Step 2: Build connection URI from clone response
+    result.cloneUri = buildCloneUri(clone);
+
+    verbose(`Clone provisioned: id=${result.cloneId}`);
+    verbose(`Clone connection URI: ${result.cloneUri}`);
+    info(`Clone provisioned in ${result.cloneProvisionMs}ms`);
+
+    // Step 3: Run deploy+verify against the clone
+    info("Running deploy+verify against clone...");
+    const deployStart = Date.now();
+
+    // Build args with clone URI as the target
+    const deployArgs: ParsedArgs = {
+      ...options.deployArgs,
+      dbUri: result.cloneUri,
+      rest: [...options.deployArgs.rest, "--verify", "--no-tui"],
+    };
+
+    let exitCode: number;
+    try {
+      exitCode = await deployFn(deployArgs);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logError(`Deploy against clone failed: ${msg}`);
+      result.deployMs = Date.now() - deployStart;
+      result.error = `Deploy failed on clone: ${msg}`;
+      return result;
+    }
+
+    result.deployMs = Date.now() - deployStart;
+
+    // Step 4: Report results
+    if (exitCode === 0) {
+      result.success = true;
+      info(`Clone test passed in ${result.deployMs}ms. Safe to deploy to production.`);
+    } else {
+      result.error = `Deploy+verify failed on clone (exit code ${exitCode}). Production was NOT touched.`;
+      logError(result.error);
+    }
+
+    return result;
+  } finally {
+    // Step 5: Always destroy the clone
+    if (result.cloneId) {
+      try {
+        verbose(`Destroying clone: ${result.cloneId}`);
+        await client.destroyClone(result.cloneId);
+        result.cloneDestroyed = true;
+        verbose("Clone destroyed successfully");
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logError(`Warning: Failed to destroy clone ${result.cloneId}: ${msg}`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the DBLab deploy workflow from CLI args.
+ *
+ * This is called from the deploy command when --dblab-url/--dblab-token
+ * flags are detected.
+ *
+ * @returns exit code (0 for success, 1 for failure)
+ */
+export async function runDblabDeploy(
+  options: DblabDeployOptions,
+  deps?: {
+    client?: DblabClient;
+    deployFn?: (args: ParsedArgs) => Promise<number>;
+  },
+): Promise<number> {
+  // Lazy import to avoid circular dependency at module level
+  const { runDeploy } = await import("./deploy");
+
+  const client = deps?.client ?? new DblabClient(options.dblabUrl, options.dblabToken);
+  const deployFn = deps?.deployFn ?? runDeploy;
+
+  const result = await executeDblabDeploy(options, { client, deployFn });
+
+  if (result.success) {
+    return 0;
+  }
+  return 1;
+}

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -22,6 +22,7 @@ import { shutdownManager } from "../signals";
 import { info, error as logError, verbose, getConfig } from "../output";
 import { sqitchToStandard } from "../db/uri";
 import { DeployProgress, shouldUseTUI } from "../tui/deploy";
+import { parseDblabOptions, runDblabDeploy } from "./deploy-dblab";
 
 // ---------------------------------------------------------------------------
 // Exit codes (SPEC R6)
@@ -777,6 +778,12 @@ function buildDependencies(
  * so that callers (and finally blocks) can run cleanup before exiting.
  */
 export async function runDeploy(args: ParsedArgs): Promise<number> {
+  // Check for DBLab flags — if present, delegate to the DBLab workflow
+  const dblabOpts = parseDblabOptions(args);
+  if (dblabOpts) {
+    return runDblabDeploy(dblabOpts);
+  }
+
   const options = parseDeployOptions(args);
 
   if (!options.dbUri) {

--- a/tests/unit/deploy-dblab.test.ts
+++ b/tests/unit/deploy-dblab.test.ts
@@ -1,0 +1,529 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { resetConfig, setConfig } from "../../src/output";
+import type { ParsedArgs } from "../../src/cli";
+import {
+  DblabClient,
+  buildCloneUri,
+  parseDblabOptions,
+  executeDblabDeploy,
+  runDblabDeploy,
+  type DblabCloneResponse,
+  type DblabDeployOptions,
+} from "../../src/commands/deploy-dblab";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal ParsedArgs for testing. */
+function makeArgs(overrides?: Partial<ParsedArgs>): ParsedArgs {
+  return {
+    command: "deploy",
+    rest: [],
+    help: false,
+    version: false,
+    format: "text",
+    quiet: false,
+    verbose: false,
+    dbUri: undefined,
+    planFile: undefined,
+    topDir: undefined,
+    registry: undefined,
+    target: undefined,
+    ...overrides,
+  };
+}
+
+/** Build a mock DBLab clone response. */
+function makeCloneResponse(
+  overrides?: Partial<DblabCloneResponse>,
+): DblabCloneResponse {
+  return {
+    id: "clone-abc-123",
+    status: { code: "OK", message: "Clone is ready" },
+    db: {
+      connStr: "postgresql://clone_user:clone_pass@clone-host:5432/testdb",
+      host: "clone-host",
+      port: "5432",
+      username: "clone_user",
+      password: "clone_pass",
+      db_name: "testdb",
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock fetch function for DBLab API.
+ *
+ * Tracks all requests for assertions.
+ */
+function createMockFetch(responses: {
+  createClone?: { status: number; body: unknown };
+  getClone?: { status: number; body: unknown };
+  destroyClone?: { status: number; body: unknown };
+}) {
+  const calls: Array<{ url: string; method: string; headers: Record<string, string>; body?: string }> = [];
+
+  const mockFn = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : (url as Request).url;
+    const method = init?.method ?? "GET";
+    const headers = init?.headers as Record<string, string> | undefined;
+    const body = init?.body ? String(init.body) : undefined;
+
+    calls.push({ url: urlStr, method, headers: headers ?? {}, body });
+
+    // POST /clone
+    if (method === "POST" && urlStr.endsWith("/clone")) {
+      const resp = responses.createClone ?? { status: 200, body: makeCloneResponse() };
+      return new Response(JSON.stringify(resp.body), {
+        status: resp.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // DELETE /clone/<id>
+    if (method === "DELETE" && urlStr.includes("/clone/")) {
+      const resp = responses.destroyClone ?? { status: 200, body: {} };
+      return new Response(JSON.stringify(resp.body), {
+        status: resp.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // GET /clone/<id>
+    if (method === "GET" && urlStr.includes("/clone/")) {
+      const resp = responses.getClone ?? {
+        status: 200,
+        body: { id: "clone-abc-123", status: { code: "OK", message: "Ready" } },
+      };
+      return new Response(JSON.stringify(resp.body), {
+        status: resp.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  };
+
+  return { mockFn: mockFn as unknown as typeof fetch, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("deploy-dblab", () => {
+  beforeEach(() => {
+    setConfig({ quiet: true }); // suppress output during tests
+  });
+
+  afterEach(() => {
+    resetConfig();
+    // Clean up env vars that tests may set
+    delete process.env.DBLAB_URL;
+    delete process.env.DBLAB_TOKEN;
+  });
+
+  // =========================================================================
+  // parseDblabOptions
+  // =========================================================================
+
+  describe("parseDblabOptions", () => {
+    it("returns null when no DBLab flags are present", () => {
+      const args = makeArgs({ rest: ["--verify", "--no-tui"] });
+      expect(parseDblabOptions(args)).toBeNull();
+    });
+
+    it("parses --dblab-url and --dblab-token from rest args", () => {
+      const args = makeArgs({
+        rest: ["--dblab-url", "https://dblab.example.com", "--dblab-token", "secret-token", "--verify"],
+      });
+      const result = parseDblabOptions(args);
+      expect(result).not.toBeNull();
+      expect(result!.dblabUrl).toBe("https://dblab.example.com");
+      expect(result!.dblabToken).toBe("secret-token");
+      // --verify should be forwarded in filteredRest
+      expect(result!.deployArgs.rest).toContain("--verify");
+      // --dblab-url/--dblab-token should NOT be forwarded
+      expect(result!.deployArgs.rest).not.toContain("--dblab-url");
+      expect(result!.deployArgs.rest).not.toContain("--dblab-token");
+    });
+
+    it("reads from environment variables when flags are not set", () => {
+      process.env.DBLAB_URL = "https://env-dblab.example.com";
+      process.env.DBLAB_TOKEN = "env-token";
+      const args = makeArgs({ rest: [] });
+      const result = parseDblabOptions(args);
+      expect(result).not.toBeNull();
+      expect(result!.dblabUrl).toBe("https://env-dblab.example.com");
+      expect(result!.dblabToken).toBe("env-token");
+    });
+
+    it("throws when --dblab-url is set without --dblab-token", () => {
+      const args = makeArgs({ rest: ["--dblab-url", "https://dblab.example.com"] });
+      expect(() => parseDblabOptions(args)).toThrow("--dblab-token is required");
+    });
+
+    it("throws when --dblab-token is set without --dblab-url", () => {
+      const args = makeArgs({ rest: ["--dblab-token", "token"] });
+      expect(() => parseDblabOptions(args)).toThrow("--dblab-url is required");
+    });
+
+    it("throws when --dblab-url is missing its value", () => {
+      const args = makeArgs({ rest: ["--dblab-url"] });
+      expect(() => parseDblabOptions(args)).toThrow("--dblab-url requires a URL value");
+    });
+
+    it("throws when --dblab-token is missing its value", () => {
+      const args = makeArgs({ rest: ["--dblab-token"] });
+      expect(() => parseDblabOptions(args)).toThrow("--dblab-token requires a token value");
+    });
+  });
+
+  // =========================================================================
+  // buildCloneUri
+  // =========================================================================
+
+  describe("buildCloneUri", () => {
+    it("returns connStr when available", () => {
+      const clone = makeCloneResponse();
+      expect(buildCloneUri(clone)).toBe(
+        "postgresql://clone_user:clone_pass@clone-host:5432/testdb",
+      );
+    });
+
+    it("builds URI from components when connStr is empty", () => {
+      const clone = makeCloneResponse({
+        db: {
+          connStr: "",
+          host: "my-host",
+          port: "6432",
+          username: "admin",
+          password: "s3cret",
+          db_name: "mydb",
+        },
+      });
+      expect(buildCloneUri(clone)).toBe(
+        "postgresql://admin:s3cret@my-host:6432/mydb",
+      );
+    });
+
+    it("builds URI without password when not provided", () => {
+      const clone = makeCloneResponse({
+        db: {
+          connStr: "",
+          host: "my-host",
+          port: "5432",
+          username: "user",
+          db_name: "db",
+        },
+      });
+      expect(buildCloneUri(clone)).toBe("postgresql://user@my-host:5432/db");
+    });
+  });
+
+  // =========================================================================
+  // DblabClient
+  // =========================================================================
+
+  describe("DblabClient", () => {
+    it("creates a clone with correct headers and body", async () => {
+      const { mockFn, calls } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com", "my-token", mockFn);
+
+      const clone = await client.createClone({ id: "test-clone" });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.url).toBe("https://dblab.example.com/clone");
+      expect(calls[0]!.method).toBe("POST");
+      expect(calls[0]!.headers["Verification-Token"]).toBe("my-token");
+      expect(calls[0]!.headers["Content-Type"]).toBe("application/json");
+      expect(JSON.parse(calls[0]!.body!)).toEqual({ id: "test-clone" });
+      expect(clone.id).toBe("clone-abc-123");
+    });
+
+    it("throws on non-2xx response from createClone", async () => {
+      const { mockFn } = createMockFetch({
+        createClone: { status: 500, body: "Internal Server Error" },
+      });
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      await expect(client.createClone()).rejects.toThrow("POST /clone returned 500");
+    });
+
+    it("destroys a clone with DELETE request", async () => {
+      const { mockFn, calls } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com/", "my-token", mockFn);
+
+      await client.destroyClone("clone-xyz");
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.url).toBe("https://dblab.example.com/clone/clone-xyz");
+      expect(calls[0]!.method).toBe("DELETE");
+      expect(calls[0]!.headers["Verification-Token"]).toBe("my-token");
+    });
+
+    it("throws on non-2xx response from destroyClone", async () => {
+      const { mockFn } = createMockFetch({
+        destroyClone: { status: 404, body: "Not Found" },
+      });
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      await expect(client.destroyClone("bad-id")).rejects.toThrow(
+        "DELETE /clone/bad-id returned 404",
+      );
+    });
+
+    it("strips trailing slash from base URL", async () => {
+      const { mockFn, calls } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com///", "token", mockFn);
+
+      await client.createClone();
+      expect(calls[0]!.url).toBe("https://dblab.example.com/clone");
+    });
+
+    it("gets clone status with GET request", async () => {
+      const { mockFn, calls } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com", "my-token", mockFn);
+
+      const status = await client.getCloneStatus("clone-abc-123");
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.url).toBe("https://dblab.example.com/clone/clone-abc-123");
+      expect(calls[0]!.method).toBe("GET");
+      expect(status.id).toBe("clone-abc-123");
+    });
+
+    it("throws on non-2xx response from getCloneStatus", async () => {
+      const { mockFn } = createMockFetch({
+        getClone: { status: 403, body: "Forbidden" },
+      });
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      await expect(client.getCloneStatus("clone-id")).rejects.toThrow(
+        "GET /clone/clone-id returned 403",
+      );
+    });
+  });
+
+  // =========================================================================
+  // executeDblabDeploy
+  // =========================================================================
+
+  describe("executeDblabDeploy", () => {
+    it("full success: provision → deploy → destroy", async () => {
+      const { mockFn } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      const deployArgs = makeArgs({ rest: [] });
+      const options: DblabDeployOptions = {
+        dblabUrl: "https://dblab.example.com",
+        dblabToken: "token",
+        deployArgs,
+      };
+
+      // Mock deployFn that succeeds
+      const deployCalls: ParsedArgs[] = [];
+      const deployFn = async (args: ParsedArgs) => {
+        deployCalls.push(args);
+        return 0;
+      };
+
+      const result = await executeDblabDeploy(options, { client, deployFn });
+
+      expect(result.success).toBe(true);
+      expect(result.cloneId).toBe("clone-abc-123");
+      expect(result.cloneDestroyed).toBe(true);
+      expect(result.error).toBeUndefined();
+      // deployFn should be called with clone URI
+      expect(deployCalls).toHaveLength(1);
+      expect(deployCalls[0]!.dbUri).toBe(
+        "postgresql://clone_user:clone_pass@clone-host:5432/testdb",
+      );
+      // --verify and --no-tui should be added
+      expect(deployCalls[0]!.rest).toContain("--verify");
+      expect(deployCalls[0]!.rest).toContain("--no-tui");
+    });
+
+    it("deploy failure: reports error, still destroys clone", async () => {
+      const { mockFn } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      const options: DblabDeployOptions = {
+        dblabUrl: "https://dblab.example.com",
+        dblabToken: "token",
+        deployArgs: makeArgs(),
+      };
+
+      const deployFn = async (_args: ParsedArgs) => 1; // exit code 1 = failure
+
+      const result = await executeDblabDeploy(options, { client, deployFn });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Deploy+verify failed on clone");
+      expect(result.error).toContain("Production was NOT touched");
+      expect(result.cloneDestroyed).toBe(true);
+    });
+
+    it("deploy exception: catches error, destroys clone", async () => {
+      const { mockFn } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      const options: DblabDeployOptions = {
+        dblabUrl: "https://dblab.example.com",
+        dblabToken: "token",
+        deployArgs: makeArgs(),
+      };
+
+      const deployFn = async (_args: ParsedArgs): Promise<number> => {
+        throw new Error("Connection refused");
+      };
+
+      const result = await executeDblabDeploy(options, { client, deployFn });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Connection refused");
+      expect(result.cloneDestroyed).toBe(true);
+    });
+
+    it("clone provisioning failure: returns error without deploy", async () => {
+      const { mockFn } = createMockFetch({
+        createClone: { status: 503, body: "Service Unavailable" },
+      });
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      const options: DblabDeployOptions = {
+        dblabUrl: "https://dblab.example.com",
+        dblabToken: "token",
+        deployArgs: makeArgs(),
+      };
+
+      let deployCalled = false;
+      const deployFn = async (_args: ParsedArgs) => {
+        deployCalled = true;
+        return 0;
+      };
+
+      const result = await executeDblabDeploy(options, { client, deployFn });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Clone provisioning failed");
+      expect(deployCalled).toBe(false);
+      // No clone to destroy since provisioning failed
+      expect(result.cloneDestroyed).toBe(false);
+    });
+
+    it("clone destroy failure: logs warning but still returns result", async () => {
+      const { mockFn } = createMockFetch({
+        destroyClone: { status: 500, body: "Internal Server Error" },
+      });
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      const options: DblabDeployOptions = {
+        dblabUrl: "https://dblab.example.com",
+        dblabToken: "token",
+        deployArgs: makeArgs(),
+      };
+
+      const deployFn = async (_args: ParsedArgs) => 0;
+
+      const result = await executeDblabDeploy(options, { client, deployFn });
+
+      // Deploy succeeded even though clone destroy failed
+      expect(result.success).toBe(true);
+      expect(result.cloneDestroyed).toBe(false);
+    });
+
+    it("clone with bad status code: returns error without deploy", async () => {
+      const { mockFn } = createMockFetch({
+        createClone: {
+          status: 200,
+          body: makeCloneResponse({
+            status: { code: "FATAL", message: "No snapshots available" },
+          }),
+        },
+      });
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      const options: DblabDeployOptions = {
+        dblabUrl: "https://dblab.example.com",
+        dblabToken: "token",
+        deployArgs: makeArgs(),
+      };
+
+      let deployCalled = false;
+      const deployFn = async (_args: ParsedArgs) => {
+        deployCalled = true;
+        return 0;
+      };
+
+      const result = await executeDblabDeploy(options, { client, deployFn });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("FATAL");
+      expect(result.error).toContain("No snapshots available");
+      expect(deployCalled).toBe(false);
+      // Clone was created but had bad status — should still try to destroy
+      expect(result.cloneDestroyed).toBe(true);
+    });
+
+    it("records timing for provisioning and deploy", async () => {
+      const { mockFn } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+
+      const options: DblabDeployOptions = {
+        dblabUrl: "https://dblab.example.com",
+        dblabToken: "token",
+        deployArgs: makeArgs(),
+      };
+
+      const deployFn = async (_args: ParsedArgs) => 0;
+
+      const result = await executeDblabDeploy(options, { client, deployFn });
+
+      expect(result.cloneProvisionMs).toBeDefined();
+      expect(typeof result.cloneProvisionMs).toBe("number");
+      expect(result.cloneProvisionMs!).toBeGreaterThanOrEqual(0);
+      expect(result.deployMs).toBeDefined();
+      expect(typeof result.deployMs).toBe("number");
+      expect(result.deployMs!).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // =========================================================================
+  // runDblabDeploy
+  // =========================================================================
+
+  describe("runDblabDeploy", () => {
+    it("returns exit code 0 on success", async () => {
+      const { mockFn } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+      const deployFn = async (_args: ParsedArgs) => 0;
+
+      const options: DblabDeployOptions = {
+        dblabUrl: "https://dblab.example.com",
+        dblabToken: "token",
+        deployArgs: makeArgs(),
+      };
+
+      const exitCode = await runDblabDeploy(options, { client, deployFn });
+      expect(exitCode).toBe(0);
+    });
+
+    it("returns exit code 1 on failure", async () => {
+      const { mockFn } = createMockFetch({});
+      const client = new DblabClient("https://dblab.example.com", "token", mockFn);
+      const deployFn = async (_args: ParsedArgs) => 1;
+
+      const options: DblabDeployOptions = {
+        dblabUrl: "https://dblab.example.com",
+        dblabToken: "token",
+        deployArgs: makeArgs(),
+      };
+
+      const exitCode = await runDblabDeploy(options, { client, deployFn });
+      expect(exitCode).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/commands/deploy-dblab.ts` implementing DBLab thin clone lifecycle: provision (POST /clone) -> deploy+verify -> destroy (DELETE /clone/<id>, always in finally block)
- Wire `--dblab-url` and `--dblab-token` flags into the existing `deploy` command — when present, the DBLab workflow runs instead of direct deploy
- Support env vars `DBLAB_URL` / `DBLAB_TOKEN` as alternatives to CLI flags
- Clone connection URI is extracted from the API response and passed as `--db-uri` to the standard deploy pipeline
- On success: "Clone test passed, safe to deploy to production"; on failure: report errors, production is never touched

## Test plan

- [x] 26 unit tests with mock DBLab API (`tests/unit/deploy-dblab.test.ts`)
- [x] `parseDblabOptions`: returns null when no flags, parses both flags, reads env vars, throws on missing flag/value (7 tests)
- [x] `buildCloneUri`: uses connStr when present, builds from components, handles missing password (3 tests)
- [x] `DblabClient`: correct headers/body on create, destroy, status; error handling on non-2xx; trailing slash stripping (7 tests)
- [x] `executeDblabDeploy`: full success flow, deploy failure, deploy exception, provisioning failure, destroy failure, bad clone status, timing (7 tests)
- [x] `runDblabDeploy`: exit code 0 on success, exit code 1 on failure (2 tests)
- [x] Existing deploy tests still pass (59 tests)
- [x] Existing CLI tests still pass (52 tests)
- [x] No new TypeScript type errors

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)