### PR TITLE
F1: PGQ-style 3-partition batch queue with SKIP LOCKED

### DIFF
--- a/src/batch/queue.ts
+++ b/src/batch/queue.ts
@@ -1,0 +1,658 @@
+// src/batch/queue.ts — PGQ-style 3-partition rotating queue for batched DML
+//
+// Implements the batch job queue described in SPEC Section 5.5 and DD9:
+//
+// - **3-partition rotation** solves bloat: completed batches cleaned via
+//   TRUNCATE (instant, zero dead tuples, no VACUUM pressure) rather than
+//   DELETE. Three partitions rotate: active (receiving work), processing
+//   (being consumed), drain (being truncated).
+//
+// - **SKIP LOCKED** solves worker concurrency: multiple batch workers
+//   dequeue from the active partition without blocking each other via
+//   SELECT ... FOR UPDATE SKIP LOCKED.
+//
+// Job lifecycle:
+//   pending -> running -> done
+//                  |
+//                failed -> (retry) -> done
+//                                  -> dead (max retries exceeded)
+//                                       |
+//                                   (manual retry) -> running
+//
+// Heartbeat: heartbeat_at column updated at start of each batch. Stale
+// workers (exceeding staleness threshold) detected and marked failed.
+
+import type { DatabaseClient } from "../db/client";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Job status values matching the lifecycle in SPEC Section 5.5. */
+export type JobStatus = "pending" | "running" | "done" | "failed" | "dead";
+
+/** Which partition a job lives in. */
+export type PartitionId = 0 | 1 | 2;
+
+/** Row shape for sqlever.batch_jobs. */
+export interface BatchJob {
+  id: number;
+  name: string;
+  status: JobStatus;
+  partition_id: PartitionId;
+  table_name: string;
+  batch_size: number;
+  sleep_ms: number;
+  last_pk: string | null;
+  attempt: number;
+  max_retries: number;
+  error_message: string | null;
+  heartbeat_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+/** Options for creating a new batch job. */
+export interface CreateJobOptions {
+  name: string;
+  tableName: string;
+  batchSize?: number;
+  sleepMs?: number;
+  maxRetries?: number;
+}
+
+/** Options for the BatchQueue itself. */
+export interface BatchQueueOptions {
+  /** Schema for the queue tables. Default: "sqlever". */
+  schema?: string;
+  /** Heartbeat staleness threshold in ms. Default: 300000 (5 min). */
+  heartbeatStalenessMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default heartbeat staleness: 5 minutes (SPEC Section 5.5). */
+export const DEFAULT_HEARTBEAT_STALENESS_MS = 300_000;
+
+/** Default batch size. */
+export const DEFAULT_BATCH_SIZE = 1000;
+
+/** Default sleep between batches in ms. */
+export const DEFAULT_SLEEP_MS = 100;
+
+/** Default max retries before a job goes to "dead". */
+export const DEFAULT_MAX_RETRIES = 3;
+
+/** Number of partitions in the rotating queue (PGQ-style). */
+export const PARTITION_COUNT = 3;
+
+/** Valid status transitions. Maps current status -> allowed next statuses. */
+export const VALID_TRANSITIONS: Record<JobStatus, readonly JobStatus[]> = {
+  pending: ["running"],
+  running: ["done", "failed", "dead"],
+  failed: ["running", "dead"],
+  dead: ["running"],
+  done: [],
+} as const;
+
+// ---------------------------------------------------------------------------
+// DDL
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the DDL to create the sqlever.batch_jobs table with
+ * 3 partitions (PGQ-style rotating queue per DD9).
+ *
+ * The parent table is partitioned by LIST on partition_id.
+ * Three child partitions hold values 0, 1, 2.
+ */
+export function generateDDL(schema = "sqlever"): string {
+  const s = quoteIdent(schema);
+
+  return `-- sqlever batch queue: PGQ-style 3-partition rotating table (DD9)
+CREATE SCHEMA IF NOT EXISTS ${s};
+
+CREATE TABLE IF NOT EXISTS ${s}.batch_jobs (
+  id            bigint GENERATED ALWAYS AS IDENTITY,
+  name          text        NOT NULL,
+  status        text        NOT NULL DEFAULT 'pending',
+  partition_id  smallint    NOT NULL,
+  table_name    text        NOT NULL,
+  batch_size    integer     NOT NULL DEFAULT ${DEFAULT_BATCH_SIZE},
+  sleep_ms      integer     NOT NULL DEFAULT ${DEFAULT_SLEEP_MS},
+  last_pk       text,
+  attempt       integer     NOT NULL DEFAULT 0,
+  max_retries   integer     NOT NULL DEFAULT ${DEFAULT_MAX_RETRIES},
+  error_message text,
+  heartbeat_at  timestamptz,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (id, partition_id),
+  CONSTRAINT batch_jobs_status_check
+    CHECK (status IN ('pending', 'running', 'done', 'failed', 'dead')),
+  CONSTRAINT batch_jobs_partition_id_check
+    CHECK (partition_id IN (0, 1, 2))
+) PARTITION BY LIST (partition_id);
+
+CREATE TABLE IF NOT EXISTS ${s}.batch_jobs_p0
+  PARTITION OF ${s}.batch_jobs FOR VALUES IN (0);
+CREATE TABLE IF NOT EXISTS ${s}.batch_jobs_p1
+  PARTITION OF ${s}.batch_jobs FOR VALUES IN (1);
+CREATE TABLE IF NOT EXISTS ${s}.batch_jobs_p2
+  PARTITION OF ${s}.batch_jobs FOR VALUES IN (2);
+
+-- Partial indexes for efficient dequeue (DD9: SKIP LOCKED on active partition)
+CREATE INDEX IF NOT EXISTS batch_jobs_pending_p0
+  ON ${s}.batch_jobs_p0 (id) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS batch_jobs_pending_p1
+  ON ${s}.batch_jobs_p1 (id) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS batch_jobs_pending_p2
+  ON ${s}.batch_jobs_p2 (id) WHERE status = 'pending';
+
+-- Index for heartbeat staleness detection
+CREATE INDEX IF NOT EXISTS batch_jobs_running_p0
+  ON ${s}.batch_jobs_p0 (heartbeat_at) WHERE status = 'running';
+CREATE INDEX IF NOT EXISTS batch_jobs_running_p1
+  ON ${s}.batch_jobs_p1 (heartbeat_at) WHERE status = 'running';
+CREATE INDEX IF NOT EXISTS batch_jobs_running_p2
+  ON ${s}.batch_jobs_p2 (heartbeat_at) WHERE status = 'running';
+
+-- Metadata table tracking which partition is in which role
+CREATE TABLE IF NOT EXISTS ${s}.batch_queue_meta (
+  key   text PRIMARY KEY,
+  value text NOT NULL
+);
+
+-- Initialize partition roles: active=0, processing=1, drain=2
+INSERT INTO ${s}.batch_queue_meta (key, value)
+VALUES ('active_partition', '0')
+ON CONFLICT (key) DO NOTHING;
+`;
+}
+
+// ---------------------------------------------------------------------------
+// BatchQueue class
+// ---------------------------------------------------------------------------
+
+/**
+ * PGQ-style 3-partition rotating queue for batched DML jobs.
+ *
+ * Partition roles rotate:
+ * - **active**: receives new jobs and is the dequeue source
+ * - **processing**: jobs are being worked on (was previously active)
+ * - **drain**: completed jobs awaiting TRUNCATE (was previously processing)
+ *
+ * Rotation: drain -> TRUNCATE -> drain becomes active -> old active
+ * becomes processing -> old processing becomes drain.
+ */
+export class BatchQueue {
+  private db: DatabaseClient;
+  private schema: string;
+  private heartbeatStalenessMs: number;
+
+  constructor(db: DatabaseClient, options: BatchQueueOptions = {}) {
+    this.db = db;
+    this.schema = options.schema ?? "sqlever";
+    this.heartbeatStalenessMs =
+      options.heartbeatStalenessMs ?? DEFAULT_HEARTBEAT_STALENESS_MS;
+  }
+
+  // -----------------------------------------------------------------------
+  // Schema setup
+  // -----------------------------------------------------------------------
+
+  /** Create the queue tables if they don't exist. */
+  async ensureSchema(): Promise<void> {
+    const ddl = generateDDL(this.schema);
+    // Execute each statement separately (pg client doesn't support multi-statement)
+    const statements = splitStatements(ddl);
+    for (const stmt of statements) {
+      await this.db.query(stmt);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Partition management (DD9: 3-partition rotation)
+  // -----------------------------------------------------------------------
+
+  /** Get the current active partition ID. */
+  async getActivePartition(): Promise<PartitionId> {
+    const result = await this.db.query<{ value: string }>(
+      `SELECT value FROM ${this.qualifiedName("batch_queue_meta")}
+       WHERE key = 'active_partition'`,
+    );
+    if (result.rows.length === 0) {
+      throw new Error("batch_queue_meta not initialized");
+    }
+    return Number(result.rows[0]!.value) as PartitionId;
+  }
+
+  /**
+   * Rotate partitions (DD9).
+   *
+   * The rotation cycle:
+   * 1. Identify current roles: active, processing = (active+1)%3, drain = (active+2)%3
+   * 2. TRUNCATE the drain partition (instant cleanup, zero bloat)
+   * 3. Advance: old drain becomes new active, old active becomes processing,
+   *    old processing becomes drain
+   *
+   * Returns the new active partition ID.
+   */
+  async rotatePartitions(): Promise<PartitionId> {
+    const current = await this.getActivePartition();
+    const drain = ((current + 2) % PARTITION_COUNT) as PartitionId;
+    const newActive = drain;
+
+    // TRUNCATE the drain partition — this is the key bloat-avoidance mechanism.
+    // TRUNCATE is instant regardless of row count; no dead tuples, no VACUUM.
+    await this.db.query(
+      `TRUNCATE ${this.qualifiedName(`batch_jobs_p${drain}`)}`,
+    );
+
+    // Update the active partition pointer
+    await this.db.query(
+      `UPDATE ${this.qualifiedName("batch_queue_meta")}
+       SET value = $1
+       WHERE key = 'active_partition'`,
+      [String(newActive)],
+    );
+
+    return newActive;
+  }
+
+  /**
+   * Get the partition table name for a given partition ID.
+   */
+  partitionTable(partitionId: PartitionId): string {
+    return this.qualifiedName(`batch_jobs_p${partitionId}`);
+  }
+
+  // -----------------------------------------------------------------------
+  // Job creation
+  // -----------------------------------------------------------------------
+
+  /**
+   * Enqueue a new batch job into the active partition.
+   */
+  async createJob(options: CreateJobOptions): Promise<BatchJob> {
+    const activePartition = await this.getActivePartition();
+
+    const result = await this.db.query<BatchJob>(
+      `INSERT INTO ${this.qualifiedName("batch_jobs")}
+         (name, table_name, batch_size, sleep_ms, max_retries, partition_id, status)
+       VALUES ($1, $2, $3, $4, $5, $6, 'pending')
+       RETURNING *`,
+      [
+        options.name,
+        options.tableName,
+        options.batchSize ?? DEFAULT_BATCH_SIZE,
+        options.sleepMs ?? DEFAULT_SLEEP_MS,
+        options.maxRetries ?? DEFAULT_MAX_RETRIES,
+        activePartition,
+      ],
+    );
+
+    return result.rows[0]!;
+  }
+
+  // -----------------------------------------------------------------------
+  // Dequeue (DD9: SELECT FOR UPDATE SKIP LOCKED)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Dequeue the next pending job from the active partition.
+   *
+   * Uses SELECT ... FOR UPDATE SKIP LOCKED so multiple workers can
+   * dequeue concurrently without blocking each other (DD9).
+   *
+   * The job is atomically transitioned from pending -> running and
+   * its heartbeat is set.
+   *
+   * Returns null if no pending jobs are available.
+   */
+  async dequeueJob(): Promise<BatchJob | null> {
+    const activePartition = await this.getActivePartition();
+
+    const result = await this.db.query<BatchJob>(
+      `UPDATE ${this.qualifiedName("batch_jobs")}
+       SET status = 'running',
+           attempt = attempt + 1,
+           heartbeat_at = now(),
+           updated_at = now()
+       WHERE id = (
+         SELECT id FROM ${this.qualifiedName("batch_jobs")}
+         WHERE partition_id = $1 AND status = 'pending'
+         ORDER BY id
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+       ) AND partition_id = $1
+       RETURNING *`,
+      [activePartition],
+    );
+
+    return result.rows[0] ?? null;
+  }
+
+  // -----------------------------------------------------------------------
+  // Job lifecycle transitions
+  // -----------------------------------------------------------------------
+
+  /**
+   * Mark a job as done.
+   */
+  async completeJob(
+    jobId: number,
+    partitionId: PartitionId,
+    lastPk?: string,
+  ): Promise<BatchJob> {
+    return this.transitionJob(jobId, partitionId, "done", {
+      lastPk,
+    });
+  }
+
+  /**
+   * Mark a job as failed. If max retries exceeded, marks as dead instead.
+   */
+  async failJob(
+    jobId: number,
+    partitionId: PartitionId,
+    errorMessage: string,
+  ): Promise<BatchJob> {
+    // Check current attempt count vs max_retries
+    const current = await this.getJob(jobId, partitionId);
+    if (!current) {
+      throw new Error(`Job ${jobId} not found in partition ${partitionId}`);
+    }
+
+    if (current.status !== "running") {
+      throw new Error(
+        `Cannot fail job ${jobId}: status is '${current.status}', expected 'running'`,
+      );
+    }
+
+    if (current.attempt >= current.max_retries) {
+      // Max retries exceeded -> dead
+      return this.transitionJob(jobId, partitionId, "dead", {
+        errorMessage,
+      });
+    }
+
+    return this.transitionJob(jobId, partitionId, "failed", {
+      errorMessage,
+    });
+  }
+
+  /**
+   * Retry a failed or dead job. Transitions back to running.
+   */
+  async retryJob(jobId: number, partitionId: PartitionId): Promise<BatchJob> {
+    const current = await this.getJob(jobId, partitionId);
+    if (!current) {
+      throw new Error(`Job ${jobId} not found in partition ${partitionId}`);
+    }
+
+    if (current.status !== "failed" && current.status !== "dead") {
+      throw new Error(
+        `Cannot retry job ${jobId}: status is '${current.status}', expected 'failed' or 'dead'`,
+      );
+    }
+
+    const result = await this.db.query<BatchJob>(
+      `UPDATE ${this.qualifiedName("batch_jobs")}
+       SET status = 'running',
+           attempt = attempt + 1,
+           heartbeat_at = now(),
+           error_message = NULL,
+           updated_at = now()
+       WHERE id = $1 AND partition_id = $2
+       RETURNING *`,
+      [jobId, partitionId],
+    );
+
+    return result.rows[0]!;
+  }
+
+  /**
+   * Update heartbeat for a running job.
+   */
+  async updateHeartbeat(
+    jobId: number,
+    partitionId: PartitionId,
+  ): Promise<void> {
+    const result = await this.db.query(
+      `UPDATE ${this.qualifiedName("batch_jobs")}
+       SET heartbeat_at = now(), updated_at = now()
+       WHERE id = $1 AND partition_id = $2 AND status = 'running'`,
+      [jobId, partitionId],
+    );
+    if (result.rowCount === 0) {
+      throw new Error(
+        `Cannot update heartbeat for job ${jobId}: not found or not running`,
+      );
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Heartbeat staleness detection (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Detect running jobs with stale heartbeats and mark them as failed.
+   *
+   * A job is stale if its heartbeat_at is older than the staleness
+   * threshold (default: 5 minutes). This handles the case where a
+   * batch worker process dies silently (OOM kill, network partition).
+   *
+   * Returns the list of jobs that were marked as failed.
+   */
+  async detectStaleJobs(): Promise<BatchJob[]> {
+    const result = await this.db.query<BatchJob>(
+      `UPDATE ${this.qualifiedName("batch_jobs")}
+       SET status = CASE
+             WHEN attempt >= max_retries THEN 'dead'
+             ELSE 'failed'
+           END,
+           error_message = 'Worker heartbeat stale (exceeded ' ||
+             $1::text || 'ms threshold)',
+           updated_at = now()
+       WHERE status = 'running'
+         AND heartbeat_at < now() - ($1 || ' milliseconds')::interval
+       RETURNING *`,
+      [this.heartbeatStalenessMs],
+    );
+
+    return result.rows;
+  }
+
+  // -----------------------------------------------------------------------
+  // Query helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * Get a job by ID and partition.
+   */
+  async getJob(
+    jobId: number,
+    partitionId: PartitionId,
+  ): Promise<BatchJob | null> {
+    const result = await this.db.query<BatchJob>(
+      `SELECT * FROM ${this.qualifiedName("batch_jobs")}
+       WHERE id = $1 AND partition_id = $2`,
+      [jobId, partitionId],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  /**
+   * List all jobs, optionally filtered by status and/or partition.
+   */
+  async listJobs(filters?: {
+    status?: JobStatus;
+    partitionId?: PartitionId;
+  }): Promise<BatchJob[]> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters?.status) {
+      params.push(filters.status);
+      conditions.push(`status = $${params.length}`);
+    }
+    if (filters?.partitionId !== undefined) {
+      params.push(filters.partitionId);
+      conditions.push(`partition_id = $${params.length}`);
+    }
+
+    const where =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    const result = await this.db.query<BatchJob>(
+      `SELECT * FROM ${this.qualifiedName("batch_jobs")} ${where} ORDER BY id`,
+      params,
+    );
+
+    return result.rows;
+  }
+
+  /**
+   * Count jobs by status in a partition.
+   */
+  async countByStatus(
+    partitionId: PartitionId,
+  ): Promise<Record<JobStatus, number>> {
+    const result = await this.db.query<{ status: JobStatus; count: string }>(
+      `SELECT status, count(*)::text as count
+       FROM ${this.qualifiedName("batch_jobs")}
+       WHERE partition_id = $1
+       GROUP BY status`,
+      [partitionId],
+    );
+
+    const counts: Record<JobStatus, number> = {
+      pending: 0,
+      running: 0,
+      done: 0,
+      failed: 0,
+      dead: 0,
+    };
+
+    for (const row of result.rows) {
+      counts[row.status] = parseInt(row.count, 10);
+    }
+
+    return counts;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * Transition a job to a new status with validation.
+   */
+  private async transitionJob(
+    jobId: number,
+    partitionId: PartitionId,
+    newStatus: JobStatus,
+    options?: { errorMessage?: string; lastPk?: string },
+  ): Promise<BatchJob> {
+    const current = await this.getJob(jobId, partitionId);
+    if (!current) {
+      throw new Error(`Job ${jobId} not found in partition ${partitionId}`);
+    }
+
+    if (!isValidTransition(current.status, newStatus)) {
+      throw new Error(
+        `Invalid status transition: ${current.status} -> ${newStatus}`,
+      );
+    }
+
+    const setClauses = [`status = $3`, `updated_at = now()`];
+    const params: unknown[] = [jobId, partitionId, newStatus];
+
+    if (options?.errorMessage !== undefined) {
+      params.push(options.errorMessage);
+      setClauses.push(`error_message = $${params.length}`);
+    }
+
+    if (options?.lastPk !== undefined) {
+      params.push(options.lastPk);
+      setClauses.push(`last_pk = $${params.length}`);
+    }
+
+    const result = await this.db.query<BatchJob>(
+      `UPDATE ${this.qualifiedName("batch_jobs")}
+       SET ${setClauses.join(", ")}
+       WHERE id = $1 AND partition_id = $2
+       RETURNING *`,
+      params,
+    );
+
+    return result.rows[0]!;
+  }
+
+  /** Build a schema-qualified table name. */
+  private qualifiedName(table: string): string {
+    return `${quoteIdent(this.schema)}.${quoteIdent(table)}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a status transition is valid per the job lifecycle.
+ */
+export function isValidTransition(
+  from: JobStatus,
+  to: JobStatus,
+): boolean {
+  return VALID_TRANSITIONS[from].includes(to);
+}
+
+/**
+ * Simple SQL identifier quoting. Double-quotes the identifier and
+ * escapes any embedded double quotes.
+ */
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Split a DDL string into individual statements.
+ * Handles comments and semicolons correctly.
+ */
+export function splitStatements(ddl: string): string[] {
+  const statements: string[] = [];
+  let current = "";
+
+  for (const line of ddl.split("\n")) {
+    const trimmed = line.trim();
+
+    // Skip pure comment lines and blank lines at statement boundaries
+    if (trimmed.startsWith("--") && current.trim() === "") {
+      continue;
+    }
+
+    current += line + "\n";
+
+    if (trimmed.endsWith(";")) {
+      const stmt = current.trim();
+      if (stmt && !stmt.startsWith("--")) {
+        // Remove trailing semicolons for pg client compatibility
+        statements.push(stmt.replace(/;\s*$/, ""));
+      }
+      current = "";
+    }
+  }
+
+  // Handle any trailing statement without semicolon
+  const remaining = current.trim();
+  if (remaining && !remaining.startsWith("--")) {
+    statements.push(remaining.replace(/;\s*$/, ""));
+  }
+
+  return statements;
+}

--- a/tests/unit/batch-queue.test.ts
+++ b/tests/unit/batch-queue.test.ts
@@ -1,0 +1,1099 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock pg/lib/client — identical pattern to client.test.ts
+// ---------------------------------------------------------------------------
+
+let mockInstances: MockPgClient[] = [];
+
+class MockPgClient {
+  options: Record<string, unknown>;
+  queries: Array<{ text: string; values?: unknown[] }> = [];
+  connected = false;
+  ended = false;
+  queryResults: Record<string, { rows: unknown[]; rowCount: number; command: string }> = {};
+  queryShouldFail: Record<string, Error> = {};
+
+  constructor(options: Record<string, unknown>) {
+    this.options = options;
+    mockInstances.push(this);
+  }
+
+  async connect() {
+    this.connected = true;
+  }
+
+  async query(text: string, values?: unknown[]) {
+    this.queries.push({ text, values });
+    if (this.queryShouldFail[text]) {
+      throw this.queryShouldFail[text];
+    }
+    return (
+      this.queryResults[text] ?? { rows: [], rowCount: 0, command: "SELECT" }
+    );
+  }
+
+  async end() {
+    this.ended = true;
+    this.connected = false;
+  }
+}
+
+mock.module("pg/lib/client", () => ({
+  default: MockPgClient,
+  __esModule: true,
+}));
+
+const { DatabaseClient } = await import("../../src/db/client");
+const {
+  BatchQueue,
+  generateDDL,
+  splitStatements,
+  isValidTransition,
+  VALID_TRANSITIONS,
+  PARTITION_COUNT,
+  DEFAULT_HEARTBEAT_STALENESS_MS,
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_SLEEP_MS,
+  DEFAULT_MAX_RETRIES,
+} = await import("../../src/batch/queue");
+
+import type {
+  BatchJob,
+  JobStatus,
+  PartitionId,
+} from "../../src/batch/queue";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeClient(): Promise<InstanceType<typeof DatabaseClient>> {
+  const client = new DatabaseClient("postgresql://user@localhost/testdb");
+  await client.connect();
+  return client;
+}
+
+function findQuery(pgClient: MockPgClient, pattern: string | RegExp) {
+  return pgClient.queries.find((q) =>
+    typeof pattern === "string"
+      ? q.text.includes(pattern)
+      : pattern.test(q.text),
+  );
+}
+
+function allQueriesMatching(pgClient: MockPgClient, pattern: string | RegExp) {
+  return pgClient.queries.filter((q) =>
+    typeof pattern === "string"
+      ? q.text.includes(pattern)
+      : pattern.test(q.text),
+  );
+}
+
+/** Create a mock job row for test returns. */
+function mockJob(overrides: Partial<BatchJob> = {}): BatchJob {
+  return {
+    id: 1,
+    name: "backfill_tiers",
+    status: "pending",
+    partition_id: 0 as PartitionId,
+    table_name: "users",
+    batch_size: DEFAULT_BATCH_SIZE,
+    sleep_ms: DEFAULT_SLEEP_MS,
+    last_pk: null,
+    attempt: 0,
+    max_retries: DEFAULT_MAX_RETRIES,
+    error_message: null,
+    heartbeat_at: null,
+    created_at: new Date("2025-01-01"),
+    updated_at: new Date("2025-01-01"),
+    ...overrides,
+  };
+}
+
+/**
+ * Set up a MockPgClient so that queries matching a pattern return specific
+ * rows. Uses a simple approach: intercepts the query method.
+ */
+function setupQueryResponses(
+  pgClient: MockPgClient,
+  responses: Array<{ pattern: string | RegExp; rows: unknown[]; rowCount?: number; command?: string }>,
+) {
+  const origQuery = pgClient.query.bind(pgClient);
+  pgClient.query = async (text: string, values?: unknown[]) => {
+    for (const r of responses) {
+      const match =
+        typeof r.pattern === "string"
+          ? text.includes(r.pattern)
+          : r.pattern.test(text);
+      if (match) {
+        pgClient.queries.push({ text, values });
+        return {
+          rows: r.rows,
+          rowCount: r.rowCount ?? r.rows.length,
+          command: r.command ?? "SELECT",
+        };
+      }
+    }
+    return origQuery(text, values);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("batch/queue", () => {
+  beforeEach(() => {
+    mockInstances = [];
+  });
+
+  // -----------------------------------------------------------------------
+  // Constants
+  // -----------------------------------------------------------------------
+
+  describe("constants", () => {
+    it("PARTITION_COUNT is 3 (PGQ-style 3-partition)", () => {
+      expect(PARTITION_COUNT).toBe(3);
+    });
+
+    it("DEFAULT_HEARTBEAT_STALENESS_MS is 5 minutes", () => {
+      expect(DEFAULT_HEARTBEAT_STALENESS_MS).toBe(300_000);
+    });
+
+    it("DEFAULT_MAX_RETRIES is 3", () => {
+      expect(DEFAULT_MAX_RETRIES).toBe(3);
+    });
+
+    it("DEFAULT_BATCH_SIZE is 1000", () => {
+      expect(DEFAULT_BATCH_SIZE).toBe(1000);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DDL generation
+  // -----------------------------------------------------------------------
+
+  describe("generateDDL()", () => {
+    it("creates parent table partitioned by LIST on partition_id", () => {
+      const ddl = generateDDL();
+      expect(ddl).toContain("PARTITION BY LIST (partition_id)");
+    });
+
+    it("creates exactly 3 child partitions (p0, p1, p2)", () => {
+      const ddl = generateDDL();
+      expect(ddl).toContain("batch_jobs_p0");
+      expect(ddl).toContain("FOR VALUES IN (0)");
+      expect(ddl).toContain("batch_jobs_p1");
+      expect(ddl).toContain("FOR VALUES IN (1)");
+      expect(ddl).toContain("batch_jobs_p2");
+      expect(ddl).toContain("FOR VALUES IN (2)");
+    });
+
+    it("includes heartbeat_at column", () => {
+      const ddl = generateDDL();
+      expect(ddl).toContain("heartbeat_at");
+      expect(ddl).toContain("timestamptz");
+    });
+
+    it("includes status CHECK constraint with all lifecycle states", () => {
+      const ddl = generateDDL();
+      expect(ddl).toContain("'pending'");
+      expect(ddl).toContain("'running'");
+      expect(ddl).toContain("'done'");
+      expect(ddl).toContain("'failed'");
+      expect(ddl).toContain("'dead'");
+    });
+
+    it("creates partial indexes for pending status on each partition", () => {
+      const ddl = generateDDL();
+      expect(ddl).toContain("batch_jobs_pending_p0");
+      expect(ddl).toContain("batch_jobs_pending_p1");
+      expect(ddl).toContain("batch_jobs_pending_p2");
+      expect(ddl).toContain("WHERE status = 'pending'");
+    });
+
+    it("creates running indexes for heartbeat staleness detection", () => {
+      const ddl = generateDDL();
+      expect(ddl).toContain("batch_jobs_running_p0");
+      expect(ddl).toContain("batch_jobs_running_p1");
+      expect(ddl).toContain("batch_jobs_running_p2");
+      expect(ddl).toContain("WHERE status = 'running'");
+    });
+
+    it("creates batch_queue_meta table with active_partition", () => {
+      const ddl = generateDDL();
+      expect(ddl).toContain("batch_queue_meta");
+      expect(ddl).toContain("active_partition");
+    });
+
+    it("uses custom schema when provided", () => {
+      const ddl = generateDDL("custom_schema");
+      expect(ddl).toContain('"custom_schema"');
+      expect(ddl).not.toContain('"sqlever"');
+    });
+
+    it("includes max_retries and attempt columns", () => {
+      const ddl = generateDDL();
+      expect(ddl).toContain("max_retries");
+      expect(ddl).toContain("attempt");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // splitStatements()
+  // -----------------------------------------------------------------------
+
+  describe("splitStatements()", () => {
+    it("splits DDL into executable statements", () => {
+      const ddl = generateDDL();
+      const stmts = splitStatements(ddl);
+      // Should have: CREATE SCHEMA, CREATE TABLE parent, 3 partitions,
+      // 6 indexes, CREATE meta table, INSERT meta
+      expect(stmts.length).toBeGreaterThanOrEqual(10);
+    });
+
+    it("strips trailing semicolons", () => {
+      const stmts = splitStatements("SELECT 1;\nSELECT 2;");
+      for (const s of stmts) {
+        expect(s.endsWith(";")).toBe(false);
+      }
+    });
+
+    it("skips pure comment lines", () => {
+      const stmts = splitStatements("-- comment\nSELECT 1;");
+      expect(stmts.length).toBe(1);
+      expect(stmts[0]).toContain("SELECT 1");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // isValidTransition()
+  // -----------------------------------------------------------------------
+
+  describe("isValidTransition()", () => {
+    it("allows pending -> running", () => {
+      expect(isValidTransition("pending", "running")).toBe(true);
+    });
+
+    it("allows running -> done", () => {
+      expect(isValidTransition("running", "done")).toBe(true);
+    });
+
+    it("allows running -> failed", () => {
+      expect(isValidTransition("running", "failed")).toBe(true);
+    });
+
+    it("allows failed -> running (retry)", () => {
+      expect(isValidTransition("failed", "running")).toBe(true);
+    });
+
+    it("allows failed -> dead (max retries exceeded)", () => {
+      expect(isValidTransition("failed", "dead")).toBe(true);
+    });
+
+    it("allows dead -> running (manual retry)", () => {
+      expect(isValidTransition("dead", "running")).toBe(true);
+    });
+
+    it("disallows done -> any transition", () => {
+      expect(isValidTransition("done", "pending")).toBe(false);
+      expect(isValidTransition("done", "running")).toBe(false);
+      expect(isValidTransition("done", "failed")).toBe(false);
+    });
+
+    it("disallows pending -> done (must go through running)", () => {
+      expect(isValidTransition("pending", "done")).toBe(false);
+    });
+
+    it("disallows pending -> failed", () => {
+      expect(isValidTransition("pending", "failed")).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // VALID_TRANSITIONS map
+  // -----------------------------------------------------------------------
+
+  describe("VALID_TRANSITIONS", () => {
+    it("covers all 5 status values", () => {
+      const statuses: JobStatus[] = ["pending", "running", "done", "failed", "dead"];
+      for (const s of statuses) {
+        expect(VALID_TRANSITIONS[s]).toBeDefined();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — getActivePartition
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.getActivePartition()", () => {
+    it("returns the active partition from metadata", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "batch_queue_meta",
+          rows: [{ value: "1" }],
+        },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const active = await queue.getActivePartition();
+      expect(active).toBe(1);
+    });
+
+    it("throws if metadata is not initialized", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await expect(queue.getActivePartition()).rejects.toThrow(
+        "batch_queue_meta not initialized",
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — createJob
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.createJob()", () => {
+    it("inserts into the active partition with correct defaults", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const createdJob = mockJob({ id: 42, partition_id: 0 as PartitionId });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "INSERT INTO", rows: [createdJob], command: "INSERT" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const job = await queue.createJob({
+        name: "backfill_tiers",
+        tableName: "users",
+      });
+
+      expect(job.id).toBe(42);
+      expect(job.name).toBe("backfill_tiers");
+
+      // Verify the INSERT query included partition_id
+      const insertQ = findQuery(pgClient, "INSERT INTO");
+      expect(insertQ).toBeDefined();
+      expect(insertQ!.values).toContain(0); // active partition
+    });
+
+    it("uses custom batch options when provided", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const createdJob = mockJob({
+        batch_size: 500,
+        sleep_ms: 200,
+        max_retries: 5,
+      });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "INSERT INTO", rows: [createdJob], command: "INSERT" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.createJob({
+        name: "backfill",
+        tableName: "orders",
+        batchSize: 500,
+        sleepMs: 200,
+        maxRetries: 5,
+      });
+
+      const insertQ = findQuery(pgClient, "INSERT INTO");
+      expect(insertQ!.values).toContain(500);
+      expect(insertQ!.values).toContain(200);
+      expect(insertQ!.values).toContain(5);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — dequeueJob (SKIP LOCKED)
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.dequeueJob()", () => {
+    it("uses FOR UPDATE SKIP LOCKED in the dequeue query", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const runningJob = mockJob({ status: "running", attempt: 1 });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [runningJob] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const job = await queue.dequeueJob();
+
+      expect(job).not.toBeNull();
+      expect(job!.status).toBe("running");
+
+      // Verify SKIP LOCKED was used
+      const dequeueQ = findQuery(pgClient, "FOR UPDATE SKIP LOCKED");
+      expect(dequeueQ).toBeDefined();
+    });
+
+    it("returns null when no pending jobs available", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const job = await queue.dequeueJob();
+
+      expect(job).toBeNull();
+    });
+
+    it("sets heartbeat_at and increments attempt on dequeue", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [mockJob()] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.dequeueJob();
+
+      const dequeueQ = findQuery(pgClient, "FOR UPDATE SKIP LOCKED");
+      expect(dequeueQ!.text).toContain("heartbeat_at = now()");
+      expect(dequeueQ!.text).toContain("attempt = attempt + 1");
+    });
+
+    it("transitions job from pending to running", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [mockJob()] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.dequeueJob();
+
+      const dequeueQ = findQuery(pgClient, "FOR UPDATE SKIP LOCKED");
+      expect(dequeueQ!.text).toContain("status = 'running'");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — rotatePartitions (DD9: TRUNCATE vs DELETE)
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.rotatePartitions()", () => {
+    it("TRUNCATEs the drain partition (not DELETE — zero bloat)", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      // Active = 0, processing = 1, drain = 2
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "TRUNCATE", rows: [], command: "TRUNCATE" },
+        { pattern: "UPDATE", rows: [], rowCount: 1, command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const newActive = await queue.rotatePartitions();
+
+      // The drain partition (2) should have been truncated
+      const truncQ = findQuery(pgClient, "TRUNCATE");
+      expect(truncQ).toBeDefined();
+      expect(truncQ!.text).toContain("batch_jobs_p2");
+
+      // New active should be the old drain (2)
+      expect(newActive).toBe(2);
+    });
+
+    it("updates the active_partition metadata after rotation", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "1" }] },
+        { pattern: "TRUNCATE", rows: [], command: "TRUNCATE" },
+        { pattern: "UPDATE", rows: [], rowCount: 1, command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.rotatePartitions();
+
+      // Active was 1, drain = (1+2)%3 = 0, new active = 0
+      const updateQ = allQueriesMatching(pgClient, "UPDATE");
+      const metaUpdate = updateQ.find((q) =>
+        q.text.includes("batch_queue_meta"),
+      );
+      expect(metaUpdate).toBeDefined();
+      expect(metaUpdate!.values).toContain("0"); // new active partition
+    });
+
+    it("rotates correctly through full cycle (0 -> 2 -> 1 -> 0)", async () => {
+      // This tests the rotation math: drain = (active + 2) % 3
+      // active=0 -> drain=2, new_active=2
+      // active=2 -> drain=1, new_active=1
+      // active=1 -> drain=0, new_active=0
+
+      const activeSequence: [PartitionId, PartitionId, PartitionId] = [0, 2, 1];
+      const drainPartitions: [PartitionId, PartitionId, PartitionId] = [2, 1, 0];
+      const newActives: [PartitionId, PartitionId, PartitionId] = [2, 1, 0];
+
+      for (let i = 0; i < 3; i++) {
+        const client = await makeClient();
+        const pgClient = mockInstances[mockInstances.length - 1]!;
+
+        setupQueryResponses(pgClient, [
+          {
+            pattern: "batch_queue_meta",
+            rows: [{ value: String(activeSequence[i]!) }],
+          },
+          { pattern: "TRUNCATE", rows: [], command: "TRUNCATE" },
+          { pattern: "UPDATE", rows: [], rowCount: 1, command: "UPDATE" },
+        ]);
+
+        const queue = new BatchQueue(client);
+        const newActive = await queue.rotatePartitions();
+
+        expect(newActive).toBe(newActives[i]!);
+
+        const truncQ = findQuery(pgClient, "TRUNCATE");
+        expect(truncQ!.text).toContain(`batch_jobs_p${drainPartitions[i]!}`);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — completeJob
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.completeJob()", () => {
+    it("transitions running -> done", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const runningJob = mockJob({ status: "running" });
+      const doneJob = mockJob({ status: "done" });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [runningJob] },
+        { pattern: "UPDATE", rows: [doneJob], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const result = await queue.completeJob(1, 0 as PartitionId);
+      expect(result.status).toBe("done");
+    });
+
+    it("stores last_pk when provided", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const runningJob = mockJob({ status: "running" });
+      const doneJob = mockJob({ status: "done", last_pk: "12345" });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [runningJob] },
+        { pattern: "UPDATE", rows: [doneJob], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.completeJob(1, 0 as PartitionId, "12345");
+
+      const updateQ = allQueriesMatching(pgClient, "UPDATE");
+      const jobUpdate = updateQ.find((q) => q.text.includes("last_pk"));
+      expect(jobUpdate).toBeDefined();
+      expect(jobUpdate!.values).toContain("12345");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — failJob
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.failJob()", () => {
+    it("transitions running -> failed when retries remain", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const runningJob = mockJob({ status: "running", attempt: 1, max_retries: 3 });
+      const failedJob = mockJob({ status: "failed", error_message: "timeout" });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [runningJob] },
+        { pattern: "UPDATE", rows: [failedJob], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const result = await queue.failJob(1, 0 as PartitionId, "timeout");
+      expect(result.status).toBe("failed");
+    });
+
+    it("transitions running -> dead when max retries exceeded", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      // attempt >= max_retries -> dead
+      const runningJob = mockJob({ status: "running", attempt: 3, max_retries: 3 });
+      const deadJob = mockJob({ status: "dead", error_message: "timeout" });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [runningJob] },
+        { pattern: "UPDATE", rows: [deadJob], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const result = await queue.failJob(1, 0 as PartitionId, "timeout");
+      expect(result.status).toBe("dead");
+    });
+
+    it("rejects if job is not in running status", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const pendingJob = mockJob({ status: "pending" });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [pendingJob] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await expect(
+        queue.failJob(1, 0 as PartitionId, "error"),
+      ).rejects.toThrow("Cannot fail job 1: status is 'pending'");
+    });
+
+    it("stores error message", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const runningJob = mockJob({ status: "running", attempt: 1 });
+      const failedJob = mockJob({ status: "failed", error_message: "OOM killed" });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [runningJob] },
+        { pattern: "UPDATE", rows: [failedJob], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.failJob(1, 0 as PartitionId, "OOM killed");
+
+      const updateQ = allQueriesMatching(pgClient, "UPDATE");
+      const jobUpdate = updateQ.find((q) => q.text.includes("error_message"));
+      expect(jobUpdate).toBeDefined();
+      expect(jobUpdate!.values).toContain("OOM killed");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — retryJob
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.retryJob()", () => {
+    it("transitions failed -> running", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const failedJob = mockJob({ status: "failed" });
+      const runningJob = mockJob({ status: "running", attempt: 2 });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [failedJob] },
+        { pattern: "UPDATE", rows: [runningJob], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const result = await queue.retryJob(1, 0 as PartitionId);
+      expect(result.status).toBe("running");
+    });
+
+    it("transitions dead -> running (manual retry)", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const deadJob = mockJob({ status: "dead" });
+      const runningJob = mockJob({ status: "running", attempt: 4 });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [deadJob] },
+        { pattern: "UPDATE", rows: [runningJob], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const result = await queue.retryJob(1, 0 as PartitionId);
+      expect(result.status).toBe("running");
+    });
+
+    it("clears error_message on retry", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const failedJob = mockJob({ status: "failed", error_message: "old error" });
+      const runningJob = mockJob({ status: "running", error_message: null });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [failedJob] },
+        { pattern: "UPDATE", rows: [runningJob], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.retryJob(1, 0 as PartitionId);
+
+      const updateQ = findQuery(pgClient, "UPDATE");
+      expect(updateQ!.text).toContain("error_message = NULL");
+    });
+
+    it("rejects retry of a pending job", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const pendingJob = mockJob({ status: "pending" });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [pendingJob] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await expect(
+        queue.retryJob(1, 0 as PartitionId),
+      ).rejects.toThrow("Cannot retry job 1: status is 'pending'");
+    });
+
+    it("rejects retry of a done job", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const doneJob = mockJob({ status: "done" });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [doneJob] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await expect(
+        queue.retryJob(1, 0 as PartitionId),
+      ).rejects.toThrow("Cannot retry job 1: status is 'done'");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — updateHeartbeat
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.updateHeartbeat()", () => {
+    it("updates heartbeat_at for a running job", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "heartbeat_at = now()",
+          rows: [],
+          rowCount: 1,
+          command: "UPDATE",
+        },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.updateHeartbeat(1, 0 as PartitionId);
+
+      const hbQ = findQuery(pgClient, "heartbeat_at = now()");
+      expect(hbQ).toBeDefined();
+      expect(hbQ!.text).toContain("status = 'running'");
+    });
+
+    it("throws when job not found or not running", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "heartbeat_at = now()",
+          rows: [],
+          rowCount: 0,
+          command: "UPDATE",
+        },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await expect(
+        queue.updateHeartbeat(999, 0 as PartitionId),
+      ).rejects.toThrow("Cannot update heartbeat for job 999");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — detectStaleJobs (heartbeat staleness)
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.detectStaleJobs()", () => {
+    it("marks stale running jobs as failed", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const staleJob = mockJob({
+        status: "failed",
+        error_message: "Worker heartbeat stale",
+      });
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "heartbeat_at <",
+          rows: [staleJob],
+          command: "UPDATE",
+        },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const staleJobs = await queue.detectStaleJobs();
+
+      expect(staleJobs).toHaveLength(1);
+
+      const detectQ = findQuery(pgClient, "heartbeat_at <");
+      expect(detectQ).toBeDefined();
+      expect(detectQ!.text).toContain("status = 'running'");
+      expect(detectQ!.values).toContain(DEFAULT_HEARTBEAT_STALENESS_MS);
+    });
+
+    it("uses custom staleness threshold", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "heartbeat_at <", rows: [], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client, {
+        heartbeatStalenessMs: 60_000,
+      });
+      await queue.detectStaleJobs();
+
+      const detectQ = findQuery(pgClient, "heartbeat_at <");
+      expect(detectQ!.values).toContain(60_000);
+    });
+
+    it("returns empty array when no stale jobs", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "heartbeat_at <", rows: [], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const staleJobs = await queue.detectStaleJobs();
+
+      expect(staleJobs).toHaveLength(0);
+    });
+
+    it("marks jobs as dead when attempt >= max_retries", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "heartbeat_at <", rows: [], command: "UPDATE" },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.detectStaleJobs();
+
+      // Verify the SQL contains the CASE for dead vs failed
+      const detectQ = findQuery(pgClient, "heartbeat_at <");
+      expect(detectQ!.text).toContain("WHEN attempt >= max_retries THEN 'dead'");
+      expect(detectQ!.text).toContain("ELSE 'failed'");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — listJobs / countByStatus
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.listJobs()", () => {
+    it("lists all jobs without filters", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const jobs = [mockJob({ id: 1 }), mockJob({ id: 2 })];
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: jobs },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const result = await queue.listJobs();
+      expect(result).toHaveLength(2);
+    });
+
+    it("filters by status", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "status = $", rows: [mockJob({ status: "pending" })] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.listJobs({ status: "pending" });
+
+      const listQ = findQuery(pgClient, "status = $");
+      expect(listQ!.values).toContain("pending");
+    });
+
+    it("filters by partition", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "partition_id = $", rows: [] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await queue.listJobs({ partitionId: 1 as PartitionId });
+
+      const listQ = findQuery(pgClient, "partition_id = $");
+      expect(listQ!.values).toContain(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — custom schema
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue with custom schema", () => {
+    it("uses custom schema in all queries", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "my_schema", rows: [{ value: "0" }] },
+      ]);
+
+      const queue = new BatchQueue(client, { schema: "my_schema" });
+      await queue.getActivePartition();
+
+      const q = findQuery(pgClient, "my_schema");
+      expect(q).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — ensureSchema
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.ensureSchema()", () => {
+    it("executes all DDL statements", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const queue = new BatchQueue(client);
+      await queue.ensureSchema();
+
+      // Should have executed multiple CREATE statements.
+      // Filter out session-setup queries (SET commands from connect())
+      const ddlQueries = pgClient.queries.filter(
+        (q) =>
+          q.text.includes("CREATE") ||
+          q.text.includes("INSERT INTO") ||
+          q.text.includes("PARTITION"),
+      );
+      expect(ddlQueries.length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — getJob
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.getJob()", () => {
+    it("returns job when found", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const job = mockJob({ id: 42 });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [job] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const result = await queue.getJob(42, 0 as PartitionId);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(42);
+    });
+
+    it("returns null when job not found", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      const result = await queue.getJob(999, 0 as PartitionId);
+      expect(result).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — invalid transitions
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue transition validation", () => {
+    it("rejects completing a pending job (must go through running first)", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const pendingJob = mockJob({ status: "pending" });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "SELECT *", rows: [pendingJob] },
+      ]);
+
+      const queue = new BatchQueue(client);
+      await expect(
+        queue.completeJob(1, 0 as PartitionId),
+      ).rejects.toThrow("Invalid status transition: pending -> done");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // BatchQueue — partitionTable helper
+  // -----------------------------------------------------------------------
+
+  describe("BatchQueue.partitionTable()", () => {
+    it("returns qualified partition table name", async () => {
+      const client = await makeClient();
+      const queue = new BatchQueue(client);
+
+      expect(queue.partitionTable(0 as PartitionId)).toBe(
+        '"sqlever"."batch_jobs_p0"',
+      );
+      expect(queue.partitionTable(1 as PartitionId)).toBe(
+        '"sqlever"."batch_jobs_p1"',
+      );
+      expect(queue.partitionTable(2 as PartitionId)).toBe(
+        '"sqlever"."batch_jobs_p2"',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements #102 — PGQ-style 3-partition rotating queue for batched background DML (SPEC DD9 + Section 5.5).

- **3-partition rotation** (DD9): Three partitions rotate (active/processing/drain). Completed batches cleaned via `TRUNCATE` — instant, zero bloat, no VACUUM pressure. Solves the dead-tuple accumulation problem that `DELETE` would cause.
- **SKIP LOCKED dequeue** (DD9): `SELECT ... FOR UPDATE SKIP LOCKED` lets multiple batch workers dequeue concurrently without blocking each other. Complementary to partition rotation (rotation = cleanup, SKIP LOCKED = concurrency).
- **Job lifecycle**: `pending -> running -> done | failed -> dead` with retry support. Dead jobs can be manually retried after operator fixes the underlying issue.
- **Heartbeat staleness detection**: `heartbeat_at` column with configurable threshold (default 5 min). Detects silently dead workers (OOM kill, network partition) and marks their jobs as failed.
- **DDL generation**: `sqlever.batch_jobs` partitioned table with 3 child partitions, partial indexes for pending/running status, and `batch_queue_meta` for partition role tracking.

## Files

- `src/batch/queue.ts` — `BatchQueue` class, DDL generation, job lifecycle, partition rotation
- `tests/unit/batch-queue.test.ts` — 63 tests covering all acceptance criteria

## Test plan

- [x] Partition rotation: TRUNCATE drain partition, rotate roles correctly through full cycle (0->2->1->0)
- [x] SKIP LOCKED dequeue: query uses `FOR UPDATE SKIP LOCKED`, returns null when empty, sets heartbeat
- [x] Job lifecycle: all valid transitions (pending->running, running->done, running->failed, failed->running, failed->dead, dead->running), invalid transitions rejected
- [x] Heartbeat staleness: detects stale jobs, marks as failed/dead based on retry count, custom threshold
- [x] DDL: 3 partitions, partial indexes, CHECK constraints, metadata table
- [x] 63 tests total (requirement: >= 20)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)