### PR TITLE
E1: Expand/contract migration pair generator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { runStatus } from "./commands/status";
 import { runDeploy } from "./commands/deploy";
 import { setConfig, type OutputFormat } from "./output";
 import { parseAddArgs, runAdd } from "./commands/add";
+import { parseExpandArgs, runExpandAdd } from "./expand-contract/generator";
 import { runLogCommand } from "./commands/log";
 import { runRevert } from "./commands/revert";
 import { parseTagArgs, runTag } from "./commands/tag";
@@ -315,6 +316,16 @@ export function main(argv: string[] = process.argv.slice(2)): void {
   }
 
   if (args.command === "add") {
+    // Check if --expand flag is present
+    if (args.rest.includes("--expand")) {
+      const expandOpts = parseExpandArgs(args.rest);
+      expandOpts.topDir = args.topDir;
+      runExpandAdd(expandOpts).catch((err: unknown) => {
+        process.stderr.write(`sqlever add --expand: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exit(1);
+      });
+      return;
+    }
     const addOpts = parseAddArgs(args.rest);
     addOpts.topDir = args.topDir;
     runAdd(addOpts).catch((err: unknown) => {

--- a/src/expand-contract/generator.ts
+++ b/src/expand-contract/generator.ts
@@ -1,0 +1,776 @@
+// src/expand-contract/generator.ts — Expand/contract migration pair generator
+//
+// Generates linked expand + contract migration pairs for zero-downtime
+// schema changes. Implements SPEC Section 5.4.
+//
+// Expand phase (backward-compatible):
+//   - Add new column alongside old
+//   - Install sync trigger (bidirectional, with recursion guard)
+//
+// Contract phase (after full app rollout):
+//   - Verify all rows backfilled
+//   - Drop sync trigger
+//   - Drop old column
+//
+// The two changes are linked in the plan with the contract requiring
+// the expand change.
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { appendChange } from "../plan/writer";
+import { computeChangeId, type ChangeIdInput, type Change } from "../plan/types";
+import {
+  readPlanInfo,
+  getPlannerIdentity,
+  nowTimestamp,
+  type AddOptions,
+} from "../commands/add";
+import type { MergedConfig } from "../config/index";
+import { info, error, verbose } from "../output";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Supported expand/contract operation types. */
+export type ExpandOperation = "rename_col" | "change_type";
+
+/** Configuration for an expand/contract migration pair. */
+export interface ExpandContractConfig {
+  /** Base name for the migration (e.g., "rename_users_name"). */
+  name: string;
+  /** The operation type. */
+  operation: ExpandOperation;
+  /** Target table (schema-qualified, e.g., "public.users"). */
+  table: string;
+  /** Old column name. */
+  oldColumn: string;
+  /** New column name. */
+  newColumn: string;
+  /** New column type (for change_type; defaults to same type for rename). */
+  newType?: string;
+  /** Old column type (used in revert scripts). */
+  oldType?: string;
+  /** Type cast expression for expand direction (old -> new). */
+  castForward?: string;
+  /** Type cast expression for contract revert (new -> old). */
+  castReverse?: string;
+  /** Note for the plan entries. */
+  note: string;
+  /** Additional requires dependencies. */
+  requires: string[];
+  /** Conflict dependencies. */
+  conflicts: string[];
+}
+
+/** Result of generating an expand/contract pair. */
+export interface ExpandContractResult {
+  /** Name of the expand change. */
+  expandName: string;
+  /** Name of the contract change. */
+  contractName: string;
+  /** Paths to all created files. */
+  files: string[];
+  /** The expand Change object (for plan). */
+  expandChange: Change;
+  /** The contract Change object (for plan). */
+  contractChange: Change;
+}
+
+// ---------------------------------------------------------------------------
+// Naming conventions
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive expand and contract change names from a base name.
+ *
+ * Convention: `<base>_expand` and `<base>_contract`
+ */
+export function deriveChangeNames(baseName: string): {
+  expandName: string;
+  contractName: string;
+} {
+  return {
+    expandName: `${baseName}_expand`,
+    contractName: `${baseName}_contract`,
+  };
+}
+
+/**
+ * Derive the sync trigger name for a given table and column pair.
+ *
+ * All sqlever-generated sync triggers use the `sqlever_sync_` prefix
+ * per SPEC 5.4 (recursion guard relies on this prefix).
+ */
+export function syncTriggerName(
+  table: string,
+  oldColumn: string,
+  newColumn: string,
+): string {
+  // Strip schema prefix for the trigger name
+  const tableName = table.includes(".") ? table.split(".").pop()! : table;
+  return `sqlever_sync_${tableName}_${oldColumn}_${newColumn}`;
+}
+
+/**
+ * Derive the sync trigger function name.
+ */
+export function syncTriggerFunctionName(
+  table: string,
+  oldColumn: string,
+  newColumn: string,
+): string {
+  const tableName = table.includes(".") ? table.split(".").pop()! : table;
+  return `sqlever_sync_fn_${tableName}_${oldColumn}_${newColumn}`;
+}
+
+// ---------------------------------------------------------------------------
+// SQL Templates — Expand phase
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the expand deploy SQL script.
+ *
+ * Actions:
+ *   1. Add new column (same type as old, or specified new type)
+ *   2. Create sync trigger function with recursion guard
+ *   3. Install BEFORE INSERT OR UPDATE trigger on the table
+ */
+export function expandDeployTemplate(config: ExpandContractConfig): string {
+  const trigName = syncTriggerName(config.table, config.oldColumn, config.newColumn);
+  const fnName = syncTriggerFunctionName(config.table, config.oldColumn, config.newColumn);
+  const colType = config.newType ?? config.oldType ?? "text";
+  const castFwd = config.castForward ? `(${config.castForward})` : `NEW.${config.oldColumn}`;
+  const castRev = config.castReverse ? `(${config.castReverse})` : `NEW.${config.newColumn}`;
+
+  return `-- Deploy ${config.name}_expand
+-- Expand phase: add new column + sync trigger
+-- Table: ${config.table}
+-- Operation: ${config.operation} (${config.oldColumn} -> ${config.newColumn})
+
+BEGIN;
+
+-- 1. Add the new column
+ALTER TABLE ${config.table} ADD COLUMN ${config.newColumn} ${colType};
+
+-- 2. Create sync trigger function with recursion guard
+--    Uses pg_trigger_depth() to prevent infinite recursion between
+--    bidirectional sync triggers. See SPEC 5.4 for rationale.
+CREATE OR REPLACE FUNCTION ${fnName}()
+RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF pg_trigger_depth() < 2 THEN
+    IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+      -- Sync old -> new when old column is modified
+      IF NEW.${config.oldColumn} IS DISTINCT FROM OLD.${config.oldColumn}
+         OR (TG_OP = 'INSERT') THEN
+        NEW.${config.newColumn} := ${castFwd};
+      END IF;
+      -- Sync new -> old when new column is modified
+      IF NEW.${config.newColumn} IS DISTINCT FROM OLD.${config.newColumn}
+         OR (TG_OP = 'INSERT' AND NEW.${config.newColumn} IS NOT NULL) THEN
+        NEW.${config.oldColumn} := ${castRev};
+      END IF;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- 3. Install the sync trigger
+CREATE TRIGGER ${trigName}
+  BEFORE INSERT OR UPDATE ON ${config.table}
+  FOR EACH ROW EXECUTE FUNCTION ${fnName}();
+
+COMMIT;
+`;
+}
+
+/**
+ * Generate the expand revert SQL script.
+ *
+ * Reverting the expand phase:
+ *   1. Drop sync trigger
+ *   2. Drop sync trigger function
+ *   3. Drop new column
+ */
+export function expandRevertTemplate(config: ExpandContractConfig): string {
+  const trigName = syncTriggerName(config.table, config.oldColumn, config.newColumn);
+  const fnName = syncTriggerFunctionName(config.table, config.oldColumn, config.newColumn);
+
+  return `-- Revert ${config.name}_expand
+-- Revert expand phase: drop trigger + new column
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS ${trigName} ON ${config.table};
+DROP FUNCTION IF EXISTS ${fnName}();
+ALTER TABLE ${config.table} DROP COLUMN IF EXISTS ${config.newColumn};
+
+COMMIT;
+`;
+}
+
+/**
+ * Generate the expand verify SQL script.
+ */
+export function expandVerifyTemplate(config: ExpandContractConfig): string {
+  const trigName = syncTriggerName(config.table, config.oldColumn, config.newColumn);
+
+  return `-- Verify ${config.name}_expand
+-- Verify: new column exists and sync trigger is installed
+
+BEGIN;
+
+-- Verify the new column exists
+SELECT ${config.newColumn} FROM ${config.table} WHERE false;
+
+-- Verify the sync trigger exists
+SELECT 1 FROM pg_trigger
+WHERE tgname = '${trigName}'
+  AND tgrelid = '${config.table}'::regclass;
+
+ROLLBACK;
+`;
+}
+
+// ---------------------------------------------------------------------------
+// SQL Templates — Contract phase
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the contract deploy SQL script.
+ *
+ * Actions:
+ *   1. Verify all rows are backfilled (new column has no NULLs where
+ *      old column is NOT NULL)
+ *   2. Drop sync trigger + function
+ *   3. Drop old column
+ */
+export function contractDeployTemplate(config: ExpandContractConfig): string {
+  const trigName = syncTriggerName(config.table, config.oldColumn, config.newColumn);
+  const fnName = syncTriggerFunctionName(config.table, config.oldColumn, config.newColumn);
+
+  return `-- Deploy ${config.name}_contract
+-- Contract phase: verify backfill, drop trigger + old column
+-- Table: ${config.table}
+-- Operation: ${config.operation} (${config.oldColumn} -> ${config.newColumn})
+
+BEGIN;
+
+-- 1. Verify backfill is complete: no rows where old column has a value
+--    but new column is NULL
+DO $$
+DECLARE
+  unsynced_count bigint;
+BEGIN
+  SELECT count(*) INTO unsynced_count
+  FROM ${config.table}
+  WHERE ${config.oldColumn} IS NOT NULL
+    AND ${config.newColumn} IS NULL;
+
+  IF unsynced_count > 0 THEN
+    RAISE EXCEPTION 'Backfill incomplete: % rows in ${config.table} have ${config.oldColumn} set but ${config.newColumn} is NULL. Run backfill before contracting.', unsynced_count;
+  END IF;
+END;
+$$;
+
+-- 2. Drop sync trigger and function
+DROP TRIGGER IF EXISTS ${trigName} ON ${config.table};
+DROP FUNCTION IF EXISTS ${fnName}();
+
+-- 3. Drop old column
+ALTER TABLE ${config.table} DROP COLUMN ${config.oldColumn};
+
+COMMIT;
+`;
+}
+
+/**
+ * Generate the contract revert SQL script.
+ *
+ * Reverting the contract phase:
+ *   1. Re-add the old column
+ *   2. Re-create the sync trigger
+ *   3. Backfill old column from new column
+ */
+export function contractRevertTemplate(config: ExpandContractConfig): string {
+  const trigName = syncTriggerName(config.table, config.oldColumn, config.newColumn);
+  const fnName = syncTriggerFunctionName(config.table, config.oldColumn, config.newColumn);
+  const oldColType = config.oldType ?? config.newType ?? "text";
+  const castRev = config.castReverse ? `(${config.castReverse})` : config.newColumn;
+
+  return `-- Revert ${config.name}_contract
+-- Revert contract: re-add old column + sync trigger
+
+BEGIN;
+
+-- 1. Re-add old column
+ALTER TABLE ${config.table} ADD COLUMN ${config.oldColumn} ${oldColType};
+
+-- 2. Re-create sync trigger function
+CREATE OR REPLACE FUNCTION ${fnName}()
+RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF pg_trigger_depth() < 2 THEN
+    IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+      IF NEW.${config.oldColumn} IS DISTINCT FROM OLD.${config.oldColumn}
+         OR (TG_OP = 'INSERT') THEN
+        NEW.${config.newColumn} := NEW.${config.oldColumn};
+      END IF;
+      IF NEW.${config.newColumn} IS DISTINCT FROM OLD.${config.newColumn}
+         OR (TG_OP = 'INSERT' AND NEW.${config.newColumn} IS NOT NULL) THEN
+        NEW.${config.oldColumn} := ${castRev};
+      END IF;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- 3. Re-install sync trigger
+CREATE TRIGGER ${trigName}
+  BEFORE INSERT OR UPDATE ON ${config.table}
+  FOR EACH ROW EXECUTE FUNCTION ${fnName}();
+
+-- 4. Backfill old column from new column
+UPDATE ${config.table} SET ${config.oldColumn} = ${castRev}
+WHERE ${config.newColumn} IS NOT NULL;
+
+COMMIT;
+`;
+}
+
+/**
+ * Generate the contract verify SQL script.
+ */
+export function contractVerifyTemplate(config: ExpandContractConfig): string {
+  return `-- Verify ${config.name}_contract
+-- Verify: old column is gone, trigger is gone
+
+BEGIN;
+
+-- Verify the old column no longer exists (this should raise an error if it does)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema || '.' || table_name = '${config.table}'
+      AND column_name = '${config.oldColumn}'
+  ) THEN
+    RAISE EXCEPTION 'Old column ${config.oldColumn} still exists on ${config.table}';
+  END IF;
+END;
+$$;
+
+-- Verify the new column exists
+SELECT ${config.newColumn} FROM ${config.table} WHERE false;
+
+ROLLBACK;
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing for --expand flag
+// ---------------------------------------------------------------------------
+
+export interface ExpandAddOptions extends AddOptions {
+  /** Whether --expand flag was provided. */
+  expand: boolean;
+  /** Target table for the expand/contract operation. */
+  table: string;
+  /** Old column name. */
+  oldColumn: string;
+  /** New column name. */
+  newColumn: string;
+  /** New column type (optional, for type changes). */
+  newType?: string;
+  /** Old column type (optional, for revert scripts). */
+  oldType?: string;
+  /** Cast expression for old -> new direction. */
+  castForward?: string;
+  /** Cast expression for new -> old direction. */
+  castReverse?: string;
+}
+
+/**
+ * Parse additional expand/contract flags from CLI args.
+ *
+ * Expected usage:
+ *   sqlever add <name> --expand --table users --old-column name --new-column full_name
+ *     [--new-type text] [--old-type varchar] [--cast-forward expr] [--cast-reverse expr]
+ */
+export function parseExpandArgs(rest: string[]): ExpandAddOptions {
+  const opts: ExpandAddOptions = {
+    name: "",
+    note: "",
+    requires: [],
+    conflicts: [],
+    noVerify: false,
+    expand: false,
+    table: "",
+    oldColumn: "",
+    newColumn: "",
+  };
+
+  let i = 0;
+  while (i < rest.length) {
+    const arg = rest[i]!;
+
+    if (arg === "--expand") {
+      opts.expand = true;
+      i++;
+      continue;
+    }
+    if (arg === "--table") {
+      opts.table = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+    if (arg === "--old-column") {
+      opts.oldColumn = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+    if (arg === "--new-column") {
+      opts.newColumn = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+    if (arg === "--new-type") {
+      opts.newType = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+    if (arg === "--old-type") {
+      opts.oldType = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+    if (arg === "--cast-forward") {
+      opts.castForward = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+    if (arg === "--cast-reverse") {
+      opts.castReverse = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+    if (arg === "-n" || arg === "--note") {
+      opts.note = rest[++i] ?? "";
+      i++;
+      continue;
+    }
+    if (arg === "-r" || arg === "--requires") {
+      const val = rest[++i];
+      if (val) opts.requires.push(val);
+      i++;
+      continue;
+    }
+    if (arg === "-c" || arg === "--conflicts") {
+      const val = rest[++i];
+      if (val) opts.conflicts.push(val);
+      i++;
+      continue;
+    }
+    if (arg === "--no-verify") {
+      opts.noVerify = true;
+      i++;
+      continue;
+    }
+
+    // First non-flag argument is the change name
+    if (opts.name === "") {
+      opts.name = arg;
+    }
+    i++;
+  }
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate expand/contract options. Returns an error message or null.
+ */
+export function validateExpandOptions(opts: ExpandAddOptions): string | null {
+  if (!opts.name) {
+    return "change name is required";
+  }
+  if (!/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(opts.name)) {
+    return `invalid change name '${opts.name}'. Names must start with a letter or underscore and contain only letters, digits, underscores, and hyphens.`;
+  }
+  if (!opts.table) {
+    return "--table is required for --expand migrations";
+  }
+  if (!opts.oldColumn) {
+    return "--old-column is required for --expand migrations";
+  }
+  if (!opts.newColumn) {
+    return "--new-column is required for --expand migrations";
+  }
+  if (opts.oldColumn === opts.newColumn) {
+    return "old column and new column must be different";
+  }
+  return null;
+}
+
+/**
+ * Determine the operation type from the options.
+ */
+export function inferOperation(opts: ExpandAddOptions): ExpandOperation {
+  if (opts.newType && opts.oldType && opts.newType !== opts.oldType) {
+    return "change_type";
+  }
+  return "rename_col";
+}
+
+// ---------------------------------------------------------------------------
+// Core generator
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate an expand/contract migration pair.
+ *
+ * Creates:
+ *   - deploy/<name>_expand.sql
+ *   - revert/<name>_expand.sql
+ *   - verify/<name>_expand.sql (unless --no-verify)
+ *   - deploy/<name>_contract.sql
+ *   - revert/<name>_contract.sql
+ *   - verify/<name>_contract.sql (unless --no-verify)
+ *
+ * And appends both changes to the plan file with the contract
+ * depending on the expand change.
+ */
+export async function generateExpandContract(
+  opts: ExpandAddOptions,
+  config: MergedConfig,
+  env?: Record<string, string | undefined>,
+): Promise<ExpandContractResult> {
+  const environment = env ?? process.env;
+
+  // Validate
+  const validationError = validateExpandOptions(opts);
+  if (validationError) {
+    throw new Error(validationError);
+  }
+
+  const topDir = resolve(opts.topDir ?? config.core.top_dir);
+  const deployDir = resolve(topDir, config.core.deploy_dir);
+  const revertDir = resolve(topDir, config.core.revert_dir);
+  const verifyDir = resolve(topDir, config.core.verify_dir);
+  const planPath = resolve(topDir, config.core.plan_file);
+
+  // Ensure plan file exists
+  if (!existsSync(planPath)) {
+    throw new Error(`plan file not found at ${planPath}. Run 'sqlever init' first.`);
+  }
+
+  // Read plan info
+  const planInfo = readPlanInfo(planPath);
+  const { expandName, contractName } = deriveChangeNames(opts.name);
+
+  // Check for duplicate names
+  if (planInfo.existingNames.has(expandName)) {
+    throw new Error(`change '${expandName}' already exists in the plan.`);
+  }
+  if (planInfo.existingNames.has(contractName)) {
+    throw new Error(`change '${contractName}' already exists in the plan.`);
+  }
+
+  // Get planner identity
+  const planner = getPlannerIdentity(environment);
+
+  // Build expand/contract config
+  const ecConfig: ExpandContractConfig = {
+    name: opts.name,
+    operation: inferOperation(opts),
+    table: opts.table,
+    oldColumn: opts.oldColumn,
+    newColumn: opts.newColumn,
+    newType: opts.newType,
+    oldType: opts.oldType,
+    castForward: opts.castForward,
+    castReverse: opts.castReverse,
+    note: opts.note,
+    requires: opts.requires,
+    conflicts: opts.conflicts,
+  };
+
+  // Create directories
+  mkdirSync(deployDir, { recursive: true });
+  mkdirSync(revertDir, { recursive: true });
+  if (!opts.noVerify) {
+    mkdirSync(verifyDir, { recursive: true });
+  }
+
+  // Check for existing files
+  const files: string[] = [];
+  const expandDeployPath = join(deployDir, `${expandName}.sql`);
+  const expandRevertPath = join(revertDir, `${expandName}.sql`);
+  const expandVerifyPath = join(verifyDir, `${expandName}.sql`);
+  const contractDeployPath = join(deployDir, `${contractName}.sql`);
+  const contractRevertPath = join(revertDir, `${contractName}.sql`);
+  const contractVerifyPath = join(verifyDir, `${contractName}.sql`);
+
+  for (const path of [expandDeployPath, expandRevertPath, contractDeployPath, contractRevertPath]) {
+    if (existsSync(path)) {
+      throw new Error(`file already exists at ${path}`);
+    }
+  }
+  if (!opts.noVerify) {
+    if (existsSync(expandVerifyPath)) {
+      throw new Error(`file already exists at ${expandVerifyPath}`);
+    }
+    if (existsSync(contractVerifyPath)) {
+      throw new Error(`file already exists at ${contractVerifyPath}`);
+    }
+  }
+
+  // Generate SQL files
+  writeFileSync(expandDeployPath, expandDeployTemplate(ecConfig), "utf-8");
+  files.push(expandDeployPath);
+  verbose(`Created ${expandDeployPath}`);
+
+  writeFileSync(expandRevertPath, expandRevertTemplate(ecConfig), "utf-8");
+  files.push(expandRevertPath);
+  verbose(`Created ${expandRevertPath}`);
+
+  if (!opts.noVerify) {
+    writeFileSync(expandVerifyPath, expandVerifyTemplate(ecConfig), "utf-8");
+    files.push(expandVerifyPath);
+    verbose(`Created ${expandVerifyPath}`);
+  }
+
+  writeFileSync(contractDeployPath, contractDeployTemplate(ecConfig), "utf-8");
+  files.push(contractDeployPath);
+  verbose(`Created ${contractDeployPath}`);
+
+  writeFileSync(contractRevertPath, contractRevertTemplate(ecConfig), "utf-8");
+  files.push(contractRevertPath);
+  verbose(`Created ${contractRevertPath}`);
+
+  if (!opts.noVerify) {
+    writeFileSync(contractVerifyPath, contractVerifyTemplate(ecConfig), "utf-8");
+    files.push(contractVerifyPath);
+    verbose(`Created ${contractVerifyPath}`);
+  }
+
+  // Build expand Change and append to plan
+  const expandTimestamp = nowTimestamp();
+  const expandRequires = [...opts.requires];
+  const expandChangeIdInput: ChangeIdInput = {
+    project: planInfo.projectName,
+    uri: planInfo.projectUri,
+    change: expandName,
+    parent: planInfo.lastChangeId,
+    planner_name: planner.name,
+    planner_email: planner.email,
+    planned_at: expandTimestamp,
+    requires: expandRequires,
+    conflicts: opts.conflicts,
+    note: opts.note ? `[expand] ${opts.note}` : `[expand] ${ecConfig.operation}: ${opts.table}.${opts.oldColumn} -> ${opts.newColumn}`,
+  };
+
+  const expandChangeId = computeChangeId(expandChangeIdInput);
+
+  const expandChange: Change = {
+    change_id: expandChangeId,
+    name: expandName,
+    project: planInfo.projectName,
+    note: expandChangeIdInput.note,
+    planner_name: planner.name,
+    planner_email: planner.email,
+    planned_at: expandTimestamp,
+    requires: expandRequires,
+    conflicts: opts.conflicts,
+    parent: planInfo.lastChangeId,
+  };
+
+  await appendChange(planPath, expandChange);
+  verbose(`Appended expand change to ${planPath}`);
+
+  // Build contract Change and append to plan
+  // Contract always requires the expand change
+  const contractTimestamp = nowTimestamp();
+  const contractRequires = [expandName];
+  const contractNote = opts.note
+    ? `[contract] ${opts.note}`
+    : `[contract] ${ecConfig.operation}: ${opts.table}.${opts.oldColumn} -> ${opts.newColumn}`;
+
+  const contractChangeIdInput: ChangeIdInput = {
+    project: planInfo.projectName,
+    uri: planInfo.projectUri,
+    change: contractName,
+    parent: expandChangeId,
+    planner_name: planner.name,
+    planner_email: planner.email,
+    planned_at: contractTimestamp,
+    requires: contractRequires,
+    conflicts: [],
+    note: contractNote,
+  };
+
+  const contractChangeId = computeChangeId(contractChangeIdInput);
+
+  const contractChange: Change = {
+    change_id: contractChangeId,
+    name: contractName,
+    project: planInfo.projectName,
+    note: contractNote,
+    planner_name: planner.name,
+    planner_email: planner.email,
+    planned_at: contractTimestamp,
+    requires: contractRequires,
+    conflicts: [],
+    parent: expandChangeId,
+  };
+
+  await appendChange(planPath, contractChange);
+  verbose(`Appended contract change to ${planPath}`);
+
+  info(`Added expand/contract pair: "${expandName}" + "${contractName}" to ${planPath}`);
+
+  return {
+    expandName,
+    contractName,
+    files,
+    expandChange,
+    contractChange,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI integration helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the expand/contract generator from CLI args.
+ *
+ * This is called from the add command when --expand is detected.
+ */
+export async function runExpandAdd(
+  opts: ExpandAddOptions,
+  config?: MergedConfig,
+  env?: Record<string, string | undefined>,
+): Promise<void> {
+  const environment = env ?? process.env;
+
+  // Load config if not provided
+  const { loadConfig } = await import("../config/index");
+  const cfg = config ?? loadConfig(opts.topDir, undefined, environment);
+
+  try {
+    await generateExpandContract(opts, cfg, environment);
+  } catch (err) {
+    error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}

--- a/tests/unit/expand-contract.test.ts
+++ b/tests/unit/expand-contract.test.ts
@@ -1,0 +1,982 @@
+// tests/unit/expand-contract.test.ts — Tests for expand/contract generator
+//
+// Validates: pair generation, plan linkage, deploy/revert/verify script
+// correctness, naming conventions, edge cases (partitioned tables, type
+// conversions), argument parsing, and validation.
+
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { rmSync } from "node:fs";
+
+import {
+  deriveChangeNames,
+  syncTriggerName,
+  syncTriggerFunctionName,
+  expandDeployTemplate,
+  expandRevertTemplate,
+  expandVerifyTemplate,
+  contractDeployTemplate,
+  contractRevertTemplate,
+  contractVerifyTemplate,
+  parseExpandArgs,
+  validateExpandOptions,
+  inferOperation,
+  generateExpandContract,
+  type ExpandContractConfig,
+} from "../../src/expand-contract/generator";
+import { readPlanInfo } from "../../src/commands/add";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function createTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "sqlever-ec-test-"));
+}
+
+/** Create a minimal project directory with sqitch.plan. */
+function setupProject(
+  dir: string,
+  planContent?: string,
+): { planPath: string; deployDir: string; revertDir: string; verifyDir: string } {
+  const planPath = join(dir, "sqitch.plan");
+  const deployDir = join(dir, "deploy");
+  const revertDir = join(dir, "revert");
+  const verifyDir = join(dir, "verify");
+
+  writeFileSync(
+    planPath,
+    planContent ??
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n",
+    "utf-8",
+  );
+
+  return { planPath, deployDir, revertDir, verifyDir };
+}
+
+/** Mock environment with planner identity. */
+const TEST_ENV: Record<string, string | undefined> = {
+  SQLEVER_USER_NAME: "Test User",
+  SQLEVER_USER_EMAIL: "test@example.com",
+};
+
+/** Create a minimal MergedConfig for testing. */
+function testConfig(topDir: string) {
+  return {
+    core: {
+      engine: undefined,
+      top_dir: topDir,
+      deploy_dir: "deploy",
+      revert_dir: "revert",
+      verify_dir: "verify",
+      plan_file: "sqitch.plan",
+    },
+    deploy: {
+      verify: true,
+      mode: "change" as const,
+      lock_retries: 0,
+      lock_timeout: "5s",
+      idle_in_transaction_session_timeout: "10min",
+      search_path: undefined,
+    },
+    engines: {},
+    targets: {},
+    analysis: {},
+    sqitchConf: { entries: [], rawLines: [], sections: new Set<string>() },
+    sqleverToml: null,
+  };
+}
+
+/** Build a default ExpandContractConfig for rename_col. */
+function renameConfig(overrides?: Partial<ExpandContractConfig>): ExpandContractConfig {
+  return {
+    name: "rename_users_name",
+    operation: "rename_col",
+    table: "public.users",
+    oldColumn: "name",
+    newColumn: "full_name",
+    oldType: "text",
+    note: "Rename name to full_name",
+    requires: [],
+    conflicts: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Naming conventions
+// ---------------------------------------------------------------------------
+
+describe("deriveChangeNames", () => {
+  it("appends _expand and _contract suffixes", () => {
+    const { expandName, contractName } = deriveChangeNames("rename_users_name");
+    expect(expandName).toBe("rename_users_name_expand");
+    expect(contractName).toBe("rename_users_name_contract");
+  });
+
+  it("handles hyphens in base name", () => {
+    const { expandName, contractName } = deriveChangeNames("rename-col");
+    expect(expandName).toBe("rename-col_expand");
+    expect(contractName).toBe("rename-col_contract");
+  });
+});
+
+describe("syncTriggerName", () => {
+  it("generates trigger name with sqlever_sync_ prefix", () => {
+    const name = syncTriggerName("public.users", "name", "full_name");
+    expect(name).toBe("sqlever_sync_users_name_full_name");
+    expect(name.startsWith("sqlever_sync_")).toBe(true);
+  });
+
+  it("strips schema from table name", () => {
+    const name = syncTriggerName("myschema.accounts", "email", "contact_email");
+    expect(name).toBe("sqlever_sync_accounts_email_contact_email");
+  });
+
+  it("handles unqualified table name", () => {
+    const name = syncTriggerName("users", "name", "full_name");
+    expect(name).toBe("sqlever_sync_users_name_full_name");
+  });
+});
+
+describe("syncTriggerFunctionName", () => {
+  it("generates function name with sqlever_sync_fn_ prefix", () => {
+    const name = syncTriggerFunctionName("public.users", "name", "full_name");
+    expect(name).toBe("sqlever_sync_fn_users_name_full_name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expand SQL Templates
+// ---------------------------------------------------------------------------
+
+describe("expandDeployTemplate", () => {
+  it("contains ALTER TABLE ADD COLUMN", () => {
+    const sql = expandDeployTemplate(renameConfig());
+    expect(sql).toContain("ALTER TABLE public.users ADD COLUMN full_name text");
+  });
+
+  it("contains sync trigger function with recursion guard", () => {
+    const sql = expandDeployTemplate(renameConfig());
+    expect(sql).toContain("pg_trigger_depth() < 2");
+    expect(sql).toContain("CREATE OR REPLACE FUNCTION sqlever_sync_fn_users_name_full_name()");
+  });
+
+  it("contains CREATE TRIGGER with BEFORE INSERT OR UPDATE", () => {
+    const sql = expandDeployTemplate(renameConfig());
+    expect(sql).toContain("CREATE TRIGGER sqlever_sync_users_name_full_name");
+    expect(sql).toContain("BEFORE INSERT OR UPDATE ON public.users");
+  });
+
+  it("wraps in transaction (BEGIN/COMMIT)", () => {
+    const sql = expandDeployTemplate(renameConfig());
+    expect(sql).toContain("BEGIN;");
+    expect(sql).toContain("COMMIT;");
+  });
+
+  it("uses custom cast expressions when provided", () => {
+    const sql = expandDeployTemplate(renameConfig({
+      newType: "integer",
+      castForward: "NEW.name::integer",
+      castReverse: "NEW.full_name::text",
+    }));
+    expect(sql).toContain("ADD COLUMN full_name integer");
+    expect(sql).toContain("(NEW.name::integer)");
+    expect(sql).toContain("(NEW.full_name::text)");
+  });
+
+  it("includes table and operation in header comment", () => {
+    const sql = expandDeployTemplate(renameConfig());
+    expect(sql).toContain("-- Table: public.users");
+    expect(sql).toContain("-- Operation: rename_col (name -> full_name)");
+  });
+});
+
+describe("expandRevertTemplate", () => {
+  it("drops trigger, function, and column", () => {
+    const sql = expandRevertTemplate(renameConfig());
+    expect(sql).toContain("DROP TRIGGER IF EXISTS sqlever_sync_users_name_full_name ON public.users");
+    expect(sql).toContain("DROP FUNCTION IF EXISTS sqlever_sync_fn_users_name_full_name()");
+    expect(sql).toContain("ALTER TABLE public.users DROP COLUMN IF EXISTS full_name");
+  });
+
+  it("wraps in transaction", () => {
+    const sql = expandRevertTemplate(renameConfig());
+    expect(sql).toContain("BEGIN;");
+    expect(sql).toContain("COMMIT;");
+  });
+});
+
+describe("expandVerifyTemplate", () => {
+  it("verifies new column and trigger existence", () => {
+    const sql = expandVerifyTemplate(renameConfig());
+    expect(sql).toContain("SELECT full_name FROM public.users WHERE false");
+    expect(sql).toContain("tgname = 'sqlever_sync_users_name_full_name'");
+  });
+
+  it("uses ROLLBACK (not COMMIT) for verify", () => {
+    const sql = expandVerifyTemplate(renameConfig());
+    expect(sql).toContain("ROLLBACK;");
+    expect(sql).not.toContain("COMMIT;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract SQL Templates
+// ---------------------------------------------------------------------------
+
+describe("contractDeployTemplate", () => {
+  it("verifies backfill completeness", () => {
+    const sql = contractDeployTemplate(renameConfig());
+    expect(sql).toContain("Backfill incomplete");
+    expect(sql).toContain("WHERE name IS NOT NULL");
+    expect(sql).toContain("AND full_name IS NULL");
+  });
+
+  it("drops trigger, function, and old column", () => {
+    const sql = contractDeployTemplate(renameConfig());
+    expect(sql).toContain("DROP TRIGGER IF EXISTS sqlever_sync_users_name_full_name");
+    expect(sql).toContain("DROP FUNCTION IF EXISTS sqlever_sync_fn_users_name_full_name()");
+    expect(sql).toContain("ALTER TABLE public.users DROP COLUMN name");
+  });
+
+  it("wraps in transaction", () => {
+    const sql = contractDeployTemplate(renameConfig());
+    expect(sql).toContain("BEGIN;");
+    expect(sql).toContain("COMMIT;");
+  });
+});
+
+describe("contractRevertTemplate", () => {
+  it("re-adds old column", () => {
+    const sql = contractRevertTemplate(renameConfig());
+    expect(sql).toContain("ALTER TABLE public.users ADD COLUMN name text");
+  });
+
+  it("re-creates sync trigger", () => {
+    const sql = contractRevertTemplate(renameConfig());
+    expect(sql).toContain("CREATE OR REPLACE FUNCTION sqlever_sync_fn_users_name_full_name()");
+    expect(sql).toContain("CREATE TRIGGER sqlever_sync_users_name_full_name");
+  });
+
+  it("backfills old column from new", () => {
+    const sql = contractRevertTemplate(renameConfig());
+    expect(sql).toContain("UPDATE public.users SET name = full_name");
+  });
+});
+
+describe("contractVerifyTemplate", () => {
+  it("verifies old column is gone", () => {
+    const sql = contractVerifyTemplate(renameConfig());
+    expect(sql).toContain("column_name = 'name'");
+    expect(sql).toContain("Old column name still exists");
+  });
+
+  it("verifies new column still exists", () => {
+    const sql = contractVerifyTemplate(renameConfig());
+    expect(sql).toContain("SELECT full_name FROM public.users WHERE false");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseExpandArgs
+// ---------------------------------------------------------------------------
+
+describe("parseExpandArgs", () => {
+  it("parses all expand-specific flags", () => {
+    const opts = parseExpandArgs([
+      "rename_users_name", "--expand",
+      "--table", "public.users",
+      "--old-column", "name",
+      "--new-column", "full_name",
+      "--old-type", "varchar(255)",
+      "--new-type", "text",
+      "-n", "Rename column",
+    ]);
+    expect(opts.name).toBe("rename_users_name");
+    expect(opts.expand).toBe(true);
+    expect(opts.table).toBe("public.users");
+    expect(opts.oldColumn).toBe("name");
+    expect(opts.newColumn).toBe("full_name");
+    expect(opts.oldType).toBe("varchar(255)");
+    expect(opts.newType).toBe("text");
+    expect(opts.note).toBe("Rename column");
+  });
+
+  it("parses cast expressions", () => {
+    const opts = parseExpandArgs([
+      "change_type", "--expand",
+      "--table", "t",
+      "--old-column", "a",
+      "--new-column", "b",
+      "--cast-forward", "NEW.a::integer",
+      "--cast-reverse", "NEW.b::text",
+    ]);
+    expect(opts.castForward).toBe("NEW.a::integer");
+    expect(opts.castReverse).toBe("NEW.b::text");
+  });
+
+  it("parses requires and conflicts", () => {
+    const opts = parseExpandArgs([
+      "rename_col", "--expand",
+      "--table", "t",
+      "--old-column", "a",
+      "--new-column", "b",
+      "-r", "dep1",
+      "-r", "dep2",
+      "-c", "conflict1",
+    ]);
+    expect(opts.requires).toEqual(["dep1", "dep2"]);
+    expect(opts.conflicts).toEqual(["conflict1"]);
+  });
+
+  it("defaults expand to false when flag not present", () => {
+    const opts = parseExpandArgs(["some_name"]);
+    expect(opts.expand).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateExpandOptions
+// ---------------------------------------------------------------------------
+
+describe("validateExpandOptions", () => {
+  it("returns null for valid options", () => {
+    const err = validateExpandOptions({
+      name: "rename_col",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    });
+    expect(err).toBeNull();
+  });
+
+  it("rejects missing name", () => {
+    const err = validateExpandOptions({
+      name: "",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "t",
+      oldColumn: "a",
+      newColumn: "b",
+    });
+    expect(err).toContain("change name is required");
+  });
+
+  it("rejects invalid name", () => {
+    const err = validateExpandOptions({
+      name: "123-bad",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "t",
+      oldColumn: "a",
+      newColumn: "b",
+    });
+    expect(err).toContain("invalid change name");
+  });
+
+  it("rejects missing table", () => {
+    const err = validateExpandOptions({
+      name: "rename_col",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "",
+      oldColumn: "a",
+      newColumn: "b",
+    });
+    expect(err).toContain("--table is required");
+  });
+
+  it("rejects missing old-column", () => {
+    const err = validateExpandOptions({
+      name: "rename_col",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "t",
+      oldColumn: "",
+      newColumn: "b",
+    });
+    expect(err).toContain("--old-column is required");
+  });
+
+  it("rejects missing new-column", () => {
+    const err = validateExpandOptions({
+      name: "rename_col",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "t",
+      oldColumn: "a",
+      newColumn: "",
+    });
+    expect(err).toContain("--new-column is required");
+  });
+
+  it("rejects same old and new column", () => {
+    const err = validateExpandOptions({
+      name: "rename_col",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "t",
+      oldColumn: "a",
+      newColumn: "a",
+    });
+    expect(err).toContain("old column and new column must be different");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferOperation
+// ---------------------------------------------------------------------------
+
+describe("inferOperation", () => {
+  it("infers rename_col when types are same or absent", () => {
+    const op = inferOperation({
+      name: "x", note: "", requires: [], conflicts: [], noVerify: false,
+      expand: true, table: "t", oldColumn: "a", newColumn: "b",
+    });
+    expect(op).toBe("rename_col");
+  });
+
+  it("infers change_type when old and new types differ", () => {
+    const op = inferOperation({
+      name: "x", note: "", requires: [], conflicts: [], noVerify: false,
+      expand: true, table: "t", oldColumn: "a", newColumn: "b",
+      oldType: "varchar", newType: "text",
+    });
+    expect(op).toBe("change_type");
+  });
+
+  it("infers rename_col when types are the same", () => {
+    const op = inferOperation({
+      name: "x", note: "", requires: [], conflicts: [], noVerify: false,
+      expand: true, table: "t", oldColumn: "a", newColumn: "b",
+      oldType: "text", newType: "text",
+    });
+    expect(op).toBe("rename_col");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateExpandContract — full integration
+// ---------------------------------------------------------------------------
+
+describe("generateExpandContract", () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates all 6 SQL files (deploy/revert/verify for expand and contract)", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const result = await generateExpandContract({
+      name: "rename_users_name",
+      note: "Rename name to full_name",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+      oldType: "text",
+    }, cfg, TEST_ENV);
+
+    expect(result.files.length).toBe(6);
+    expect(existsSync(join(tmpDir, "deploy", "rename_users_name_expand.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "revert", "rename_users_name_expand.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "verify", "rename_users_name_expand.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "deploy", "rename_users_name_contract.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "revert", "rename_users_name_contract.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "verify", "rename_users_name_contract.sql"))).toBe(true);
+  });
+
+  it("skips verify files when noVerify is true", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const result = await generateExpandContract({
+      name: "rename_users_name",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: true,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    expect(result.files.length).toBe(4);
+    expect(existsSync(join(tmpDir, "verify", "rename_users_name_expand.sql"))).toBe(false);
+    expect(existsSync(join(tmpDir, "verify", "rename_users_name_contract.sql"))).toBe(false);
+  });
+
+  it("appends both changes to the plan file", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await generateExpandContract({
+      name: "rename_users_name",
+      note: "test",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const lines = plan.split("\n").filter(l => !l.startsWith("%") && l.trim() !== "");
+    expect(lines.length).toBe(2);
+    expect(lines[0]).toMatch(/^rename_users_name_expand\s/);
+    expect(lines[1]).toMatch(/^rename_users_name_contract\s/);
+  });
+
+  it("contract change depends on expand change in plan", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await generateExpandContract({
+      name: "rename_users_name",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const contractLine = plan.split("\n").find(l => l.startsWith("rename_users_name_contract"));
+    expect(contractLine).toBeTruthy();
+    expect(contractLine).toContain("[rename_users_name_expand]");
+  });
+
+  it("expand change inherits user-specified requires", async () => {
+    setupProject(tmpDir,
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "create_schema 2024-01-15T10:30:00Z Test User <test@example.com> # schema\n",
+    );
+    const cfg = testConfig(tmpDir);
+
+    await generateExpandContract({
+      name: "rename_users_name",
+      note: "",
+      requires: ["create_schema"],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    const plan = readFileSync(join(tmpDir, "sqitch.plan"), "utf-8");
+    const expandLine = plan.split("\n").find(l => l.startsWith("rename_users_name_expand"));
+    expect(expandLine).toBeTruthy();
+    expect(expandLine).toContain("[create_schema]");
+  });
+
+  it("errors on duplicate expand name", async () => {
+    setupProject(tmpDir,
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "rename_users_name_expand 2024-01-15T10:30:00Z Test User <test@example.com> # existing\n",
+    );
+    const cfg = testConfig(tmpDir);
+
+    await expect(
+      generateExpandContract({
+        name: "rename_users_name",
+        note: "",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+        expand: true,
+        table: "public.users",
+        oldColumn: "name",
+        newColumn: "full_name",
+      }, cfg, TEST_ENV),
+    ).rejects.toThrow("already exists");
+  });
+
+  it("errors on duplicate contract name", async () => {
+    setupProject(tmpDir,
+      "%syntax-version=1.0.0\n" +
+      "%project=myproject\n" +
+      "\n" +
+      "rename_users_name_contract 2024-01-15T10:30:00Z Test User <test@example.com> # existing\n",
+    );
+    const cfg = testConfig(tmpDir);
+
+    await expect(
+      generateExpandContract({
+        name: "rename_users_name",
+        note: "",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+        expand: true,
+        table: "public.users",
+        oldColumn: "name",
+        newColumn: "full_name",
+      }, cfg, TEST_ENV),
+    ).rejects.toThrow("already exists");
+  });
+
+  it("errors when plan file is missing", async () => {
+    // No plan file setup
+    const cfg = testConfig(tmpDir);
+
+    await expect(
+      generateExpandContract({
+        name: "rename_users_name",
+        note: "",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+        expand: true,
+        table: "public.users",
+        oldColumn: "name",
+        newColumn: "full_name",
+      }, cfg, TEST_ENV),
+    ).rejects.toThrow("plan file not found");
+  });
+
+  it("errors when deploy file already exists", async () => {
+    setupProject(tmpDir);
+    mkdirSync(join(tmpDir, "deploy"), { recursive: true });
+    writeFileSync(join(tmpDir, "deploy", "rename_users_name_expand.sql"), "existing", "utf-8");
+    const cfg = testConfig(tmpDir);
+
+    await expect(
+      generateExpandContract({
+        name: "rename_users_name",
+        note: "",
+        requires: [],
+        conflicts: [],
+        noVerify: false,
+        expand: true,
+        table: "public.users",
+        oldColumn: "name",
+        newColumn: "full_name",
+      }, cfg, TEST_ENV),
+    ).rejects.toThrow("file already exists");
+  });
+
+  it("creates correct deploy script content for expand", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await generateExpandContract({
+      name: "rename_users_name",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+      oldType: "text",
+    }, cfg, TEST_ENV);
+
+    const deploySql = readFileSync(join(tmpDir, "deploy", "rename_users_name_expand.sql"), "utf-8");
+    expect(deploySql).toContain("ALTER TABLE public.users ADD COLUMN full_name text");
+    expect(deploySql).toContain("pg_trigger_depth()");
+    expect(deploySql).toContain("CREATE TRIGGER sqlever_sync_users_name_full_name");
+  });
+
+  it("creates correct deploy script content for contract", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await generateExpandContract({
+      name: "rename_users_name",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    const deploySql = readFileSync(join(tmpDir, "deploy", "rename_users_name_contract.sql"), "utf-8");
+    expect(deploySql).toContain("Backfill incomplete");
+    expect(deploySql).toContain("DROP TRIGGER IF EXISTS sqlever_sync_users_name_full_name");
+    expect(deploySql).toContain("ALTER TABLE public.users DROP COLUMN name");
+  });
+
+  it("handles type change operation with cast expressions", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await generateExpandContract({
+      name: "change_users_age",
+      note: "Convert age from text to integer",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "age",
+      newColumn: "age_int",
+      oldType: "text",
+      newType: "integer",
+      castForward: "NEW.age::integer",
+      castReverse: "NEW.age_int::text",
+    }, cfg, TEST_ENV);
+
+    const expandSql = readFileSync(join(tmpDir, "deploy", "change_users_age_expand.sql"), "utf-8");
+    expect(expandSql).toContain("ADD COLUMN age_int integer");
+    expect(expandSql).toContain("(NEW.age::integer)");
+    expect(expandSql).toContain("(NEW.age_int::text)");
+  });
+
+  it("adds [expand] and [contract] prefixes to notes", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const result = await generateExpandContract({
+      name: "rename_users_name",
+      note: "Rename name column",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    expect(result.expandChange.note).toContain("[expand]");
+    expect(result.contractChange.note).toContain("[contract]");
+  });
+
+  it("generates auto-notes when no note is provided", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const result = await generateExpandContract({
+      name: "rename_users_name",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    expect(result.expandChange.note).toContain("[expand]");
+    expect(result.expandChange.note).toContain("rename_col");
+    expect(result.expandChange.note).toContain("public.users.name");
+  });
+
+  it("sets correct parent chain (expand -> contract)", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    const result = await generateExpandContract({
+      name: "rename_users_name",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    // Contract's parent should be expand's change_id
+    expect(result.contractChange.parent).toBe(result.expandChange.change_id);
+  });
+
+  it("handles schema-qualified table in partitioned table scenario", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await generateExpandContract({
+      name: "rename_orders_status",
+      note: "Partitioned table rename",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "sales.orders",
+      oldColumn: "status",
+      newColumn: "order_status",
+      oldType: "varchar(50)",
+    }, cfg, TEST_ENV);
+
+    const expandSql = readFileSync(join(tmpDir, "deploy", "rename_orders_status_expand.sql"), "utf-8");
+    // Trigger is installed on parent table (PG 14+ inherits to partitions per SPEC 5.4)
+    expect(expandSql).toContain("ON sales.orders");
+    expect(expandSql).toContain("ADD COLUMN order_status varchar(50)");
+
+    // Trigger name strips schema
+    expect(expandSql).toContain("sqlever_sync_orders_status_order_status");
+  });
+
+  it("plan file has correct readback after generation", async () => {
+    setupProject(tmpDir);
+    const cfg = testConfig(tmpDir);
+
+    await generateExpandContract({
+      name: "rename_users_name",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    const planInfo = readPlanInfo(join(tmpDir, "sqitch.plan"));
+    expect(planInfo.existingNames.has("rename_users_name_expand")).toBe(true);
+    expect(planInfo.existingNames.has("rename_users_name_contract")).toBe(true);
+    expect(planInfo.lastChangeId).toBeTruthy();
+  });
+
+  it("creates directories if they do not exist", async () => {
+    // Only create plan file, not the dirs
+    const planPath = join(tmpDir, "sqitch.plan");
+    writeFileSync(planPath, "%syntax-version=1.0.0\n%project=myproject\n\n", "utf-8");
+    const cfg = testConfig(tmpDir);
+
+    await generateExpandContract({
+      name: "rename_users_name",
+      note: "",
+      requires: [],
+      conflicts: [],
+      noVerify: false,
+      expand: true,
+      table: "public.users",
+      oldColumn: "name",
+      newColumn: "full_name",
+    }, cfg, TEST_ENV);
+
+    expect(existsSync(join(tmpDir, "deploy"))).toBe(true);
+    expect(existsSync(join(tmpDir, "revert"))).toBe(true);
+    expect(existsSync(join(tmpDir, "verify"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI integration (subprocess)
+// ---------------------------------------------------------------------------
+
+describe("sqlever add --expand (subprocess)", () => {
+  const CWD = import.meta.dir + "/../..";
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runCli(
+    ...args: string[]
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const proc = Bun.spawn(["bun", "run", join(CWD, "src/cli.ts"), ...args], {
+      cwd: tmpDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        SQLEVER_USER_NAME: "CLI Test",
+        SQLEVER_USER_EMAIL: "cli@test.com",
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("creates expand/contract pair via CLI", async () => {
+    setupProject(tmpDir);
+
+    const { stdout, exitCode } = await runCli(
+      "add", "rename_users_name", "--expand",
+      "--table", "public.users",
+      "--old-column", "name",
+      "--new-column", "full_name",
+      "--old-type", "text",
+      "-n", "Rename column",
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("expand/contract pair");
+    expect(existsSync(join(tmpDir, "deploy", "rename_users_name_expand.sql"))).toBe(true);
+    expect(existsSync(join(tmpDir, "deploy", "rename_users_name_contract.sql"))).toBe(true);
+  });
+
+  it("exits 1 when --table is missing", async () => {
+    setupProject(tmpDir);
+
+    const { exitCode, stderr } = await runCli(
+      "add", "rename_col", "--expand",
+      "--old-column", "a",
+      "--new-column", "b",
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--table is required");
+  });
+});


### PR DESCRIPTION
## Summary
- Implements issue #98: creates `src/expand-contract/generator.ts` with the expand/contract migration pair generator per SPEC Section 5.4
- `sqlever add <name> --expand --table <table> --old-column <old> --new-column <new>` generates a linked expand + contract migration pair
- **Expand deploy**: adds new column alongside old + installs bidirectional sync trigger with `pg_trigger_depth()` recursion guard (per SPEC 5.4 trigger edge case #1)
- **Contract deploy**: verifies backfill completeness (no NULLs) + drops sync trigger + drops old column
- Contract change automatically depends on expand change in the plan via `[expand_name]` dependency
- Supports `rename_col` and `change_type` operations with custom `--cast-forward` / `--cast-reverse` expressions
- Schema-qualified tables handled correctly; trigger installed on parent (partitioned table support per SPEC 5.4 edge case #3)
- CLI wired into `add` command: `--expand` flag routes to the expand/contract generator
- 58 tests covering: naming, SQL template correctness, argument parsing, validation, plan linkage, duplicate detection, file creation, type changes, partitioned tables, CLI subprocess

## Test plan
- [x] 58 unit tests pass (`bun test tests/unit/expand-contract.test.ts`)
- [x] All existing tests still pass (1838 pass, 8 pre-existing integration failures requiring PG)
- [x] No new TypeScript errors in added files
- [x] CLI integration tests verify subprocess behavior

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)