### PR TITLE
G1: sqlever explain — LLM-powered migration explainer

### DIFF
--- a/src/ai/explain.ts
+++ b/src/ai/explain.ts
@@ -1,0 +1,883 @@
+// src/ai/explain.ts — AI-powered migration explanation engine
+//
+// Parses migration SQL via libpg-query, builds structured context
+// (tables affected, DDL types, lock types, estimated risk), and sends
+// to an LLM for plain-English explanation.
+//
+// Implements SPEC Section 5.7 and GitHub issue #106.
+// Design principle DD10: No hidden network calls — LLM is only
+// contacted when `sqlever explain` is explicitly invoked.
+
+import { parseSync, loadModule } from "libpg-query";
+import { preprocessSql } from "../analysis/preprocessor";
+import type { ParseResult, StmtEntry } from "../analysis/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Supported LLM providers. */
+export type LLMProvider = "openai" | "anthropic" | "ollama";
+
+/** Configuration for the explain engine. */
+export interface ExplainConfig {
+  /** LLM provider. */
+  provider: LLMProvider;
+  /** Model name (provider-specific). */
+  model: string;
+  /** API key (not needed for Ollama). */
+  apiKey?: string;
+  /** Ollama base URL (default: http://localhost:11434). */
+  ollamaBaseUrl?: string;
+}
+
+/** A DDL operation extracted from a migration. */
+export interface DDLOperation {
+  /** The DDL type (e.g., "CREATE TABLE", "ALTER TABLE", "CREATE INDEX"). */
+  type: string;
+  /** The object name affected. */
+  objectName: string;
+  /** Sub-operations (e.g., ADD COLUMN, DROP CONSTRAINT). */
+  subOperations: string[];
+}
+
+/** Lock information for a DDL operation. */
+export interface LockInfo {
+  /** Lock type (e.g., "AccessExclusiveLock", "ShareLock"). */
+  lockType: string;
+  /** Whether this lock blocks reads. */
+  blocksReads: boolean;
+  /** Whether this lock blocks writes. */
+  blocksWrites: boolean;
+}
+
+/** Risk level of a migration. */
+export type RiskLevel = "low" | "medium" | "high" | "critical";
+
+/** Structured context built from parsing the migration SQL. */
+export interface MigrationContext {
+  /** Tables affected by the migration. */
+  tablesAffected: string[];
+  /** DDL operations. */
+  operations: DDLOperation[];
+  /** Lock information per operation. */
+  locks: LockInfo[];
+  /** Estimated risk level. */
+  riskLevel: RiskLevel;
+  /** Risk factors found. */
+  riskFactors: string[];
+  /** The original SQL. */
+  sql: string;
+}
+
+/** Result of the explain command. */
+export interface ExplainResult {
+  /** The structured migration context. */
+  context: MigrationContext;
+  /** Plain-English explanation from the LLM. */
+  explanation: string;
+}
+
+/** Response shape returned by LLM API calls. */
+export interface LLMResponse {
+  content: string;
+}
+
+// ---------------------------------------------------------------------------
+// WASM loading
+// ---------------------------------------------------------------------------
+
+let wasmLoaded = false;
+
+export async function ensureWasm(): Promise<void> {
+  if (!wasmLoaded) {
+    await loadModule();
+    wasmLoaded = true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SQL parsing and context extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Lock type mapping for DDL operations.
+ * Based on PostgreSQL documentation for lock types acquired by various DDL.
+ */
+const LOCK_MAP: Record<string, LockInfo> = {
+  "CREATE TABLE": {
+    lockType: "AccessExclusiveLock",
+    blocksReads: false,
+    blocksWrites: false,
+  },
+  "DROP TABLE": {
+    lockType: "AccessExclusiveLock",
+    blocksReads: true,
+    blocksWrites: true,
+  },
+  "ALTER TABLE": {
+    lockType: "AccessExclusiveLock",
+    blocksReads: true,
+    blocksWrites: true,
+  },
+  "CREATE INDEX": {
+    lockType: "ShareLock",
+    blocksReads: false,
+    blocksWrites: true,
+  },
+  "CREATE INDEX CONCURRENTLY": {
+    lockType: "ShareUpdateExclusiveLock",
+    blocksReads: false,
+    blocksWrites: false,
+  },
+  "DROP INDEX": {
+    lockType: "AccessExclusiveLock",
+    blocksReads: true,
+    blocksWrites: true,
+  },
+  "CREATE FUNCTION": {
+    lockType: "none",
+    blocksReads: false,
+    blocksWrites: false,
+  },
+  "CREATE VIEW": {
+    lockType: "none",
+    blocksReads: false,
+    blocksWrites: false,
+  },
+  "CREATE TRIGGER": {
+    lockType: "ShareRowExclusiveLock",
+    blocksReads: false,
+    blocksWrites: true,
+  },
+  "DROP TRIGGER": {
+    lockType: "AccessExclusiveLock",
+    blocksReads: true,
+    blocksWrites: true,
+  },
+  "CREATE SEQUENCE": {
+    lockType: "none",
+    blocksReads: false,
+    blocksWrites: false,
+  },
+  "CREATE TYPE": {
+    lockType: "none",
+    blocksReads: false,
+    blocksWrites: false,
+  },
+  "CREATE SCHEMA": {
+    lockType: "none",
+    blocksReads: false,
+    blocksWrites: false,
+  },
+  "ADD CONSTRAINT": {
+    lockType: "AccessExclusiveLock",
+    blocksReads: true,
+    blocksWrites: true,
+  },
+  "VALIDATE CONSTRAINT": {
+    lockType: "ShareUpdateExclusiveLock",
+    blocksReads: false,
+    blocksWrites: false,
+  },
+};
+
+/** Risk factors and their associated risk level escalation. */
+const RISK_ESCALATION: Array<{
+  pattern: string;
+  level: RiskLevel;
+  factor: string;
+}> = [
+  {
+    pattern: "DROP TABLE",
+    level: "critical",
+    factor: "Drops a table — data loss if no backup",
+  },
+  {
+    pattern: "DROP COLUMN",
+    level: "high",
+    factor: "Drops a column — data loss",
+  },
+  {
+    pattern: "ALTER COLUMN TYPE",
+    level: "high",
+    factor: "Changes column type — may cause full table rewrite with AccessExclusiveLock",
+  },
+  {
+    pattern: "NOT NULL",
+    level: "medium",
+    factor: "Adds NOT NULL constraint — requires full table scan to validate",
+  },
+  {
+    pattern: "CREATE INDEX",
+    level: "medium",
+    factor: "Creates index — blocks writes unless CONCURRENTLY",
+  },
+  {
+    pattern: "CONCURRENTLY",
+    level: "low",
+    factor: "Uses CONCURRENTLY — non-blocking but slower",
+  },
+  {
+    pattern: "ADD COLUMN",
+    level: "low",
+    factor: "Adds column — fast in PG 11+ with volatile defaults",
+  },
+];
+
+/**
+ * Extract the relation (table) name from a libpg-query RangeVar node.
+ */
+function extractRelationName(relation: Record<string, unknown>): string {
+  const schema = relation.schemaname as string | undefined;
+  const name = relation.relname as string | undefined;
+  if (!name) return "unknown";
+  return schema ? `${schema}.${name}` : name;
+}
+
+/**
+ * Extract sub-operations from ALTER TABLE commands.
+ */
+function extractAlterSubOps(cmds: Array<Record<string, unknown>>): string[] {
+  const subOps: string[] = [];
+  for (const cmdEntry of cmds) {
+    const cmd = cmdEntry.AlterTableCmd as Record<string, unknown> | undefined;
+    if (!cmd) continue;
+
+    const subtype = cmd.subtype as string;
+    const colName = cmd.name as string | undefined;
+
+    // For ADD COLUMN, the name is in def.ColumnDef.colname, not cmd.name
+    const defColName = (cmd.def as Record<string, unknown> | undefined)
+      ?.ColumnDef as Record<string, unknown> | undefined;
+    const effectiveName = colName ?? (defColName?.colname as string | undefined);
+
+    switch (subtype) {
+      case "AT_AddColumn":
+        subOps.push(`ADD COLUMN${effectiveName ? ` "${effectiveName}"` : ""}`);
+        break;
+      case "AT_DropColumn":
+        subOps.push(`DROP COLUMN${effectiveName ? ` "${effectiveName}"` : ""}`);
+        break;
+      case "AT_AlterColumnType":
+        subOps.push(`ALTER COLUMN TYPE${colName ? ` "${colName}"` : ""}`);
+        break;
+      case "AT_SetNotNull":
+        subOps.push(`SET NOT NULL${colName ? ` "${colName}"` : ""}`);
+        break;
+      case "AT_DropNotNull":
+        subOps.push(`DROP NOT NULL${colName ? ` "${colName}"` : ""}`);
+        break;
+      case "AT_AddConstraint":
+        subOps.push("ADD CONSTRAINT");
+        break;
+      case "AT_DropConstraint":
+        subOps.push("DROP CONSTRAINT");
+        break;
+      case "AT_SetDefault":
+        subOps.push(`SET DEFAULT${colName ? ` "${colName}"` : ""}`);
+        break;
+      case "AT_DropDefault":
+        subOps.push(`DROP DEFAULT${colName ? ` "${colName}"` : ""}`);
+        break;
+      case "AT_AddIndex":
+        subOps.push("ADD INDEX");
+        break;
+      case "AT_ValidateConstraint":
+        subOps.push("VALIDATE CONSTRAINT");
+        break;
+      case "AT_ColumnDefault":
+        subOps.push(`COLUMN DEFAULT${colName ? ` "${colName}"` : ""}`);
+        break;
+      default:
+        subOps.push(subtype ?? "UNKNOWN");
+    }
+  }
+  return subOps;
+}
+
+/**
+ * Parse a single statement entry and extract DDL operations.
+ */
+function parseStmtEntry(entry: StmtEntry): DDLOperation | null {
+  const stmt = entry.stmt;
+
+  // CREATE TABLE
+  if (stmt.CreateStmt) {
+    const createStmt = stmt.CreateStmt as Record<string, unknown>;
+    const relation = createStmt.relation as Record<string, unknown>;
+    return {
+      type: "CREATE TABLE",
+      objectName: extractRelationName(relation),
+      subOperations: [],
+    };
+  }
+
+  // ALTER TABLE
+  if (stmt.AlterTableStmt) {
+    const alterStmt = stmt.AlterTableStmt as Record<string, unknown>;
+    const relation = alterStmt.relation as Record<string, unknown>;
+    const cmds = (alterStmt.cmds ?? []) as Array<Record<string, unknown>>;
+    return {
+      type: "ALTER TABLE",
+      objectName: extractRelationName(relation),
+      subOperations: extractAlterSubOps(cmds),
+    };
+  }
+
+  // CREATE INDEX
+  if (stmt.IndexStmt) {
+    const indexStmt = stmt.IndexStmt as Record<string, unknown>;
+    const idxName = (indexStmt.idxname as string) ?? "unnamed";
+    const relation = indexStmt.relation as Record<string, unknown>;
+    const concurrent = indexStmt.concurrent as boolean | undefined;
+    const tableName = extractRelationName(relation);
+    return {
+      type: concurrent ? "CREATE INDEX CONCURRENTLY" : "CREATE INDEX",
+      objectName: `${idxName} ON ${tableName}`,
+      subOperations: [],
+    };
+  }
+
+  // DROP TABLE
+  if (stmt.DropStmt) {
+    const dropStmt = stmt.DropStmt as Record<string, unknown>;
+    const removeType = dropStmt.removeType as string;
+    if (removeType === "OBJECT_TABLE") {
+      const objects = (dropStmt.objects ?? []) as Array<unknown>;
+      const names = objects.map((obj) => {
+        if (Array.isArray(obj)) {
+          return obj.map((n: Record<string, unknown>) => (n.String as Record<string, unknown>)?.sval ?? "").join(".");
+        }
+        return "unknown";
+      });
+      return {
+        type: "DROP TABLE",
+        objectName: names.join(", "),
+        subOperations: [],
+      };
+    }
+    if (removeType === "OBJECT_INDEX") {
+      const objects = (dropStmt.objects ?? []) as Array<unknown>;
+      const names = objects.map((obj) => {
+        if (Array.isArray(obj)) {
+          return obj.map((n: Record<string, unknown>) => (n.String as Record<string, unknown>)?.sval ?? "").join(".");
+        }
+        return "unknown";
+      });
+      return {
+        type: "DROP INDEX",
+        objectName: names.join(", "),
+        subOperations: [],
+      };
+    }
+    return null;
+  }
+
+  // CREATE FUNCTION / PROCEDURE
+  if (stmt.CreateFunctionStmt) {
+    const funcStmt = stmt.CreateFunctionStmt as Record<string, unknown>;
+    const funcname = (funcStmt.funcname ?? []) as Array<Record<string, unknown>>;
+    const name = funcname.map((n) => (n.String as Record<string, unknown>)?.sval ?? "").join(".");
+    return {
+      type: "CREATE FUNCTION",
+      objectName: name,
+      subOperations: [],
+    };
+  }
+
+  // CREATE VIEW
+  if (stmt.ViewStmt) {
+    const viewStmt = stmt.ViewStmt as Record<string, unknown>;
+    const view = viewStmt.view as Record<string, unknown>;
+    return {
+      type: "CREATE VIEW",
+      objectName: extractRelationName(view),
+      subOperations: [],
+    };
+  }
+
+  // CREATE TRIGGER
+  if (stmt.CreateTrigStmt) {
+    const trigStmt = stmt.CreateTrigStmt as Record<string, unknown>;
+    const trigName = (trigStmt.trigname as string) ?? "unnamed";
+    const relation = trigStmt.relation as Record<string, unknown>;
+    const tableName = extractRelationName(relation);
+    return {
+      type: "CREATE TRIGGER",
+      objectName: `${trigName} ON ${tableName}`,
+      subOperations: [],
+    };
+  }
+
+  // CREATE SEQUENCE
+  if (stmt.CreateSeqStmt) {
+    const seqStmt = stmt.CreateSeqStmt as Record<string, unknown>;
+    const seq = seqStmt.sequence as Record<string, unknown>;
+    return {
+      type: "CREATE SEQUENCE",
+      objectName: extractRelationName(seq),
+      subOperations: [],
+    };
+  }
+
+  // CREATE SCHEMA
+  if (stmt.CreateSchemaStmt) {
+    const schemaStmt = stmt.CreateSchemaStmt as Record<string, unknown>;
+    const schemaName = (schemaStmt.schemaname as string) ?? "unnamed";
+    return {
+      type: "CREATE SCHEMA",
+      objectName: schemaName,
+      subOperations: [],
+    };
+  }
+
+  // CREATE TYPE
+  if (stmt.CreateEnumStmt || stmt.CompositeTypeStmt) {
+    const typeStmt = (stmt.CreateEnumStmt ?? stmt.CompositeTypeStmt) as Record<string, unknown>;
+    const typeName = (typeStmt.typeName ?? []) as Array<Record<string, unknown>>;
+    const name = typeName.map((n) => (n.String as Record<string, unknown>)?.sval ?? "").join(".");
+    return {
+      type: "CREATE TYPE",
+      objectName: name,
+      subOperations: [],
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Extract tables affected from operations.
+ */
+function extractTablesAffected(operations: DDLOperation[]): string[] {
+  const tables = new Set<string>();
+  for (const op of operations) {
+    // Extract the base table name (strip index/trigger "X ON Y" syntax)
+    if (op.objectName.includes(" ON ")) {
+      const parts = op.objectName.split(" ON ");
+      tables.add(parts[1]!.trim());
+    } else if (
+      op.type === "CREATE TABLE" ||
+      op.type === "ALTER TABLE" ||
+      op.type === "DROP TABLE"
+    ) {
+      tables.add(op.objectName);
+    }
+  }
+  return Array.from(tables);
+}
+
+/**
+ * Compute risk level from operations.
+ */
+function computeRisk(operations: DDLOperation[]): {
+  level: RiskLevel;
+  factors: string[];
+} {
+  let level: RiskLevel = "low";
+  const factors: string[] = [];
+  const riskOrder: Record<RiskLevel, number> = {
+    low: 0,
+    medium: 1,
+    high: 2,
+    critical: 3,
+  };
+
+  for (const op of operations) {
+    for (const escalation of RISK_ESCALATION) {
+      const matchesType = op.type.includes(escalation.pattern);
+      const matchesSubOp = op.subOperations.some((sub) =>
+        sub.includes(escalation.pattern),
+      );
+
+      if (matchesType || matchesSubOp) {
+        if (!factors.includes(escalation.factor)) {
+          factors.push(escalation.factor);
+        }
+        if (riskOrder[escalation.level]! > riskOrder[level]!) {
+          level = escalation.level;
+        }
+      }
+    }
+  }
+
+  // If no factors found, add a default
+  if (factors.length === 0) {
+    factors.push("No significant risk factors detected");
+  }
+
+  return { level, factors };
+}
+
+/**
+ * Get lock information for an operation.
+ */
+function getLockInfo(operation: DDLOperation): LockInfo {
+  // Check for ALTER TABLE sub-operations that have specific lock types
+  if (operation.type === "ALTER TABLE") {
+    for (const subOp of operation.subOperations) {
+      if (subOp === "VALIDATE CONSTRAINT") {
+        return (
+          LOCK_MAP["VALIDATE CONSTRAINT"] ?? {
+            lockType: "AccessExclusiveLock",
+            blocksReads: true,
+            blocksWrites: true,
+          }
+        );
+      }
+    }
+  }
+
+  return (
+    LOCK_MAP[operation.type] ?? {
+      lockType: "unknown",
+      blocksReads: false,
+      blocksWrites: false,
+    }
+  );
+}
+
+/**
+ * Parse migration SQL and build structured context.
+ *
+ * This is the pure analysis step — no LLM calls.
+ */
+export function buildMigrationContext(sql: string): MigrationContext {
+  const { cleanedSql } = preprocessSql(sql);
+
+  let ast: ParseResult;
+  try {
+    ast = parseSync(cleanedSql) as ParseResult;
+  } catch {
+    // Return minimal context if parsing fails
+    return {
+      tablesAffected: [],
+      operations: [],
+      locks: [],
+      riskLevel: "medium",
+      riskFactors: ["SQL could not be parsed — manual review recommended"],
+      sql,
+    };
+  }
+
+  const operations: DDLOperation[] = [];
+
+  for (const entry of ast.stmts) {
+    const op = parseStmtEntry(entry);
+    if (op) {
+      operations.push(op);
+    }
+  }
+
+  const tablesAffected = extractTablesAffected(operations);
+  const locks = operations.map(getLockInfo);
+  const { level: riskLevel, factors: riskFactors } = computeRisk(operations);
+
+  return {
+    tablesAffected,
+    operations,
+    locks,
+    riskLevel,
+    riskFactors,
+    sql,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// LLM prompt building
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a prompt for the LLM from the migration context.
+ */
+export function buildPrompt(context: MigrationContext): string {
+  const parts: string[] = [];
+
+  parts.push(
+    "You are a PostgreSQL migration expert. Analyze the following migration and provide:",
+  );
+  parts.push("1. A plain-English summary of what this migration does");
+  parts.push(
+    "2. A risk assessment covering potential issues, lock contention, and downtime impact",
+  );
+  parts.push("");
+  parts.push("## Migration SQL");
+  parts.push("```sql");
+  parts.push(context.sql.trim());
+  parts.push("```");
+  parts.push("");
+
+  if (context.operations.length > 0) {
+    parts.push("## Detected Operations");
+    for (let i = 0; i < context.operations.length; i++) {
+      const op = context.operations[i]!;
+      const lock = context.locks[i];
+      parts.push(
+        `- ${op.type} ${op.objectName}${op.subOperations.length > 0 ? ` (${op.subOperations.join(", ")})` : ""}${lock ? ` [Lock: ${lock.lockType}]` : ""}`,
+      );
+    }
+    parts.push("");
+  }
+
+  if (context.tablesAffected.length > 0) {
+    parts.push(`## Tables Affected: ${context.tablesAffected.join(", ")}`);
+    parts.push("");
+  }
+
+  parts.push(`## Risk Level: ${context.riskLevel.toUpperCase()}`);
+  parts.push("### Risk Factors");
+  for (const factor of context.riskFactors) {
+    parts.push(`- ${factor}`);
+  }
+  parts.push("");
+  parts.push(
+    "Provide a concise explanation followed by a risk assessment. " +
+      "Focus on operational impact: will this block reads or writes? " +
+      "Could it cause downtime? Are there safer alternatives?",
+  );
+
+  return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// LLM API calls (fetch-based, no SDK dependencies)
+// ---------------------------------------------------------------------------
+
+/** Default models per provider. */
+export const DEFAULT_MODELS: Record<LLMProvider, string> = {
+  openai: "gpt-4o",
+  anthropic: "claude-sonnet-4-20250514",
+  ollama: "llama3.2",
+};
+
+/** Default Ollama base URL. */
+const DEFAULT_OLLAMA_URL = "http://localhost:11434";
+
+/**
+ * Call the OpenAI API.
+ */
+async function callOpenAI(
+  prompt: string,
+  config: ExplainConfig,
+  fetchFn: typeof globalThis.fetch = globalThis.fetch,
+): Promise<LLMResponse> {
+  if (!config.apiKey) {
+    throw new Error(
+      "OpenAI API key required. Set --api-key or OPENAI_API_KEY environment variable.",
+    );
+  }
+
+  const response = await fetchFn("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: config.model,
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0.3,
+      max_tokens: 2000,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`OpenAI API error (${response.status}): ${errorText}`);
+  }
+
+  const data = (await response.json()) as {
+    choices: Array<{ message: { content: string } }>;
+  };
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error("OpenAI returned an empty response");
+  }
+
+  return { content };
+}
+
+/**
+ * Call the Anthropic API.
+ */
+async function callAnthropic(
+  prompt: string,
+  config: ExplainConfig,
+  fetchFn: typeof globalThis.fetch = globalThis.fetch,
+): Promise<LLMResponse> {
+  if (!config.apiKey) {
+    throw new Error(
+      "Anthropic API key required. Set --api-key or ANTHROPIC_API_KEY environment variable.",
+    );
+  }
+
+  const response = await fetchFn("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": config.apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: config.model,
+      max_tokens: 2000,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Anthropic API error (${response.status}): ${errorText}`);
+  }
+
+  const data = (await response.json()) as {
+    content: Array<{ type: string; text: string }>;
+  };
+  const textBlock = data.content?.find((b) => b.type === "text");
+  if (!textBlock?.text) {
+    throw new Error("Anthropic returned an empty response");
+  }
+
+  return { content: textBlock.text };
+}
+
+/**
+ * Call the Ollama API (local).
+ */
+async function callOllama(
+  prompt: string,
+  config: ExplainConfig,
+  fetchFn: typeof globalThis.fetch = globalThis.fetch,
+): Promise<LLMResponse> {
+  const baseUrl = config.ollamaBaseUrl ?? DEFAULT_OLLAMA_URL;
+  const response = await fetchFn(`${baseUrl}/api/generate`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: config.model,
+      prompt,
+      stream: false,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Ollama API error (${response.status}): ${errorText}`);
+  }
+
+  const data = (await response.json()) as { response: string };
+  if (!data.response) {
+    throw new Error("Ollama returned an empty response");
+  }
+
+  return { content: data.response };
+}
+
+/**
+ * Call the configured LLM provider.
+ */
+export async function callLLM(
+  prompt: string,
+  config: ExplainConfig,
+  fetchFn: typeof globalThis.fetch = globalThis.fetch,
+): Promise<LLMResponse> {
+  switch (config.provider) {
+    case "openai":
+      return callOpenAI(prompt, config, fetchFn);
+    case "anthropic":
+      return callAnthropic(prompt, config, fetchFn);
+    case "ollama":
+      return callOllama(prompt, config, fetchFn);
+    default:
+      throw new Error(
+        `Unknown LLM provider: ${config.provider as string}. Supported: openai, anthropic, ollama.`,
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format the explain result for terminal output.
+ */
+export function formatExplainOutput(result: ExplainResult): string {
+  const parts: string[] = [];
+
+  // Header
+  parts.push("=== Migration Explanation ===");
+  parts.push("");
+
+  // Context summary
+  if (result.context.tablesAffected.length > 0) {
+    parts.push(
+      `Tables affected: ${result.context.tablesAffected.join(", ")}`,
+    );
+  }
+
+  if (result.context.operations.length > 0) {
+    parts.push(
+      `Operations: ${result.context.operations.map((op) => op.type).join(", ")}`,
+    );
+  }
+
+  const blockingLocks = result.context.locks.filter(
+    (l) => l.blocksReads || l.blocksWrites,
+  );
+  if (blockingLocks.length > 0) {
+    const lockTypes = [...new Set(blockingLocks.map((l) => l.lockType))];
+    parts.push(`Blocking locks: ${lockTypes.join(", ")}`);
+  }
+
+  parts.push(`Risk level: ${result.context.riskLevel.toUpperCase()}`);
+  parts.push("");
+
+  // Risk factors
+  parts.push("--- Risk Factors ---");
+  for (const factor of result.context.riskFactors) {
+    parts.push(`  - ${factor}`);
+  }
+  parts.push("");
+
+  // LLM explanation
+  parts.push("--- Explanation ---");
+  parts.push(result.explanation);
+  parts.push("");
+
+  return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main explain function
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the explain engine: parse SQL, build context, call LLM.
+ *
+ * @param sql The migration SQL to explain.
+ * @param config LLM configuration.
+ * @param fetchFn Optional fetch function override (for testing).
+ */
+export async function explain(
+  sql: string,
+  config: ExplainConfig,
+  fetchFn: typeof globalThis.fetch = globalThis.fetch,
+): Promise<ExplainResult> {
+  // 1. Build structured context
+  const context = buildMigrationContext(sql);
+
+  // 2. Build prompt
+  const prompt = buildPrompt(context);
+
+  // 3. Call LLM
+  const response = await callLLM(prompt, config, fetchFn);
+
+  return {
+    context,
+    explanation: response.content,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { parseShowArgs, runShow } from "./commands/show";
 import { runPlan } from "./commands/plan";
 import { runVerify } from "./commands/verify";
 import { parseAnalyzeArgs, runAnalyze } from "./commands/analyze";
+import { parseExplainArgs, runExplain } from "./commands/explain";
 import { runDoctor } from "./commands/doctor";
 import { runDiff } from "./commands/diff";
 
@@ -421,6 +422,14 @@ export function main(argv: string[] = process.argv.slice(2)): void {
     runAnalyze(analyzeOpts)
       .then((result) => { if (result.exitCode !== 0) process.exit(result.exitCode); })
       .catch((err: unknown) => { process.stderr.write(`sqlever analyze: ${err instanceof Error ? err.message : String(err)}\n`); process.exit(1); });
+    return;
+  }
+
+  if (args.command === "explain") {
+    const explainOpts = parseExplainArgs(args.rest);
+    runExplain(explainOpts)
+      .then((exitCode) => { if (exitCode !== 0) process.exit(exitCode); })
+      .catch((err: unknown) => { process.stderr.write(`sqlever explain: ${err instanceof Error ? err.message : String(err)}\n`); process.exit(1); });
     return;
   }
 

--- a/src/commands/explain.ts
+++ b/src/commands/explain.ts
@@ -1,0 +1,174 @@
+// src/commands/explain.ts — sqlever explain command
+//
+// Usage:
+//   sqlever explain <file.sql>          — explain a migration file
+//   sqlever explain --provider openai   — use OpenAI (default)
+//   sqlever explain --provider anthropic — use Anthropic
+//   sqlever explain --provider ollama   — use local Ollama
+//   sqlever explain --model gpt-4o     — specify model
+//   sqlever explain --api-key sk-...   — API key (or env var)
+//
+// Implements SPEC Section 5.7 and GitHub issue #106.
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  ensureWasm,
+  explain,
+  formatExplainOutput,
+  DEFAULT_MODELS,
+  type LLMProvider,
+  type ExplainConfig,
+} from "../ai/explain";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ExplainOptions {
+  /** Path to the migration SQL file. */
+  target?: string;
+  /** LLM provider. */
+  provider: LLMProvider;
+  /** Model name. */
+  model?: string;
+  /** API key. */
+  apiKey?: string;
+  /** Ollama base URL. */
+  ollamaBaseUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse explain-specific arguments from the rest array.
+ */
+export function parseExplainArgs(rest: string[]): ExplainOptions {
+  const opts: ExplainOptions = {
+    provider: "openai",
+  };
+
+  let i = 0;
+  while (i < rest.length) {
+    const arg = rest[i]!;
+
+    if (arg === "--provider") {
+      const val = rest[i + 1];
+      if (val === "openai" || val === "anthropic" || val === "ollama") {
+        opts.provider = val;
+      } else {
+        throw new Error(
+          `Invalid --provider value '${val ?? ""}'. Expected openai, anthropic, or ollama.`,
+        );
+      }
+      i += 2;
+      continue;
+    }
+
+    if (arg === "--model") {
+      const val = rest[i + 1];
+      if (!val) {
+        throw new Error("--model requires a value");
+      }
+      opts.model = val;
+      i += 2;
+      continue;
+    }
+
+    if (arg === "--api-key") {
+      const val = rest[i + 1];
+      if (!val) {
+        throw new Error("--api-key requires a value");
+      }
+      opts.apiKey = val;
+      i += 2;
+      continue;
+    }
+
+    if (arg === "--ollama-url") {
+      const val = rest[i + 1];
+      if (!val) {
+        throw new Error("--ollama-url requires a value");
+      }
+      opts.ollamaBaseUrl = val;
+      i += 2;
+      continue;
+    }
+
+    // Positional argument — file target
+    if (!opts.target) {
+      opts.target = arg;
+    }
+    i++;
+  }
+
+  return opts;
+}
+
+/**
+ * Resolve the API key from args, environment variables, or error.
+ */
+function resolveApiKey(opts: ExplainOptions): string | undefined {
+  if (opts.apiKey) return opts.apiKey;
+
+  switch (opts.provider) {
+    case "openai":
+      return process.env.OPENAI_API_KEY;
+    case "anthropic":
+      return process.env.ANTHROPIC_API_KEY;
+    case "ollama":
+      return undefined; // No key needed
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main command
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the explain command.
+ */
+export async function runExplain(opts: ExplainOptions): Promise<number> {
+  // Validate target
+  if (!opts.target) {
+    throw new Error(
+      "Usage: sqlever explain <file.sql> [--provider openai|anthropic|ollama] [--model <name>] [--api-key <key>]",
+    );
+  }
+
+  const filePath = resolve(opts.target);
+  if (!existsSync(filePath)) {
+    throw new Error(`File not found: ${opts.target}`);
+  }
+
+  // Read SQL
+  const sql = readFileSync(filePath, "utf-8");
+  if (sql.trim().length === 0) {
+    throw new Error(`File is empty: ${opts.target}`);
+  }
+
+  // Resolve API key
+  const apiKey = resolveApiKey(opts);
+
+  // Build config
+  const config: ExplainConfig = {
+    provider: opts.provider,
+    model: opts.model ?? DEFAULT_MODELS[opts.provider],
+    apiKey,
+    ollamaBaseUrl: opts.ollamaBaseUrl,
+  };
+
+  // Ensure WASM loaded for SQL parsing
+  await ensureWasm();
+
+  // Run explain
+  const result = await explain(sql, config);
+
+  // Output
+  const output = formatExplainOutput(result);
+  process.stdout.write(output);
+
+  return 0;
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -309,7 +309,7 @@ describe("unknown commands", () => {
 
 describe("command stubs", () => {
   // "help" is handled specially (not a stub); "init", "add", "deploy", "log", "revert", "verify", "tag", "rework", "show", "status", "plan", and "analyze" are implemented — exclude them
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "deploy" && c !== "log" && c !== "revert" && c !== "verify" && c !== "tag" && c !== "rework" && c !== "show" && c !== "status" && c !== "plan" && c !== "analyze" && c !== "diff");
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "deploy" && c !== "log" && c !== "revert" && c !== "verify" && c !== "tag" && c !== "rework" && c !== "show" && c !== "status" && c !== "plan" && c !== "analyze" && c !== "explain" && c !== "diff");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {

--- a/tests/unit/explain.test.ts
+++ b/tests/unit/explain.test.ts
@@ -1,0 +1,634 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import {
+  ensureWasm,
+  buildMigrationContext,
+  buildPrompt,
+  callLLM,
+  explain,
+  formatExplainOutput,
+  DEFAULT_MODELS,
+  type ExplainConfig,
+  type ExplainResult,
+  type LLMProvider,
+} from "../../src/ai/explain";
+import { parseExplainArgs } from "../../src/commands/explain";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock fetch function that returns a canned LLM response.
+ */
+function mockFetch(
+  provider: LLMProvider,
+  responseText: string,
+): typeof globalThis.fetch {
+  return (async (_url: string | URL | Request, _init?: RequestInit) => {
+    let body: string;
+    switch (provider) {
+      case "openai":
+        body = JSON.stringify({
+          choices: [{ message: { content: responseText } }],
+        });
+        break;
+      case "anthropic":
+        body = JSON.stringify({
+          content: [{ type: "text", text: responseText }],
+        });
+        break;
+      case "ollama":
+        body = JSON.stringify({ response: responseText });
+        break;
+    }
+    return new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+/**
+ * Create a mock fetch that returns an error status.
+ */
+function mockFetchError(status: number, errorText: string): typeof globalThis.fetch {
+  return (async (_url: string | URL | Request, _init?: RequestInit) => {
+    return new Response(errorText, { status });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await ensureWasm();
+});
+
+// ---------------------------------------------------------------------------
+// 1. SQL Parsing — buildMigrationContext
+// ---------------------------------------------------------------------------
+
+describe("buildMigrationContext", () => {
+  test("parses CREATE TABLE", () => {
+    const ctx = buildMigrationContext(
+      "CREATE TABLE users (id serial PRIMARY KEY, name text NOT NULL);",
+    );
+    expect(ctx.tablesAffected).toContain("users");
+    expect(ctx.operations).toHaveLength(1);
+    expect(ctx.operations[0]!.type).toBe("CREATE TABLE");
+    expect(ctx.operations[0]!.objectName).toBe("users");
+    expect(ctx.riskLevel).toBe("low");
+  });
+
+  test("parses ALTER TABLE ADD COLUMN", () => {
+    const ctx = buildMigrationContext(
+      "ALTER TABLE users ADD COLUMN email text;",
+    );
+    expect(ctx.tablesAffected).toContain("users");
+    expect(ctx.operations).toHaveLength(1);
+    expect(ctx.operations[0]!.type).toBe("ALTER TABLE");
+    expect(ctx.operations[0]!.subOperations).toContain('ADD COLUMN "email"');
+    expect(ctx.locks[0]!.lockType).toBe("AccessExclusiveLock");
+  });
+
+  test("parses DROP TABLE as critical risk", () => {
+    const ctx = buildMigrationContext("DROP TABLE users;");
+    expect(ctx.operations).toHaveLength(1);
+    expect(ctx.operations[0]!.type).toBe("DROP TABLE");
+    expect(ctx.riskLevel).toBe("critical");
+    expect(ctx.riskFactors.some((f) => f.includes("data loss"))).toBe(true);
+  });
+
+  test("parses CREATE INDEX (non-concurrent) as medium risk", () => {
+    const ctx = buildMigrationContext(
+      "CREATE INDEX idx_users_email ON users (email);",
+    );
+    expect(ctx.operations).toHaveLength(1);
+    expect(ctx.operations[0]!.type).toBe("CREATE INDEX");
+    expect(ctx.locks[0]!.lockType).toBe("ShareLock");
+    expect(ctx.locks[0]!.blocksWrites).toBe(true);
+    expect(ctx.riskLevel).toBe("medium");
+  });
+
+  test("parses CREATE INDEX CONCURRENTLY as low risk", () => {
+    const ctx = buildMigrationContext(
+      "CREATE INDEX CONCURRENTLY idx_users_email ON users (email);",
+    );
+    expect(ctx.operations).toHaveLength(1);
+    expect(ctx.operations[0]!.type).toBe("CREATE INDEX CONCURRENTLY");
+    expect(ctx.locks[0]!.lockType).toBe("ShareUpdateExclusiveLock");
+    expect(ctx.locks[0]!.blocksWrites).toBe(false);
+  });
+
+  test("parses multiple statements", () => {
+    const sql = `
+      CREATE TABLE orders (id serial PRIMARY KEY, user_id int);
+      CREATE INDEX idx_orders_user_id ON orders (user_id);
+      ALTER TABLE orders ADD COLUMN total numeric;
+    `;
+    const ctx = buildMigrationContext(sql);
+    expect(ctx.tablesAffected).toContain("orders");
+    expect(ctx.operations).toHaveLength(3);
+    expect(ctx.operations[0]!.type).toBe("CREATE TABLE");
+    expect(ctx.operations[1]!.type).toBe("CREATE INDEX");
+    expect(ctx.operations[2]!.type).toBe("ALTER TABLE");
+  });
+
+  test("handles unparseable SQL gracefully", () => {
+    const ctx = buildMigrationContext("THIS IS NOT VALID SQL !!!");
+    expect(ctx.operations).toHaveLength(0);
+    expect(ctx.riskLevel).toBe("medium");
+    expect(ctx.riskFactors[0]).toContain("could not be parsed");
+  });
+
+  test("parses ALTER TABLE with DROP COLUMN as high risk", () => {
+    const ctx = buildMigrationContext(
+      "ALTER TABLE users DROP COLUMN email;",
+    );
+    expect(ctx.riskLevel).toBe("high");
+    expect(ctx.riskFactors.some((f) => f.includes("Drops a column"))).toBe(true);
+  });
+
+  test("parses CREATE FUNCTION", () => {
+    const ctx = buildMigrationContext(
+      "CREATE FUNCTION add(a int, b int) RETURNS int AS $$ SELECT a + b; $$ LANGUAGE sql;",
+    );
+    expect(ctx.operations).toHaveLength(1);
+    expect(ctx.operations[0]!.type).toBe("CREATE FUNCTION");
+    expect(ctx.locks[0]!.lockType).toBe("none");
+    expect(ctx.riskLevel).toBe("low");
+  });
+
+  test("parses schema-qualified table names", () => {
+    const ctx = buildMigrationContext(
+      "CREATE TABLE public.users (id serial PRIMARY KEY);",
+    );
+    expect(ctx.tablesAffected).toContain("public.users");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Prompt building
+// ---------------------------------------------------------------------------
+
+describe("buildPrompt", () => {
+  test("includes SQL in prompt", () => {
+    const ctx = buildMigrationContext(
+      "CREATE TABLE users (id serial PRIMARY KEY);",
+    );
+    const prompt = buildPrompt(ctx);
+    expect(prompt).toContain("CREATE TABLE users");
+    expect(prompt).toContain("```sql");
+  });
+
+  test("includes operations in prompt", () => {
+    const ctx = buildMigrationContext(
+      "ALTER TABLE users ADD COLUMN email text;",
+    );
+    const prompt = buildPrompt(ctx);
+    expect(prompt).toContain("ALTER TABLE");
+    expect(prompt).toContain("Detected Operations");
+  });
+
+  test("includes risk level in prompt", () => {
+    const ctx = buildMigrationContext("DROP TABLE users;");
+    const prompt = buildPrompt(ctx);
+    expect(prompt).toContain("CRITICAL");
+    expect(prompt).toContain("Risk Factors");
+  });
+
+  test("includes tables affected in prompt", () => {
+    const ctx = buildMigrationContext(
+      "CREATE INDEX idx_email ON users (email);",
+    );
+    const prompt = buildPrompt(ctx);
+    expect(prompt).toContain("Tables Affected: users");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. LLM provider calls
+// ---------------------------------------------------------------------------
+
+describe("callLLM", () => {
+  test("calls OpenAI with correct format", async () => {
+    let capturedUrl = "";
+    let capturedBody: Record<string, unknown> = {};
+
+    const mockFn = (async (url: string | URL | Request, init?: RequestInit) => {
+      capturedUrl = url as string;
+      capturedBody = JSON.parse(init?.body as string) as Record<string, unknown>;
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "Test explanation" } }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof globalThis.fetch;
+
+    const config: ExplainConfig = {
+      provider: "openai",
+      model: "gpt-4o",
+      apiKey: "test-key",
+    };
+
+    const result = await callLLM("test prompt", config, mockFn);
+    expect(result.content).toBe("Test explanation");
+    expect(capturedUrl).toContain("openai.com");
+    expect(capturedBody.model).toBe("gpt-4o");
+  });
+
+  test("calls Anthropic with correct format", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: Record<string, string> = {};
+
+    const mockFn = (async (url: string | URL | Request, init?: RequestInit) => {
+      capturedUrl = url as string;
+      const headers = init?.headers as Record<string, string>;
+      capturedHeaders = headers;
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "Anthropic explanation" }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof globalThis.fetch;
+
+    const config: ExplainConfig = {
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "test-key",
+    };
+
+    const result = await callLLM("test prompt", config, mockFn);
+    expect(result.content).toBe("Anthropic explanation");
+    expect(capturedUrl).toContain("anthropic.com");
+    expect(capturedHeaders["x-api-key"]).toBe("test-key");
+  });
+
+  test("calls Ollama with correct format", async () => {
+    let capturedUrl = "";
+
+    const mockFn = (async (url: string | URL | Request) => {
+      capturedUrl = url as string;
+      return new Response(
+        JSON.stringify({ response: "Ollama explanation" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof globalThis.fetch;
+
+    const config: ExplainConfig = {
+      provider: "ollama",
+      model: "llama3.2",
+    };
+
+    const result = await callLLM("test prompt", config, mockFn);
+    expect(result.content).toBe("Ollama explanation");
+    expect(capturedUrl).toContain("localhost:11434");
+  });
+
+  test("throws on missing OpenAI API key", async () => {
+    const config: ExplainConfig = {
+      provider: "openai",
+      model: "gpt-4o",
+    };
+
+    await expect(callLLM("test", config)).rejects.toThrow("API key required");
+  });
+
+  test("throws on missing Anthropic API key", async () => {
+    const config: ExplainConfig = {
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+    };
+
+    await expect(callLLM("test", config)).rejects.toThrow("API key required");
+  });
+
+  test("handles API error responses", async () => {
+    const config: ExplainConfig = {
+      provider: "openai",
+      model: "gpt-4o",
+      apiKey: "bad-key",
+    };
+
+    const mockFn = mockFetchError(401, "Unauthorized");
+    await expect(callLLM("test", config, mockFn)).rejects.toThrow(
+      "OpenAI API error (401)",
+    );
+  });
+
+  test("handles Anthropic API error responses", async () => {
+    const config: ExplainConfig = {
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "bad-key",
+    };
+
+    const mockFn = mockFetchError(403, "Forbidden");
+    await expect(callLLM("test", config, mockFn)).rejects.toThrow(
+      "Anthropic API error (403)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. End-to-end explain with mock LLM
+// ---------------------------------------------------------------------------
+
+describe("explain (end-to-end with mock)", () => {
+  test("produces full explain result for CREATE TABLE", async () => {
+    const sql = "CREATE TABLE users (id serial PRIMARY KEY, name text NOT NULL);";
+    const config: ExplainConfig = {
+      provider: "openai",
+      model: "gpt-4o",
+      apiKey: "test-key",
+    };
+
+    const result = await explain(
+      sql,
+      config,
+      mockFetch("openai", "This migration creates a new users table."),
+    );
+
+    expect(result.context.tablesAffected).toContain("users");
+    expect(result.context.operations[0]!.type).toBe("CREATE TABLE");
+    expect(result.explanation).toBe(
+      "This migration creates a new users table.",
+    );
+  });
+
+  test("produces full explain result for ALTER TABLE", async () => {
+    const sql = "ALTER TABLE users ADD COLUMN email text NOT NULL DEFAULT '';";
+    const config: ExplainConfig = {
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      apiKey: "test-key",
+    };
+
+    const result = await explain(
+      sql,
+      config,
+      mockFetch("anthropic", "This migration adds an email column to users."),
+    );
+
+    expect(result.context.tablesAffected).toContain("users");
+    expect(result.context.riskLevel).toBe("low");
+    expect(result.explanation).toBe(
+      "This migration adds an email column to users.",
+    );
+  });
+
+  test("produces full explain result with Ollama", async () => {
+    const sql = "DROP TABLE old_logs;";
+    const config: ExplainConfig = {
+      provider: "ollama",
+      model: "llama3.2",
+    };
+
+    const result = await explain(
+      sql,
+      config,
+      mockFetch("ollama", "This migration drops the old_logs table."),
+    );
+
+    expect(result.context.riskLevel).toBe("critical");
+    expect(result.explanation).toBe(
+      "This migration drops the old_logs table.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Output formatting
+// ---------------------------------------------------------------------------
+
+describe("formatExplainOutput", () => {
+  test("formats output with all sections", () => {
+    const result: ExplainResult = {
+      context: {
+        tablesAffected: ["users"],
+        operations: [
+          { type: "ALTER TABLE", objectName: "users", subOperations: ["ADD COLUMN"] },
+        ],
+        locks: [
+          { lockType: "AccessExclusiveLock", blocksReads: true, blocksWrites: true },
+        ],
+        riskLevel: "medium",
+        riskFactors: ["Adds column"],
+        sql: "ALTER TABLE users ADD COLUMN email text;",
+      },
+      explanation: "This adds an email column.",
+    };
+
+    const output = formatExplainOutput(result);
+    expect(output).toContain("Migration Explanation");
+    expect(output).toContain("Tables affected: users");
+    expect(output).toContain("Risk level: MEDIUM");
+    expect(output).toContain("Blocking locks: AccessExclusiveLock");
+    expect(output).toContain("This adds an email column.");
+  });
+
+  test("handles no blocking locks", () => {
+    const result: ExplainResult = {
+      context: {
+        tablesAffected: ["users"],
+        operations: [
+          { type: "CREATE TABLE", objectName: "users", subOperations: [] },
+        ],
+        locks: [
+          { lockType: "AccessExclusiveLock", blocksReads: false, blocksWrites: false },
+        ],
+        riskLevel: "low",
+        riskFactors: ["No significant risk factors detected"],
+        sql: "CREATE TABLE users (id serial PRIMARY KEY);",
+      },
+      explanation: "Creates a new table.",
+    };
+
+    const output = formatExplainOutput(result);
+    expect(output).not.toContain("Blocking locks:");
+    expect(output).toContain("Risk level: LOW");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Argument parsing
+// ---------------------------------------------------------------------------
+
+describe("parseExplainArgs", () => {
+  test("parses file target", () => {
+    const opts = parseExplainArgs(["migration.sql"]);
+    expect(opts.target).toBe("migration.sql");
+    expect(opts.provider).toBe("openai"); // default
+  });
+
+  test("parses --provider", () => {
+    const opts = parseExplainArgs(["--provider", "anthropic", "file.sql"]);
+    expect(opts.provider).toBe("anthropic");
+    expect(opts.target).toBe("file.sql");
+  });
+
+  test("parses --model", () => {
+    const opts = parseExplainArgs(["--model", "gpt-3.5-turbo", "file.sql"]);
+    expect(opts.model).toBe("gpt-3.5-turbo");
+  });
+
+  test("parses --api-key", () => {
+    const opts = parseExplainArgs(["--api-key", "sk-test", "file.sql"]);
+    expect(opts.apiKey).toBe("sk-test");
+  });
+
+  test("parses --ollama-url", () => {
+    const opts = parseExplainArgs(["--ollama-url", "http://myhost:11434", "file.sql"]);
+    expect(opts.ollamaBaseUrl).toBe("http://myhost:11434");
+  });
+
+  test("throws on invalid provider", () => {
+    expect(() => parseExplainArgs(["--provider", "invalid"])).toThrow(
+      "Invalid --provider",
+    );
+  });
+
+  test("throws on missing --model value", () => {
+    expect(() => parseExplainArgs(["--model"])).toThrow("--model requires");
+  });
+
+  test("throws on missing --api-key value", () => {
+    expect(() => parseExplainArgs(["--api-key"])).toThrow("--api-key requires");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Default models
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_MODELS", () => {
+  test("has defaults for all providers", () => {
+    expect(DEFAULT_MODELS.openai).toBeDefined();
+    expect(DEFAULT_MODELS.anthropic).toBeDefined();
+    expect(DEFAULT_MODELS.ollama).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Lock info detection
+// ---------------------------------------------------------------------------
+
+describe("lock detection", () => {
+  test("ALTER TABLE gets AccessExclusiveLock", () => {
+    const ctx = buildMigrationContext("ALTER TABLE users ADD COLUMN age int;");
+    expect(ctx.locks[0]!.lockType).toBe("AccessExclusiveLock");
+    expect(ctx.locks[0]!.blocksReads).toBe(true);
+    expect(ctx.locks[0]!.blocksWrites).toBe(true);
+  });
+
+  test("CREATE INDEX CONCURRENTLY gets ShareUpdateExclusiveLock", () => {
+    const ctx = buildMigrationContext(
+      "CREATE INDEX CONCURRENTLY idx ON users (email);",
+    );
+    expect(ctx.locks[0]!.lockType).toBe("ShareUpdateExclusiveLock");
+    expect(ctx.locks[0]!.blocksReads).toBe(false);
+    expect(ctx.locks[0]!.blocksWrites).toBe(false);
+  });
+
+  test("CREATE TABLE does not block reads or writes on existing tables", () => {
+    const ctx = buildMigrationContext("CREATE TABLE new_table (id int);");
+    expect(ctx.locks[0]!.blocksReads).toBe(false);
+    expect(ctx.locks[0]!.blocksWrites).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Risk computation
+// ---------------------------------------------------------------------------
+
+describe("risk computation", () => {
+  test("DROP TABLE is critical", () => {
+    const ctx = buildMigrationContext("DROP TABLE users;");
+    expect(ctx.riskLevel).toBe("critical");
+  });
+
+  test("ALTER COLUMN TYPE is high risk", () => {
+    const ctx = buildMigrationContext(
+      "ALTER TABLE users ALTER COLUMN name TYPE varchar(500);",
+    );
+    expect(ctx.riskLevel).toBe("high");
+  });
+
+  test("CREATE TABLE is low risk", () => {
+    const ctx = buildMigrationContext("CREATE TABLE t (id int);");
+    expect(ctx.riskLevel).toBe("low");
+  });
+
+  test("multiple operations pick the highest risk", () => {
+    const sql = `
+      CREATE TABLE t1 (id int);
+      DROP TABLE t2;
+    `;
+    const ctx = buildMigrationContext(sql);
+    expect(ctx.riskLevel).toBe("critical");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Edge cases
+// ---------------------------------------------------------------------------
+
+describe("edge cases", () => {
+  test("empty SQL returns minimal context", () => {
+    // Empty string won't parse but buildMigrationContext handles gracefully
+    const ctx = buildMigrationContext(
+      "SELECT 1;",
+    );
+    // SELECT is not a DDL, so no operations
+    expect(ctx.operations).toHaveLength(0);
+    expect(ctx.tablesAffected).toHaveLength(0);
+  });
+
+  test("psql metacommands are stripped before parsing", () => {
+    const sql = `\\set ON_ERROR_STOP on
+CREATE TABLE users (id serial PRIMARY KEY);`;
+    const ctx = buildMigrationContext(sql);
+    expect(ctx.operations).toHaveLength(1);
+    expect(ctx.operations[0]!.type).toBe("CREATE TABLE");
+  });
+
+  test("complex migration with multiple DDL types", () => {
+    const sql = `
+      CREATE TABLE orders (id serial PRIMARY KEY);
+      ALTER TABLE orders ADD COLUMN user_id int;
+      CREATE INDEX CONCURRENTLY idx_orders_user ON orders (user_id);
+      CREATE FUNCTION get_order(int) RETURNS orders AS $$ SELECT * FROM orders WHERE id = $1; $$ LANGUAGE sql;
+    `;
+    const ctx = buildMigrationContext(sql);
+    expect(ctx.operations.length).toBeGreaterThanOrEqual(4);
+    expect(ctx.tablesAffected).toContain("orders");
+    // Should have mix of lock types
+    const lockTypes = ctx.locks.map((l) => l.lockType);
+    expect(lockTypes).toContain("AccessExclusiveLock");
+    expect(lockTypes).toContain("ShareUpdateExclusiveLock");
+    expect(lockTypes).toContain("none");
+  });
+
+  test("Ollama uses custom base URL", async () => {
+    let capturedUrl = "";
+    const mockFn = (async (url: string | URL | Request) => {
+      capturedUrl = url as string;
+      return new Response(
+        JSON.stringify({ response: "explanation" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof globalThis.fetch;
+
+    const config: ExplainConfig = {
+      provider: "ollama",
+      model: "llama3.2",
+      ollamaBaseUrl: "http://custom:9999",
+    };
+
+    await callLLM("prompt", config, mockFn);
+    expect(capturedUrl).toContain("custom:9999");
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `sqlever explain <file.sql>` — parses migration SQL via libpg-query, builds structured context (tables affected, DDL types, lock types, estimated risk), and sends to an LLM for plain-English explanation and risk assessment
- Supports three LLM providers: OpenAI (`--provider openai`), Anthropic (`--provider anthropic`), and Ollama (`--provider ollama` for local inference) — all via raw `fetch()` with no SDK dependencies
- Flags: `--provider`, `--model`, `--api-key` (also reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env vars), `--ollama-url`
- Follows DD10 (no hidden network calls): LLM is only contacted when `sqlever explain` is explicitly invoked

## Files

- `src/ai/explain.ts` — core engine: SQL parsing, context extraction, lock/risk mapping, LLM API calls, output formatting
- `src/commands/explain.ts` — CLI command: argument parsing, file reading, wiring to engine
- `src/cli.ts` — wired explain command into dispatch
- `tests/unit/explain.test.ts` — 46 tests with mock LLM responses covering SQL parsing, context generation, prompt building, all 3 providers, argument parsing, lock detection, risk computation, and edge cases

## Test plan

- [x] 46 unit tests passing (exceeds the 10-test minimum from acceptance criteria)
- [x] Tests cover: SQL parsing (9 tests), prompt building (4), LLM provider calls (7), end-to-end with mocks (3), output formatting (2), argument parsing (8), default models (1), lock detection (3), risk computation (4), edge cases (5)
- [x] No new TypeScript type errors introduced
- [x] Existing CLI tests updated and passing

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)