### PR TITLE
feat: sqlever review — structured PR comment generator

### DIFF
--- a/src/ai/review.ts
+++ b/src/ai/review.ts
@@ -1,0 +1,394 @@
+// src/ai/review.ts — AI-powered migration review engine
+//
+// Combines static analysis findings (from Analyzer) with LLM explanation
+// to produce a structured risk report suitable for posting as a PR comment.
+//
+// Implements SPEC Section 5.7 — `sqlever review`.
+
+import type { Finding, Severity } from "../analysis/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Risk level for the overall migration review. */
+export type RiskLevel = "high" | "medium" | "low";
+
+/** A single entry in the findings table. */
+export interface FindingEntry {
+  ruleId: string;
+  severity: Severity;
+  message: string;
+  file: string;
+  line: number;
+  suggestion?: string;
+}
+
+/** LLM-generated explanation of what the migration does. */
+export interface LLMExplanation {
+  /** Plain-English summary of the migration. */
+  summary: string;
+  /** Suggested improvements from the LLM. */
+  suggestedImprovements: string[];
+}
+
+/** Interface for LLM providers — allows mocking in tests. */
+export interface LLMProvider {
+  /**
+   * Generate an explanation for the given SQL migration(s).
+   *
+   * @param sql - The SQL text of the migration(s)
+   * @param findings - Static analysis findings for context
+   * @returns LLM-generated explanation
+   */
+  explain(sql: string, findings: FindingEntry[]): Promise<LLMExplanation>;
+}
+
+/** Result of the review process. */
+export interface ReviewResult {
+  /** Overall risk level. */
+  risk: RiskLevel;
+  /** Static analysis findings. */
+  findings: FindingEntry[];
+  /** LLM-generated explanation (present when LLM provider is available). */
+  explanation?: LLMExplanation;
+  /** Files that were reviewed. */
+  filesReviewed: string[];
+  /** Total count of errors. */
+  errorCount: number;
+  /** Total count of warnings. */
+  warnCount: number;
+  /** Total count of info findings. */
+  infoCount: number;
+}
+
+/** Options for the review engine. */
+export interface ReviewOptions {
+  /** Output format. */
+  format: "markdown" | "text" | "json";
+  /** Optional LLM provider for explanations. */
+  llm?: LLMProvider;
+  /** SQL content of the files being reviewed (keyed by file path). */
+  sqlContents?: Map<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Risk assessment
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the overall risk level based on findings.
+ *
+ * - high: any error-level findings
+ * - medium: any warn-level findings but no errors
+ * - low: only info-level findings or no findings
+ */
+export function assessRisk(findings: FindingEntry[]): RiskLevel {
+  let hasError = false;
+  let hasWarn = false;
+
+  for (const f of findings) {
+    if (f.severity === "error") hasError = true;
+    if (f.severity === "warn") hasWarn = true;
+  }
+
+  if (hasError) return "high";
+  if (hasWarn) return "medium";
+  return "low";
+}
+
+// ---------------------------------------------------------------------------
+// Convert analysis findings to review entries
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert raw analysis findings to structured review entries.
+ */
+export function toFindingEntries(findings: readonly Finding[]): FindingEntry[] {
+  return findings.map((f) => ({
+    ruleId: f.ruleId,
+    severity: f.severity,
+    message: f.message,
+    file: f.location.file,
+    line: f.location.line,
+    suggestion: f.suggestion,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Count helpers
+// ---------------------------------------------------------------------------
+
+function countBySeverity(
+  entries: FindingEntry[],
+  severity: Severity,
+): number {
+  return entries.filter((e) => e.severity === severity).length;
+}
+
+// ---------------------------------------------------------------------------
+// Review engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a review: combine static analysis findings with optional LLM explanation.
+ *
+ * @param analysisFindings - Findings from the Analyzer
+ * @param filesReviewed - List of files that were analyzed
+ * @param options - Review options (format, LLM provider, SQL contents)
+ * @returns ReviewResult
+ */
+export async function runReview(
+  analysisFindings: readonly Finding[],
+  filesReviewed: string[],
+  options: ReviewOptions,
+): Promise<ReviewResult> {
+  const entries = toFindingEntries(analysisFindings);
+  const risk = assessRisk(entries);
+
+  let explanation: LLMExplanation | undefined;
+
+  if (options.llm && options.sqlContents && options.sqlContents.size > 0) {
+    // Concatenate all SQL for LLM context
+    const allSql = Array.from(options.sqlContents.entries())
+      .map(([path, sql]) => `-- File: ${path}\n${sql}`)
+      .join("\n\n");
+
+    try {
+      explanation = await options.llm.explain(allSql, entries);
+    } catch {
+      // LLM failure is non-fatal — review still works without explanation
+    }
+  }
+
+  return {
+    risk,
+    findings: entries,
+    explanation,
+    filesReviewed,
+    errorCount: countBySeverity(entries, "error"),
+    warnCount: countBySeverity(entries, "warn"),
+    infoCount: countBySeverity(entries, "info"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown formatter
+// ---------------------------------------------------------------------------
+
+const RISK_EMOJI: Record<RiskLevel, string> = {
+  high: "\u{1F534}",   // red circle
+  medium: "\u{1F7E1}", // yellow circle
+  low: "\u{1F7E2}",    // green circle
+};
+
+/**
+ * Format a review result as Markdown suitable for a PR comment.
+ */
+export function formatReviewMarkdown(result: ReviewResult): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push("## sqlever review");
+  lines.push("");
+
+  // Risk summary
+  const emoji = RISK_EMOJI[result.risk];
+  const riskLabel = result.risk.toUpperCase();
+  lines.push(`**Risk: ${emoji} ${riskLabel}**`);
+  lines.push("");
+
+  // Counts
+  const counts: string[] = [];
+  if (result.errorCount > 0) {
+    counts.push(
+      `${result.errorCount} error${result.errorCount !== 1 ? "s" : ""}`,
+    );
+  }
+  if (result.warnCount > 0) {
+    counts.push(
+      `${result.warnCount} warning${result.warnCount !== 1 ? "s" : ""}`,
+    );
+  }
+  if (result.infoCount > 0) {
+    counts.push(
+      `${result.infoCount} info`,
+    );
+  }
+  if (counts.length > 0) {
+    lines.push(`${counts.join(", ")} across ${result.filesReviewed.length} file${result.filesReviewed.length !== 1 ? "s" : ""}`);
+  } else {
+    lines.push(`No issues found across ${result.filesReviewed.length} file${result.filesReviewed.length !== 1 ? "s" : ""}`);
+  }
+  lines.push("");
+
+  // Findings table
+  if (result.findings.length > 0) {
+    lines.push("### Analysis findings");
+    lines.push("");
+    lines.push("| Severity | Rule | Message | File | Line |");
+    lines.push("|----------|------|---------|------|------|");
+
+    for (const f of result.findings) {
+      const sevIcon = severityIcon(f.severity);
+      const escapedMsg = escapeMarkdown(f.message);
+      const shortFile = shortenPath(f.file);
+      lines.push(
+        `| ${sevIcon} ${f.severity} | ${f.ruleId} | ${escapedMsg} | ${shortFile} | ${f.line} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  // Suggestions from static analysis
+  const suggestions = result.findings.filter((f) => f.suggestion);
+  if (suggestions.length > 0) {
+    lines.push("### Suggested improvements");
+    lines.push("");
+    for (const f of suggestions) {
+      lines.push(`- **${f.ruleId}**: ${f.suggestion}`);
+    }
+    lines.push("");
+  }
+
+  // LLM explanation
+  if (result.explanation) {
+    lines.push("### What this migration does");
+    lines.push("");
+    lines.push(result.explanation.summary);
+    lines.push("");
+
+    if (result.explanation.suggestedImprovements.length > 0) {
+      lines.push("### AI-suggested improvements");
+      lines.push("");
+      for (const improvement of result.explanation.suggestedImprovements) {
+        lines.push(`- ${improvement}`);
+      }
+      lines.push("");
+    }
+  }
+
+  // Footer
+  lines.push("---");
+  lines.push("*Generated by sqlever review*");
+
+  return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Text formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a review result as plain text.
+ */
+export function formatReviewText(result: ReviewResult): string {
+  const lines: string[] = [];
+
+  lines.push(`Risk: ${result.risk.toUpperCase()}`);
+  lines.push("");
+
+  // Counts
+  const counts: string[] = [];
+  if (result.errorCount > 0) counts.push(`${result.errorCount} error(s)`);
+  if (result.warnCount > 0) counts.push(`${result.warnCount} warning(s)`);
+  if (result.infoCount > 0) counts.push(`${result.infoCount} info`);
+  if (counts.length > 0) {
+    lines.push(`${counts.join(", ")} across ${result.filesReviewed.length} file(s)`);
+  } else {
+    lines.push(`No issues found across ${result.filesReviewed.length} file(s)`);
+  }
+  lines.push("");
+
+  // Findings
+  if (result.findings.length > 0) {
+    lines.push("Findings:");
+    for (const f of result.findings) {
+      lines.push(`  ${f.severity} ${f.ruleId}: ${f.message}`);
+      lines.push(`    at ${f.file}:${f.line}`);
+      if (f.suggestion) {
+        lines.push(`    suggestion: ${f.suggestion}`);
+      }
+    }
+    lines.push("");
+  }
+
+  // LLM explanation
+  if (result.explanation) {
+    lines.push("Explanation:");
+    lines.push(`  ${result.explanation.summary}`);
+    if (result.explanation.suggestedImprovements.length > 0) {
+      lines.push("");
+      lines.push("AI-suggested improvements:");
+      for (const s of result.explanation.suggestedImprovements) {
+        lines.push(`  - ${s}`);
+      }
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// JSON formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a review result as JSON.
+ */
+export function formatReviewJson(result: ReviewResult): string {
+  return JSON.stringify(result, null, 2) + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Unified format dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a review result using the specified format.
+ */
+export function formatReview(
+  result: ReviewResult,
+  format: "markdown" | "text" | "json",
+): string {
+  switch (format) {
+    case "markdown":
+      return formatReviewMarkdown(result);
+    case "text":
+      return formatReviewText(result);
+    case "json":
+      return formatReviewJson(result);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function severityIcon(severity: Severity): string {
+  switch (severity) {
+    case "error":
+      return "\u{274C}";  // red cross
+    case "warn":
+      return "\u{26A0}\u{FE0F}";  // warning sign
+    case "info":
+      return "\u{2139}\u{FE0F}";  // info icon
+  }
+}
+
+/**
+ * Escape pipe characters in Markdown table cells.
+ */
+function escapeMarkdown(text: string): string {
+  return text.replace(/\|/g, "\\|");
+}
+
+/**
+ * Shorten a file path for display by taking only the last 2 segments.
+ */
+export function shortenPath(filePath: string): string {
+  const parts = filePath.split("/");
+  if (parts.length <= 2) return filePath;
+  return parts.slice(-2).join("/");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { parseAnalyzeArgs, runAnalyze } from "./commands/analyze";
 import { parseExplainArgs, runExplain } from "./commands/explain";
 import { runDoctor } from "./commands/doctor";
 import { runDiff } from "./commands/diff";
+import { parseReviewArgs, runReviewCommand } from "./commands/review";
 
 // ---------------------------------------------------------------------------
 // Command registry — all commands from SPEC R1 plus sqlever extensions
@@ -445,6 +446,16 @@ export function main(argv: string[] = process.argv.slice(2)): void {
       process.stderr.write(`sqlever diff: ${msg}\n`);
       process.exit(1);
     });
+    return;
+  }
+
+  if (args.command === "review") {
+    const reviewOpts = parseReviewArgs(args.rest);
+    if (args.topDir !== undefined) reviewOpts.topDir = args.topDir;
+    if (args.planFile !== undefined) reviewOpts.planFile = args.planFile;
+    runReviewCommand(reviewOpts)
+      .then((result) => { if (result.exitCode !== 0) process.exit(result.exitCode); })
+      .catch((err: unknown) => { process.stderr.write(`sqlever review: ${err instanceof Error ? err.message : String(err)}\n`); process.exit(1); });
     return;
   }
 

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,0 +1,342 @@
+// src/commands/review.ts — sqlever review command
+//
+// Structured risk report suitable for posting as a PR comment (Markdown output).
+// Designed to be called by AI coding agents reviewing PRs.
+//
+// Usage:
+//   sqlever review file.sql              — review a single migration
+//   sqlever review dir/                  — review all .sql files in a directory
+//   sqlever review                       — review pending migrations from sqitch.plan
+//   sqlever review --all                 — review all migrations from sqitch.plan
+//   sqlever review --changed             — review files changed in git diff
+//
+// Options:
+//   --format markdown|text|json          — output format (default: markdown)
+//
+// The markdown output is ready to pipe to `gh pr comment`:
+//   sqlever review --format markdown | gh pr comment --body-file -
+//
+// Implements SPEC Section 5.7 (GitHub issue #107).
+
+import { existsSync, readFileSync, statSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { Analyzer } from "../analysis/index";
+import { defaultRegistry } from "../analysis/registry";
+import { allRules } from "../analysis/rules/index";
+import type { Finding } from "../analysis/types";
+import type { AnalysisConfig } from "../analysis/types";
+import {
+  runReview,
+  formatReview,
+  type ReviewResult,
+  type ReviewOptions,
+  type LLMProvider,
+} from "../ai/review";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ReviewFormat = "markdown" | "text" | "json";
+
+export interface ReviewCommandOptions {
+  /** Positional arguments (file paths / directories). */
+  targets: string[];
+  /** Output format. */
+  format: ReviewFormat;
+  /** Review all migrations, not just pending. */
+  all: boolean;
+  /** Review files changed in git diff. */
+  changed: boolean;
+  /** Rules to forcibly skip (--force-rule). */
+  forceRules: string[];
+  /** Project top directory. */
+  topDir?: string;
+  /** Plan file path override. */
+  planFile?: string;
+  /** LLM provider (optional, for explanations). */
+  llm?: LLMProvider;
+}
+
+export interface ReviewCommandResult {
+  /** The review result. */
+  review: ReviewResult;
+  /** Exit code: 0 if no errors, 2 if errors found. */
+  exitCode: number;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse review-specific arguments from the rest array.
+ */
+export function parseReviewArgs(rest: string[]): ReviewCommandOptions {
+  const opts: ReviewCommandOptions = {
+    targets: [],
+    format: "markdown",
+    all: false,
+    changed: false,
+    forceRules: [],
+  };
+
+  let i = 0;
+  while (i < rest.length) {
+    const arg = rest[i]!;
+
+    if (arg === "--format") {
+      const val = rest[i + 1];
+      if (val === "markdown" || val === "text" || val === "json") {
+        opts.format = val;
+      } else {
+        throw new Error(
+          `Invalid --format value '${val ?? ""}'. Expected markdown, text, or json.`,
+        );
+      }
+      i += 2;
+      continue;
+    }
+
+    if (arg === "--all") {
+      opts.all = true;
+      i++;
+      continue;
+    }
+
+    if (arg === "--changed") {
+      opts.changed = true;
+      i++;
+      continue;
+    }
+
+    if (arg === "--force-rule") {
+      const val = rest[i + 1];
+      if (!val) {
+        throw new Error("--force-rule requires a rule ID argument");
+      }
+      opts.forceRules.push(val);
+      i += 2;
+      continue;
+    }
+
+    if (arg === "--top-dir") {
+      opts.topDir = rest[i + 1];
+      i += 2;
+      continue;
+    }
+
+    if (arg === "--plan-file") {
+      opts.planFile = rest[i + 1];
+      i += 2;
+      continue;
+    }
+
+    // Positional argument — file or directory target
+    opts.targets.push(arg);
+    i++;
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// File resolution (shared logic with analyze)
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all .sql files from a directory (non-recursive).
+ */
+function collectSqlFiles(dirPath: string): string[] {
+  const entries = readdirSync(dirPath, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith(".sql"))
+    .map((e) => join(dirPath, e.name))
+    .sort();
+}
+
+/**
+ * Resolve explicit targets (files and directories) to a list of .sql file paths.
+ */
+function resolveExplicitTargets(targets: string[]): string[] {
+  const files: string[] = [];
+  for (const target of targets) {
+    const resolved = resolve(target);
+    if (!existsSync(resolved)) {
+      throw new Error(`Path not found: ${target}`);
+    }
+    const stat = statSync(resolved);
+    if (stat.isDirectory()) {
+      files.push(...collectSqlFiles(resolved));
+    } else {
+      files.push(resolved);
+    }
+  }
+  return files;
+}
+
+/**
+ * Get migration file paths from sqitch.plan.
+ */
+function resolveFromPlan(planPath: string, deployDir: string): string[] {
+  if (!existsSync(planPath)) {
+    throw new Error(`Plan file not found: ${planPath}`);
+  }
+
+  const { parsePlan } = require("../plan/parser") as typeof import("../plan/parser");
+  const planContent = readFileSync(planPath, "utf-8");
+  const plan = parsePlan(planContent);
+
+  const files: string[] = [];
+  for (const change of plan.changes) {
+    const deployFile = join(deployDir, `${change.name}.sql`);
+    if (existsSync(deployFile)) {
+      files.push(resolve(deployFile));
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Get files changed in git diff. Only returns .sql files.
+ */
+function resolveChangedFiles(): string[] {
+  try {
+    const proc = Bun.spawnSync(["git", "diff", "--name-only", "HEAD"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const diffOutput = proc.stdout.toString().trim();
+
+    const stagedProc = Bun.spawnSync(
+      ["git", "diff", "--name-only", "--cached"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stagedOutput = stagedProc.stdout.toString().trim();
+
+    const untrackedProc = Bun.spawnSync(
+      ["git", "ls-files", "--others", "--exclude-standard"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const untrackedOutput = untrackedProc.stdout.toString().trim();
+
+    const allFiles = new Set<string>();
+    for (const output of [diffOutput, stagedOutput, untrackedOutput]) {
+      if (output) {
+        for (const f of output.split("\n")) {
+          if (f.endsWith(".sql")) {
+            const abs = resolve(f);
+            if (existsSync(abs)) {
+              allFiles.add(abs);
+            }
+          }
+        }
+      }
+    }
+
+    return Array.from(allFiles).sort();
+  } catch {
+    throw new Error("Failed to determine changed files from git");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core review command
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the review command.
+ *
+ * @returns ReviewCommandResult with review data and exit code.
+ */
+export async function runReviewCommand(
+  opts: ReviewCommandOptions,
+): Promise<ReviewCommandResult> {
+  // Register all rules into the default registry (idempotent)
+  for (const rule of allRules) {
+    if (!defaultRegistry.has(rule.id)) {
+      defaultRegistry.register(rule);
+    }
+  }
+
+  const analyzer = new Analyzer(defaultRegistry);
+  await analyzer.ensureWasm();
+
+  // Resolve file list
+  let files: string[];
+
+  if (opts.targets.length > 0) {
+    files = resolveExplicitTargets(opts.targets);
+  } else if (opts.changed) {
+    files = resolveChangedFiles();
+  } else {
+    const topDir = opts.topDir ?? ".";
+    const planFile = opts.planFile ?? join(topDir, "sqitch.plan");
+    const deployDir = join(topDir, "deploy");
+
+    if (!existsSync(planFile)) {
+      if (opts.planFile) {
+        throw new Error(`Plan file not found: ${planFile}`);
+      }
+      // No plan file and no explicit targets — empty review
+      const emptyResult: ReviewResult = {
+        risk: "low",
+        findings: [],
+        filesReviewed: [],
+        errorCount: 0,
+        warnCount: 0,
+        infoCount: 0,
+      };
+      const output = formatReview(emptyResult, opts.format);
+      process.stdout.write(output);
+      return { review: emptyResult, exitCode: 0 };
+    }
+
+    files = resolveFromPlan(planFile, deployDir);
+  }
+
+  // Build analysis config
+  const config: AnalysisConfig = {
+    skip: [...opts.forceRules],
+  };
+
+  // Read SQL contents for LLM context
+  const sqlContents = new Map<string, string>();
+  const allFindings: Finding[] = [];
+
+  for (const filePath of files) {
+    try {
+      const sql = readFileSync(filePath, "utf-8");
+      sqlContents.set(filePath, sql);
+      const findings = analyzer.analyze(filePath, { config });
+      allFindings.push(...findings);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      allFindings.push({
+        ruleId: "analyze-error",
+        severity: "error",
+        message: `Failed to analyze file: ${message}`,
+        location: { file: filePath, line: 1, column: 1 },
+      });
+    }
+  }
+
+  // Run review
+  const reviewOpts: ReviewOptions = {
+    format: opts.format,
+    llm: opts.llm,
+    sqlContents,
+  };
+
+  const result = await runReview(allFindings, files, reviewOpts);
+
+  // Format and print output
+  const output = formatReview(result, opts.format);
+  process.stdout.write(output);
+
+  // Exit code: 2 if errors found
+  const exitCode = result.errorCount > 0 ? 2 : 0;
+
+  return { review: result, exitCode };
+}

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -309,7 +309,7 @@ describe("unknown commands", () => {
 
 describe("command stubs", () => {
   // "help" is handled specially (not a stub); "init", "add", "deploy", "log", "revert", "verify", "tag", "rework", "show", "status", "plan", and "analyze" are implemented — exclude them
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "deploy" && c !== "log" && c !== "revert" && c !== "verify" && c !== "tag" && c !== "rework" && c !== "show" && c !== "status" && c !== "plan" && c !== "analyze" && c !== "explain" && c !== "diff");
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "deploy" && c !== "log" && c !== "revert" && c !== "verify" && c !== "tag" && c !== "rework" && c !== "show" && c !== "status" && c !== "plan" && c !== "analyze" && c !== "explain" && c !== "diff" && c !== "review");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {

--- a/tests/unit/review.test.ts
+++ b/tests/unit/review.test.ts
@@ -1,0 +1,744 @@
+/**
+ * Tests for src/ai/review.ts and src/commands/review.ts
+ *
+ * Covers: risk assessment, finding conversion, markdown formatting, text
+ * formatting, JSON formatting, review engine with mock LLM, review
+ * engine without LLM, argument parsing, CLI wiring, and edge cases.
+ *
+ * >=10 tests as required by issue #107.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { loadModule } from "libpg-query";
+import { join } from "node:path";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
+import {
+  assessRisk,
+  toFindingEntries,
+  runReview,
+  formatReviewMarkdown,
+  formatReviewText,
+  formatReviewJson,
+  formatReview,
+  shortenPath,
+  type FindingEntry,
+  type LLMProvider,
+  type LLMExplanation,
+  type ReviewResult,
+} from "../../src/ai/review";
+import {
+  parseReviewArgs,
+  runReviewCommand,
+} from "../../src/commands/review";
+import type { Finding } from "../../src/analysis/types";
+
+// Ensure WASM module is loaded before tests
+beforeAll(async () => {
+  await loadModule();
+});
+
+const TMP_DIR = join(import.meta.dir, "..", ".tmp-review-tests");
+
+// Create temp directory structure for tests
+beforeAll(() => {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true });
+  }
+  mkdirSync(TMP_DIR, { recursive: true });
+  mkdirSync(join(TMP_DIR, "deploy"), { recursive: true });
+
+  // Clean SQL file
+  writeFileSync(
+    join(TMP_DIR, "deploy", "clean.sql"),
+    "CREATE TABLE t (id serial PRIMARY KEY);\n",
+  );
+
+  // SQL file that triggers SA004 (CREATE INDEX without CONCURRENTLY)
+  writeFileSync(
+    join(TMP_DIR, "deploy", "index_issue.sql"),
+    "CREATE INDEX idx_t_id ON t (id);\n",
+  );
+
+  // SQL file that triggers SA010 (UPDATE without WHERE)
+  writeFileSync(
+    join(TMP_DIR, "deploy", "no_where.sql"),
+    "UPDATE t SET x = 1;\n",
+  );
+
+  // SQL file with SA001 error (ADD COLUMN NOT NULL without DEFAULT)
+  writeFileSync(
+    join(TMP_DIR, "deploy", "error_migration.sql"),
+    "ALTER TABLE users ADD COLUMN active boolean NOT NULL;\n",
+  );
+
+  // A sqitch.plan file
+  writeFileSync(
+    join(TMP_DIR, "sqitch.plan"),
+    `%project=test
+%uri=https://example.com
+
+clean 2024-01-15T10:30:00Z dev <dev@example.com> # clean migration
+index_issue 2024-01-15T10:31:00Z dev <dev@example.com> # index issue
+no_where 2024-01-15T10:32:00Z dev <dev@example.com> # no where
+error_migration 2024-01-15T10:33:00Z dev <dev@example.com> # error migration
+`,
+  );
+});
+
+afterAll(() => {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true });
+  }
+});
+
+// Suppress stdout during test runs
+function silenceStdout(): () => void {
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (() => true) as typeof process.stdout.write;
+  return () => {
+    process.stdout.write = original;
+  };
+}
+
+// Capture stdout during test runs
+function captureStdout(): { getOutput: () => string; restore: () => void } {
+  let output = "";
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: unknown) => {
+    output += typeof chunk === "string" ? chunk : String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    getOutput: () => output,
+    restore: () => {
+      process.stdout.write = original;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const mockFindings: Finding[] = [
+  {
+    ruleId: "SA004",
+    severity: "warn",
+    message: 'CREATE INDEX on table "t" without CONCURRENTLY may lock the table.',
+    location: { file: "/path/to/deploy/index_issue.sql", line: 1, column: 1 },
+    suggestion: "Use CREATE INDEX CONCURRENTLY to avoid table locks.",
+  },
+  {
+    ruleId: "SA001",
+    severity: "error",
+    message: 'Adding NOT NULL column "active" to table "users" without a DEFAULT will fail.',
+    location: { file: "/path/to/deploy/error_migration.sql", line: 1, column: 1 },
+    suggestion: "Add a DEFAULT value, or add the column as nullable first.",
+  },
+  {
+    ruleId: "SA010",
+    severity: "warn",
+    message: "UPDATE without WHERE clause affects all rows.",
+    location: { file: "/path/to/deploy/no_where.sql", line: 1, column: 1 },
+  },
+];
+
+const mockFindingEntries: FindingEntry[] = [
+  {
+    ruleId: "SA004",
+    severity: "warn",
+    message: 'CREATE INDEX on table "t" without CONCURRENTLY may lock the table.',
+    file: "/path/to/deploy/index_issue.sql",
+    line: 1,
+    suggestion: "Use CREATE INDEX CONCURRENTLY to avoid table locks.",
+  },
+  {
+    ruleId: "SA001",
+    severity: "error",
+    message: 'Adding NOT NULL column "active" to table "users" without a DEFAULT will fail.',
+    file: "/path/to/deploy/error_migration.sql",
+    line: 1,
+    suggestion: "Add a DEFAULT value, or add the column as nullable first.",
+  },
+  {
+    ruleId: "SA010",
+    severity: "warn",
+    message: "UPDATE without WHERE clause affects all rows.",
+    file: "/path/to/deploy/no_where.sql",
+    line: 1,
+  },
+];
+
+/** Mock LLM provider for testing. */
+class MockLLMProvider implements LLMProvider {
+  async explain(
+    _sql: string,
+    _findings: FindingEntry[],
+  ): Promise<LLMExplanation> {
+    return {
+      summary:
+        "This migration adds an index on the t table, updates all rows in t, and adds a NOT NULL column to users.",
+      suggestedImprovements: [
+        "Use CREATE INDEX CONCURRENTLY to avoid locking the table during index creation.",
+        "Add a WHERE clause to the UPDATE statement to limit the scope of changes.",
+        "Add a DEFAULT value when adding a NOT NULL column to avoid failures on populated tables.",
+      ],
+    };
+  }
+}
+
+/** Mock LLM provider that throws an error. */
+class FailingLLMProvider implements LLMProvider {
+  async explain(): Promise<LLMExplanation> {
+    throw new Error("LLM service unavailable");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: assessRisk
+// ---------------------------------------------------------------------------
+
+describe("assessRisk", () => {
+  test("returns 'high' when there are error-level findings", () => {
+    const result = assessRisk(mockFindingEntries);
+    expect(result).toBe("high");
+  });
+
+  test("returns 'medium' when there are only warnings", () => {
+    const warnOnly = mockFindingEntries.filter((f) => f.severity === "warn");
+    const result = assessRisk(warnOnly);
+    expect(result).toBe("medium");
+  });
+
+  test("returns 'low' when there are no findings", () => {
+    const result = assessRisk([]);
+    expect(result).toBe("low");
+  });
+
+  test("returns 'low' when there are only info findings", () => {
+    const infoOnly: FindingEntry[] = [
+      {
+        ruleId: "SA999",
+        severity: "info",
+        message: "Informational message",
+        file: "test.sql",
+        line: 1,
+      },
+    ];
+    const result = assessRisk(infoOnly);
+    expect(result).toBe("low");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: toFindingEntries
+// ---------------------------------------------------------------------------
+
+describe("toFindingEntries", () => {
+  test("converts raw Finding[] to FindingEntry[]", () => {
+    const entries = toFindingEntries(mockFindings);
+    expect(entries.length).toBe(3);
+    expect(entries[0]!.ruleId).toBe("SA004");
+    expect(entries[0]!.file).toBe("/path/to/deploy/index_issue.sql");
+    expect(entries[0]!.line).toBe(1);
+    expect(entries[0]!.suggestion).toBe(
+      "Use CREATE INDEX CONCURRENTLY to avoid table locks.",
+    );
+    expect(entries[2]!.suggestion).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: formatReviewMarkdown
+// ---------------------------------------------------------------------------
+
+describe("formatReviewMarkdown", () => {
+  test("produces markdown with risk summary, findings table, and suggestions", () => {
+    const result: ReviewResult = {
+      risk: "high",
+      findings: mockFindingEntries,
+      filesReviewed: ["file1.sql", "file2.sql", "file3.sql"],
+      errorCount: 1,
+      warnCount: 2,
+      infoCount: 0,
+    };
+
+    const md = formatReviewMarkdown(result);
+
+    // Header
+    expect(md).toContain("## sqlever review");
+
+    // Risk summary
+    expect(md).toContain("HIGH");
+
+    // Counts
+    expect(md).toContain("1 error");
+    expect(md).toContain("2 warnings");
+    expect(md).toContain("3 files");
+
+    // Findings table
+    expect(md).toContain("| Severity | Rule | Message | File | Line |");
+    expect(md).toContain("SA004");
+    expect(md).toContain("SA001");
+    expect(md).toContain("SA010");
+
+    // Suggestions
+    expect(md).toContain("### Suggested improvements");
+    expect(md).toContain("Use CREATE INDEX CONCURRENTLY");
+
+    // Footer
+    expect(md).toContain("Generated by sqlever review");
+  });
+
+  test("includes LLM explanation when present", () => {
+    const result: ReviewResult = {
+      risk: "medium",
+      findings: [mockFindingEntries[0]!],
+      explanation: {
+        summary: "This migration creates an index on the t table.",
+        suggestedImprovements: ["Use CONCURRENTLY."],
+      },
+      filesReviewed: ["file1.sql"],
+      errorCount: 0,
+      warnCount: 1,
+      infoCount: 0,
+    };
+
+    const md = formatReviewMarkdown(result);
+    expect(md).toContain("### What this migration does");
+    expect(md).toContain("This migration creates an index on the t table.");
+    expect(md).toContain("### AI-suggested improvements");
+    expect(md).toContain("Use CONCURRENTLY.");
+  });
+
+  test("shows 'No issues found' when there are no findings", () => {
+    const result: ReviewResult = {
+      risk: "low",
+      findings: [],
+      filesReviewed: ["file1.sql"],
+      errorCount: 0,
+      warnCount: 0,
+      infoCount: 0,
+    };
+
+    const md = formatReviewMarkdown(result);
+    expect(md).toContain("No issues found");
+    expect(md).toContain("LOW");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: formatReviewText
+// ---------------------------------------------------------------------------
+
+describe("formatReviewText", () => {
+  test("produces plain text with risk and findings", () => {
+    const result: ReviewResult = {
+      risk: "high",
+      findings: mockFindingEntries,
+      filesReviewed: ["file1.sql"],
+      errorCount: 1,
+      warnCount: 2,
+      infoCount: 0,
+    };
+
+    const text = formatReviewText(result);
+    expect(text).toContain("Risk: HIGH");
+    expect(text).toContain("1 error(s)");
+    expect(text).toContain("2 warning(s)");
+    expect(text).toContain("SA004");
+    expect(text).toContain("SA001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: formatReviewJson
+// ---------------------------------------------------------------------------
+
+describe("formatReviewJson", () => {
+  test("produces valid JSON with all review fields", () => {
+    const result: ReviewResult = {
+      risk: "medium",
+      findings: [mockFindingEntries[0]!],
+      filesReviewed: ["file1.sql"],
+      errorCount: 0,
+      warnCount: 1,
+      infoCount: 0,
+    };
+
+    const jsonStr = formatReviewJson(result);
+    const parsed = JSON.parse(jsonStr);
+    expect(parsed.risk).toBe("medium");
+    expect(parsed.findings.length).toBe(1);
+    expect(parsed.findings[0].ruleId).toBe("SA004");
+    expect(parsed.errorCount).toBe(0);
+    expect(parsed.warnCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: runReview with mock LLM
+// ---------------------------------------------------------------------------
+
+describe("runReview with mock LLM", () => {
+  test("integrates static findings with LLM explanation", async () => {
+    const sqlContents = new Map<string, string>();
+    sqlContents.set(
+      "/path/to/deploy/index_issue.sql",
+      "CREATE INDEX idx_t_id ON t (id);\n",
+    );
+
+    const result = await runReview(mockFindings, ["file1.sql", "file2.sql"], {
+      format: "markdown",
+      llm: new MockLLMProvider(),
+      sqlContents,
+    });
+
+    expect(result.risk).toBe("high");
+    expect(result.findings.length).toBe(3);
+    expect(result.explanation).toBeDefined();
+    expect(result.explanation!.summary).toContain("migration");
+    expect(result.explanation!.suggestedImprovements.length).toBe(3);
+    expect(result.errorCount).toBe(1);
+    expect(result.warnCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: runReview without LLM (graceful degradation)
+// ---------------------------------------------------------------------------
+
+describe("runReview without LLM", () => {
+  test("produces review without explanation when no LLM provided", async () => {
+    const result = await runReview(mockFindings, ["file1.sql"], {
+      format: "markdown",
+    });
+
+    expect(result.risk).toBe("high");
+    expect(result.findings.length).toBe(3);
+    expect(result.explanation).toBeUndefined();
+  });
+
+  test("handles LLM failure gracefully", async () => {
+    const sqlContents = new Map<string, string>();
+    sqlContents.set("file.sql", "CREATE TABLE t (id int);");
+
+    const result = await runReview(mockFindings, ["file1.sql"], {
+      format: "markdown",
+      llm: new FailingLLMProvider(),
+      sqlContents,
+    });
+
+    expect(result.risk).toBe("high");
+    expect(result.findings.length).toBe(3);
+    // LLM failure is non-fatal — explanation should be undefined
+    expect(result.explanation).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: parseReviewArgs
+// ---------------------------------------------------------------------------
+
+describe("parseReviewArgs", () => {
+  test("parses empty args with default format markdown", () => {
+    const opts = parseReviewArgs([]);
+    expect(opts.targets).toEqual([]);
+    expect(opts.format).toBe("markdown");
+    expect(opts.all).toBe(false);
+    expect(opts.changed).toBe(false);
+  });
+
+  test("parses --format text", () => {
+    const opts = parseReviewArgs(["--format", "text"]);
+    expect(opts.format).toBe("text");
+  });
+
+  test("parses --format json", () => {
+    const opts = parseReviewArgs(["--format", "json"]);
+    expect(opts.format).toBe("json");
+  });
+
+  test("parses --format markdown", () => {
+    const opts = parseReviewArgs(["--format", "markdown"]);
+    expect(opts.format).toBe("markdown");
+  });
+
+  test("throws on invalid --format value", () => {
+    expect(() => parseReviewArgs(["--format", "xml"])).toThrow(
+      "Invalid --format",
+    );
+  });
+
+  test("parses positional targets", () => {
+    const opts = parseReviewArgs(["file1.sql", "dir/"]);
+    expect(opts.targets).toEqual(["file1.sql", "dir/"]);
+  });
+
+  test("parses --all flag", () => {
+    const opts = parseReviewArgs(["--all"]);
+    expect(opts.all).toBe(true);
+  });
+
+  test("parses --changed flag", () => {
+    const opts = parseReviewArgs(["--changed"]);
+    expect(opts.changed).toBe(true);
+  });
+
+  test("parses --force-rule", () => {
+    const opts = parseReviewArgs(["--force-rule", "SA004"]);
+    expect(opts.forceRules).toEqual(["SA004"]);
+  });
+
+  test("parses combined flags and targets", () => {
+    const opts = parseReviewArgs([
+      "file.sql",
+      "--format",
+      "json",
+      "--force-rule",
+      "SA001",
+      "--all",
+    ]);
+    expect(opts.targets).toEqual(["file.sql"]);
+    expect(opts.format).toBe("json");
+    expect(opts.forceRules).toEqual(["SA001"]);
+    expect(opts.all).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: runReviewCommand with real analysis
+// ---------------------------------------------------------------------------
+
+describe("runReviewCommand", () => {
+  test("reviews a clean SQL file with exit code 0 and low risk", async () => {
+    const restore = silenceStdout();
+    try {
+      const result = await runReviewCommand({
+        targets: [join(TMP_DIR, "deploy", "clean.sql")],
+        format: "markdown",
+        all: false,
+        changed: false,
+        forceRules: [],
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.review.risk).toBe("low");
+    } finally {
+      restore();
+    }
+  });
+
+  test("reviews a file with warnings and assigns medium risk", async () => {
+    const restore = silenceStdout();
+    try {
+      const result = await runReviewCommand({
+        targets: [join(TMP_DIR, "deploy", "no_where.sql")],
+        format: "markdown",
+        all: false,
+        changed: false,
+        forceRules: [],
+      });
+      // SA010 is a warning — risk should be medium, exit code 0
+      expect(result.exitCode).toBe(0);
+      expect(result.review.risk).toBe("medium");
+      expect(result.review.warnCount).toBeGreaterThan(0);
+    } finally {
+      restore();
+    }
+  });
+
+  test("reviews a file with errors and assigns high risk", async () => {
+    const restore = silenceStdout();
+    try {
+      const result = await runReviewCommand({
+        targets: [join(TMP_DIR, "deploy", "error_migration.sql")],
+        format: "markdown",
+        all: false,
+        changed: false,
+        forceRules: [],
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.review.risk).toBe("high");
+      expect(result.review.errorCount).toBeGreaterThan(0);
+    } finally {
+      restore();
+    }
+  });
+
+  test("outputs valid JSON when --format json", async () => {
+    const cap = captureStdout();
+    try {
+      await runReviewCommand({
+        targets: [join(TMP_DIR, "deploy", "clean.sql")],
+        format: "json",
+        all: false,
+        changed: false,
+        forceRules: [],
+      });
+      const parsed = JSON.parse(cap.getOutput());
+      expect(parsed.risk).toBe("low");
+      expect(Array.isArray(parsed.findings)).toBe(true);
+      expect(parsed.filesReviewed).toBeDefined();
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("outputs markdown with table headers when --format markdown", async () => {
+    const cap = captureStdout();
+    try {
+      await runReviewCommand({
+        targets: [join(TMP_DIR, "deploy", "no_where.sql")],
+        format: "markdown",
+        all: false,
+        changed: false,
+        forceRules: [],
+      });
+      const output = cap.getOutput();
+      expect(output).toContain("## sqlever review");
+      expect(output).toContain("| Severity | Rule | Message | File | Line |");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("respects --force-rule to skip specific rules", async () => {
+    const restore = silenceStdout();
+    try {
+      const result = await runReviewCommand({
+        targets: [join(TMP_DIR, "deploy", "no_where.sql")],
+        format: "text",
+        all: false,
+        changed: false,
+        forceRules: ["SA010"],
+      });
+      const sa010 = result.review.findings.filter((f) => f.ruleId === "SA010");
+      expect(sa010.length).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  test("reviews from sqitch.plan when no targets given", async () => {
+    const restore = silenceStdout();
+    try {
+      const result = await runReviewCommand({
+        targets: [],
+        format: "markdown",
+        all: false,
+        changed: false,
+        forceRules: [],
+        topDir: TMP_DIR,
+        planFile: join(TMP_DIR, "sqitch.plan"),
+      });
+      // Plan has 4 changes
+      expect(result.review.filesReviewed.length).toBe(4);
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 10: formatReview dispatcher
+// ---------------------------------------------------------------------------
+
+describe("formatReview dispatcher", () => {
+  const result: ReviewResult = {
+    risk: "low",
+    findings: [],
+    filesReviewed: ["file1.sql"],
+    errorCount: 0,
+    warnCount: 0,
+    infoCount: 0,
+  };
+
+  test("dispatches to markdown formatter", () => {
+    const output = formatReview(result, "markdown");
+    expect(output).toContain("## sqlever review");
+  });
+
+  test("dispatches to text formatter", () => {
+    const output = formatReview(result, "text");
+    expect(output).toContain("Risk: LOW");
+  });
+
+  test("dispatches to json formatter", () => {
+    const output = formatReview(result, "json");
+    const parsed = JSON.parse(output);
+    expect(parsed.risk).toBe("low");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 11: shortenPath helper
+// ---------------------------------------------------------------------------
+
+describe("shortenPath", () => {
+  test("shortens long paths to last 2 segments", () => {
+    expect(shortenPath("/home/user/project/deploy/migration.sql")).toBe(
+      "deploy/migration.sql",
+    );
+  });
+
+  test("preserves short paths", () => {
+    expect(shortenPath("file.sql")).toBe("file.sql");
+    expect(shortenPath("deploy/file.sql")).toBe("deploy/file.sql");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 12: CLI wiring
+// ---------------------------------------------------------------------------
+
+describe("CLI wiring", () => {
+  const CLI_PATH = join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+  test("sqlever review file.sql runs successfully", async () => {
+    const cleanFile = join(TMP_DIR, "deploy", "clean.sql");
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_PATH, "review", cleanFile],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  });
+
+  test("sqlever review --format markdown outputs markdown", async () => {
+    const cleanFile = join(TMP_DIR, "deploy", "clean.sql");
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_PATH, "review", "--format", "markdown", cleanFile],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    await proc.exited;
+    expect(stdout).toContain("## sqlever review");
+  });
+
+  test("sqlever review --format json outputs valid JSON", async () => {
+    const cleanFile = join(TMP_DIR, "deploy", "clean.sql");
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_PATH, "review", "--format", "json", cleanFile],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    await proc.exited;
+    const parsed = JSON.parse(stdout);
+    expect(parsed.risk).toBe("low");
+  });
+
+  test("sqlever review exits 2 when errors found", async () => {
+    const errorFile = join(TMP_DIR, "deploy", "error_migration.sql");
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_PATH, "review", errorFile],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `sqlever review` command (SPEC Section 5.7, issue #107) — produces structured risk reports suitable for posting as PR comments
- Creates `src/ai/review.ts` (review engine: risk assessment, finding conversion, LLM integration, markdown/text/json formatters) and `src/commands/review.ts` (CLI command with file/directory/plan resolution and argument parsing)
- `--format markdown` outputs ready-to-post content that can be piped to `gh pr comment --body-file -`
- Wires into CLI dispatcher, updates stub exclusion list in cli.test.ts
- 39 tests covering risk assessment, markdown/text/JSON formatting, mock LLM integration, graceful LLM failure, argument parsing, real analysis integration, and CLI wiring

## Output structure (markdown format)

- **Risk summary**: high/medium/low with visual indicator
- **Analysis findings table**: severity, rule ID, message, file, line
- **Suggested improvements**: from static analysis rule suggestions
- **LLM explanation** (when provider available): what the migration does + AI-suggested improvements

## Test plan

- [x] `assessRisk` returns correct level for error/warn/info/empty findings
- [x] `toFindingEntries` converts raw `Finding[]` to structured entries
- [x] Markdown formatter includes risk summary, findings table, suggestions, footer
- [x] Markdown formatter includes LLM explanation when present
- [x] Text formatter produces plain text output
- [x] JSON formatter produces valid JSON with all fields
- [x] Review engine integrates static findings with mock LLM
- [x] Review engine works without LLM (graceful degradation)
- [x] Review engine handles LLM failure gracefully
- [x] Argument parser handles all flags and formats
- [x] `runReviewCommand` with real analysis: clean file (low risk), warnings (medium), errors (high)
- [x] CLI wiring: subprocess tests for `sqlever review` with markdown/json output

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)