### PR TITLE
F3: Batch monitoring — replication lag + VACUUM pressure

### DIFF
--- a/src/batch/progress.ts
+++ b/src/batch/progress.ts
@@ -1,0 +1,579 @@
+// src/batch/progress.ts — Batch job progress monitoring (SPEC Section 5.5)
+//
+// Monitors batch job health across five dimensions:
+//
+// 1. **Row counting**: rows done vs total, percentage, ETA based on
+//    observed throughput.
+//
+// 2. **Replication lag**: queries pg_stat_replication.replay_lag and
+//    pauses the batch when lag exceeds a configurable threshold (default
+//    10s). Most production databases have replicas; unthrottled batched
+//    writes cause replica lag incidents.
+//
+// 3. **VACUUM pressure**: queries pg_stat_user_tables.n_dead_tup and
+//    computes the dead tuple ratio n_dead_tup/(n_live_tup+n_dead_tup).
+//    Pauses when the ratio exceeds a configurable threshold (default 10%).
+//    Many small transactions create dead tuples; autovacuum may not keep
+//    up on hot tables.
+//
+// 4. **Heartbeat staleness**: detects dead workers by comparing
+//    heartbeat_at to a configurable threshold (default 5 min). Handles
+//    OOM kill, network partition, etc.
+//
+// 5. **pg_stat_activity**: shows the current batch query, duration, and
+//    wait event for operator visibility.
+
+import type { DatabaseClient, QueryResult } from "../db/client";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Progress snapshot for a batch job. */
+export interface BatchProgress {
+  /** Rows processed so far. */
+  rowsDone: number;
+  /** Total rows to process (estimated). */
+  rowsTotal: number;
+  /** Completion percentage (0-100). */
+  percentage: number;
+  /** Estimated time remaining in milliseconds, or null if not enough data. */
+  etaMs: number | null;
+  /** Rows processed per second (throughput). */
+  rowsPerSecond: number;
+}
+
+/** Replication lag information from pg_stat_replication. */
+export interface ReplicationLagInfo {
+  /** Replay lag as an interval string from Postgres (e.g. "00:00:05.123"). */
+  replayLag: string | null;
+  /** Replay lag converted to seconds. */
+  replayLagSeconds: number;
+  /** Whether lag exceeds the configured threshold. */
+  exceedsThreshold: boolean;
+  /** The configured threshold in seconds. */
+  thresholdSeconds: number;
+  /** Name of the replica (application_name from pg_stat_replication). */
+  replicaName: string | null;
+}
+
+/** VACUUM pressure information from pg_stat_user_tables. */
+export interface VacuumPressureInfo {
+  /** Number of dead tuples. */
+  deadTuples: number;
+  /** Number of live tuples. */
+  liveTuples: number;
+  /** Dead tuple ratio: n_dead_tup / (n_live_tup + n_dead_tup). */
+  deadTupleRatio: number;
+  /** Whether the ratio exceeds the configured threshold. */
+  exceedsThreshold: boolean;
+  /** The configured threshold ratio (0-1). */
+  thresholdRatio: number;
+  /** Schema-qualified table name. */
+  tableName: string;
+}
+
+/** Heartbeat staleness detection result. */
+export interface HeartbeatStatus {
+  /** Job ID. */
+  jobId: number;
+  /** Last heartbeat timestamp. */
+  lastHeartbeat: Date | null;
+  /** Age of heartbeat in milliseconds. */
+  ageMs: number;
+  /** Whether the heartbeat is stale (exceeds threshold). */
+  isStale: boolean;
+  /** The configured staleness threshold in milliseconds. */
+  thresholdMs: number;
+}
+
+/** Current batch query from pg_stat_activity. */
+export interface BatchQueryInfo {
+  /** Process ID (pid) from pg_stat_activity. */
+  pid: number;
+  /** The currently executing query text. */
+  query: string;
+  /** How long the query has been running, in milliseconds. */
+  durationMs: number;
+  /** Current wait event type (or null if not waiting). */
+  waitEventType: string | null;
+  /** Current wait event (or null if not waiting). */
+  waitEvent: string | null;
+  /** State of the backend (active, idle, etc.). */
+  state: string;
+  /** Application name (should match sqlever/batch/...). */
+  applicationName: string;
+}
+
+/** Configuration for the progress monitor. */
+export interface ProgressMonitorConfig {
+  /** Replication lag threshold in seconds. Default: 10. */
+  replicationLagThresholdSeconds?: number;
+  /** Dead tuple ratio threshold (0-1). Default: 0.10 (10%). */
+  maxDeadTupleRatio?: number;
+  /** Heartbeat staleness threshold in milliseconds. Default: 300000 (5 min). */
+  heartbeatStalenessMs?: number;
+  /** Schema for sqlever tables. Default: "sqlever". */
+  schema?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default replication lag threshold: 10 seconds (SPEC Section 5.5). */
+export const DEFAULT_REPLICATION_LAG_THRESHOLD_SECONDS = 10;
+
+/** Default max dead tuple ratio: 10% (SPEC Section 5.5). */
+export const DEFAULT_MAX_DEAD_TUPLE_RATIO = 0.10;
+
+/** Default heartbeat staleness threshold: 5 minutes (SPEC Section 5.5). */
+export const DEFAULT_HEARTBEAT_STALENESS_MS = 300_000;
+
+// ---------------------------------------------------------------------------
+// Pure functions (no DB dependency — easily testable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate batch progress: percentage, ETA, throughput.
+ *
+ * ETA is computed from observed throughput (rowsDone / elapsedMs). Returns
+ * null when rowsDone is 0 (not enough data to extrapolate).
+ */
+export function calculateProgress(
+  rowsDone: number,
+  rowsTotal: number,
+  elapsedMs: number,
+): BatchProgress {
+  if (rowsTotal <= 0) {
+    return {
+      rowsDone,
+      rowsTotal: 0,
+      percentage: 100,
+      etaMs: null,
+      rowsPerSecond: 0,
+    };
+  }
+
+  const clamped = Math.min(rowsDone, rowsTotal);
+  const percentage = (clamped / rowsTotal) * 100;
+
+  let rowsPerSecond = 0;
+  let etaMs: number | null = null;
+
+  if (elapsedMs > 0 && rowsDone > 0) {
+    rowsPerSecond = (rowsDone / elapsedMs) * 1000;
+    const rowsRemaining = rowsTotal - clamped;
+    etaMs = rowsRemaining > 0 ? (rowsRemaining / rowsPerSecond) * 1000 : 0;
+  }
+
+  return {
+    rowsDone: clamped,
+    rowsTotal,
+    percentage: Math.round(percentage * 100) / 100,
+    etaMs: etaMs !== null ? Math.round(etaMs) : null,
+    rowsPerSecond: Math.round(rowsPerSecond * 100) / 100,
+  };
+}
+
+/**
+ * Parse a PostgreSQL interval string (from replay_lag) to seconds.
+ *
+ * Handles formats:
+ *   - "HH:MM:SS" or "HH:MM:SS.fff"
+ *   - null or empty -> 0
+ */
+export function parseIntervalToSeconds(interval: string | null): number {
+  if (!interval || interval.trim() === "") {
+    return 0;
+  }
+
+  const trimmed = interval.trim();
+
+  // Match HH:MM:SS or HH:MM:SS.fractional
+  const match = trimmed.match(
+    /^(?:(\d+)\s+days?\s+)?(\d{1,2}):(\d{2}):(\d{2})(?:\.(\d+))?$/,
+  );
+  if (match) {
+    const days = match[1] ? parseInt(match[1], 10) : 0;
+    const hours = parseInt(match[2]!, 10);
+    const minutes = parseInt(match[3]!, 10);
+    const seconds = parseInt(match[4]!, 10);
+    const fraction = match[5] ? parseFloat(`0.${match[5]}`) : 0;
+    return days * 86400 + hours * 3600 + minutes * 60 + seconds + fraction;
+  }
+
+  // Attempt to parse as a bare number (seconds)
+  const num = parseFloat(trimmed);
+  if (!isNaN(num)) {
+    return num;
+  }
+
+  return 0;
+}
+
+/**
+ * Compute the dead tuple ratio.
+ *
+ * Formula: n_dead_tup / (n_live_tup + n_dead_tup)
+ *
+ * Returns 0 when both are 0 (empty table — no pressure).
+ */
+export function computeDeadTupleRatio(
+  deadTuples: number,
+  liveTuples: number,
+): number {
+  const total = liveTuples + deadTuples;
+  if (total <= 0) return 0;
+  return deadTuples / total;
+}
+
+/**
+ * Determine if a heartbeat is stale.
+ *
+ * @param heartbeatAt - Last heartbeat timestamp (null = never heartbeated)
+ * @param thresholdMs - Staleness threshold in milliseconds
+ * @param now - Current time (injectable for testing)
+ * @returns Object with ageMs and isStale
+ */
+export function checkHeartbeatStaleness(
+  heartbeatAt: Date | null,
+  thresholdMs: number,
+  now: Date = new Date(),
+): { ageMs: number; isStale: boolean } {
+  if (heartbeatAt === null) {
+    // Never heartbeated — always stale
+    return { ageMs: Infinity, isStale: true };
+  }
+
+  const ageMs = now.getTime() - heartbeatAt.getTime();
+  return {
+    ageMs,
+    isStale: ageMs > thresholdMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ProgressMonitor class — queries Postgres for live metrics
+// ---------------------------------------------------------------------------
+
+/**
+ * Monitors batch job progress and Postgres health metrics.
+ *
+ * Queries pg_stat_replication, pg_stat_user_tables, and pg_stat_activity
+ * to provide real-time visibility into batch job impact.
+ */
+export class ProgressMonitor {
+  private db: DatabaseClient;
+  private config: Required<ProgressMonitorConfig>;
+
+  constructor(db: DatabaseClient, config: ProgressMonitorConfig = {}) {
+    this.db = db;
+    this.config = {
+      replicationLagThresholdSeconds:
+        config.replicationLagThresholdSeconds ??
+        DEFAULT_REPLICATION_LAG_THRESHOLD_SECONDS,
+      maxDeadTupleRatio:
+        config.maxDeadTupleRatio ?? DEFAULT_MAX_DEAD_TUPLE_RATIO,
+      heartbeatStalenessMs:
+        config.heartbeatStalenessMs ?? DEFAULT_HEARTBEAT_STALENESS_MS,
+      schema: config.schema ?? "sqlever",
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Replication lag monitoring (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Query pg_stat_replication for the maximum replay lag across all
+   * replicas. Returns lag info for the most-lagged replica.
+   *
+   * When no replicas are connected, returns zero lag (no pause needed).
+   */
+  async getReplicationLag(): Promise<ReplicationLagInfo> {
+    const result: QueryResult<{
+      replay_lag: string | null;
+      application_name: string | null;
+    }> = await this.db.query(
+      `SELECT replay_lag::text, application_name
+       FROM pg_stat_replication
+       ORDER BY replay_lag DESC NULLS LAST
+       LIMIT 1`,
+    );
+
+    if (result.rows.length === 0) {
+      // No replicas — no lag concern
+      return {
+        replayLag: null,
+        replayLagSeconds: 0,
+        exceedsThreshold: false,
+        thresholdSeconds: this.config.replicationLagThresholdSeconds,
+        replicaName: null,
+      };
+    }
+
+    const row = result.rows[0]!;
+    const lagSeconds = parseIntervalToSeconds(row.replay_lag);
+
+    return {
+      replayLag: row.replay_lag,
+      replayLagSeconds: lagSeconds,
+      exceedsThreshold: lagSeconds > this.config.replicationLagThresholdSeconds,
+      thresholdSeconds: this.config.replicationLagThresholdSeconds,
+      replicaName: row.application_name ?? null,
+    };
+  }
+
+  /**
+   * Check if replication lag requires pausing the batch.
+   *
+   * Returns true if any replica's replay_lag exceeds the threshold.
+   */
+  async shouldPauseForReplicationLag(): Promise<boolean> {
+    const lag = await this.getReplicationLag();
+    return lag.exceedsThreshold;
+  }
+
+  // -----------------------------------------------------------------------
+  // VACUUM pressure monitoring (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Query pg_stat_user_tables for dead tuple information on a specific
+   * table. Computes the dead tuple ratio and checks against threshold.
+   *
+   * @param schemaName - Table schema (e.g., "public")
+   * @param tableName - Table name (e.g., "users")
+   */
+  async getVacuumPressure(
+    schemaName: string,
+    tableName: string,
+  ): Promise<VacuumPressureInfo> {
+    const result: QueryResult<{
+      n_dead_tup: string;
+      n_live_tup: string;
+    }> = await this.db.query(
+      `SELECT n_dead_tup::text, n_live_tup::text
+       FROM pg_stat_user_tables
+       WHERE schemaname = $1 AND relname = $2`,
+      [schemaName, tableName],
+    );
+
+    if (result.rows.length === 0) {
+      // Table not found in stats — assume no pressure
+      return {
+        deadTuples: 0,
+        liveTuples: 0,
+        deadTupleRatio: 0,
+        exceedsThreshold: false,
+        thresholdRatio: this.config.maxDeadTupleRatio,
+        tableName: `${schemaName}.${tableName}`,
+      };
+    }
+
+    const row = result.rows[0]!;
+    const deadTuples = parseInt(row.n_dead_tup, 10);
+    const liveTuples = parseInt(row.n_live_tup, 10);
+    const ratio = computeDeadTupleRatio(deadTuples, liveTuples);
+
+    return {
+      deadTuples,
+      liveTuples,
+      deadTupleRatio: Math.round(ratio * 10000) / 10000,
+      exceedsThreshold: ratio > this.config.maxDeadTupleRatio,
+      thresholdRatio: this.config.maxDeadTupleRatio,
+      tableName: `${schemaName}.${tableName}`,
+    };
+  }
+
+  /**
+   * Check if VACUUM pressure requires pausing the batch.
+   *
+   * Returns true if the dead tuple ratio exceeds the configured threshold.
+   */
+  async shouldPauseForVacuumPressure(
+    schemaName: string,
+    tableName: string,
+  ): Promise<boolean> {
+    const pressure = await this.getVacuumPressure(schemaName, tableName);
+    return pressure.exceedsThreshold;
+  }
+
+  // -----------------------------------------------------------------------
+  // Heartbeat staleness detection (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Check heartbeat staleness for a specific job.
+   *
+   * Queries the batch_jobs table for the job's heartbeat_at and
+   * determines if the worker is likely dead.
+   */
+  async checkJobHeartbeat(
+    jobId: number,
+    partitionId: number,
+  ): Promise<HeartbeatStatus> {
+    const s = quoteIdent(this.config.schema);
+
+    const result: QueryResult<{ heartbeat_at: Date | null }> =
+      await this.db.query(
+        `SELECT heartbeat_at
+         FROM ${s}."batch_jobs"
+         WHERE id = $1 AND partition_id = $2 AND status = 'running'`,
+        [jobId, partitionId],
+      );
+
+    if (result.rows.length === 0) {
+      return {
+        jobId,
+        lastHeartbeat: null,
+        ageMs: Infinity,
+        isStale: true,
+        thresholdMs: this.config.heartbeatStalenessMs,
+      };
+    }
+
+    const heartbeatAt = result.rows[0]!.heartbeat_at;
+    const { ageMs, isStale } = checkHeartbeatStaleness(
+      heartbeatAt,
+      this.config.heartbeatStalenessMs,
+    );
+
+    return {
+      jobId,
+      lastHeartbeat: heartbeatAt,
+      ageMs,
+      isStale,
+      thresholdMs: this.config.heartbeatStalenessMs,
+    };
+  }
+
+  /**
+   * Find all running jobs with stale heartbeats.
+   *
+   * Returns heartbeat status for each stale job. Does NOT mark them
+   * as failed — that responsibility belongs to BatchQueue.detectStaleJobs().
+   */
+  async findStaleWorkers(): Promise<HeartbeatStatus[]> {
+    const s = quoteIdent(this.config.schema);
+
+    const result: QueryResult<{
+      id: number;
+      heartbeat_at: Date | null;
+    }> = await this.db.query(
+      `SELECT id, heartbeat_at
+       FROM ${s}."batch_jobs"
+       WHERE status = 'running'
+         AND (heartbeat_at IS NULL
+              OR heartbeat_at < now() - ($1 || ' milliseconds')::interval)`,
+      [this.config.heartbeatStalenessMs],
+    );
+
+    return result.rows.map((row) => {
+      const { ageMs, isStale } = checkHeartbeatStaleness(
+        row.heartbeat_at,
+        this.config.heartbeatStalenessMs,
+      );
+
+      return {
+        jobId: row.id,
+        lastHeartbeat: row.heartbeat_at,
+        ageMs,
+        isStale,
+        thresholdMs: this.config.heartbeatStalenessMs,
+      };
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // pg_stat_activity monitoring (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Query pg_stat_activity for the current batch query.
+   *
+   * Filters by application_name matching 'sqlever/batch%' to find
+   * batch worker connections.
+   */
+  async getBatchQueries(): Promise<BatchQueryInfo[]> {
+    const result: QueryResult<{
+      pid: number;
+      query: string;
+      duration_ms: string;
+      wait_event_type: string | null;
+      wait_event: string | null;
+      state: string;
+      application_name: string;
+    }> = await this.db.query(
+      `SELECT pid,
+              query,
+              EXTRACT(EPOCH FROM (now() - query_start))::bigint * 1000 AS duration_ms,
+              wait_event_type,
+              wait_event,
+              state,
+              application_name
+       FROM pg_stat_activity
+       WHERE application_name LIKE 'sqlever/%'
+         AND pid <> pg_backend_pid()
+       ORDER BY query_start ASC NULLS LAST`,
+    );
+
+    return result.rows.map((row) => ({
+      pid: row.pid,
+      query: row.query,
+      durationMs: parseInt(row.duration_ms, 10) || 0,
+      waitEventType: row.wait_event_type,
+      waitEvent: row.wait_event,
+      state: row.state,
+      applicationName: row.application_name,
+    }));
+  }
+
+  // -----------------------------------------------------------------------
+  // Combined health check
+  // -----------------------------------------------------------------------
+
+  /**
+   * Check whether the batch should pause due to any health concern.
+   *
+   * Returns a reason string if the batch should pause, or null if
+   * it is safe to continue.
+   */
+  async shouldPause(
+    schemaName: string,
+    tableName: string,
+  ): Promise<string | null> {
+    const lag = await this.getReplicationLag();
+    if (lag.exceedsThreshold) {
+      return (
+        `Replication lag ${lag.replayLagSeconds.toFixed(1)}s exceeds ` +
+        `threshold ${lag.thresholdSeconds}s` +
+        (lag.replicaName ? ` (replica: ${lag.replicaName})` : "")
+      );
+    }
+
+    const pressure = await this.getVacuumPressure(schemaName, tableName);
+    if (pressure.exceedsThreshold) {
+      return (
+        `Dead tuple ratio ${(pressure.deadTupleRatio * 100).toFixed(1)}% ` +
+        `exceeds threshold ${(pressure.thresholdRatio * 100).toFixed(1)}% ` +
+        `on ${pressure.tableName}`
+      );
+    }
+
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Simple SQL identifier quoting. Double-quotes the identifier and
+ * escapes any embedded double quotes.
+ */
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}

--- a/tests/unit/batch-progress.test.ts
+++ b/tests/unit/batch-progress.test.ts
@@ -1,0 +1,674 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock pg/lib/client — identical pattern to batch-queue.test.ts
+// ---------------------------------------------------------------------------
+
+let mockInstances: MockPgClient[] = [];
+
+class MockPgClient {
+  options: Record<string, unknown>;
+  queries: Array<{ text: string; values?: unknown[] }> = [];
+  connected = false;
+  ended = false;
+
+  constructor(options: Record<string, unknown>) {
+    this.options = options;
+    mockInstances.push(this);
+  }
+
+  async connect() {
+    this.connected = true;
+  }
+
+  async query(text: string, values?: unknown[]) {
+    this.queries.push({ text, values });
+    return { rows: [], rowCount: 0, command: "SELECT" };
+  }
+
+  async end() {
+    this.ended = true;
+    this.connected = false;
+  }
+}
+
+mock.module("pg/lib/client", () => ({
+  default: MockPgClient,
+  __esModule: true,
+}));
+
+const { DatabaseClient } = await import("../../src/db/client");
+const {
+  calculateProgress,
+  parseIntervalToSeconds,
+  computeDeadTupleRatio,
+  checkHeartbeatStaleness,
+  ProgressMonitor,
+  DEFAULT_REPLICATION_LAG_THRESHOLD_SECONDS,
+  DEFAULT_MAX_DEAD_TUPLE_RATIO,
+  DEFAULT_HEARTBEAT_STALENESS_MS,
+} = await import("../../src/batch/progress");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeClient(): Promise<InstanceType<typeof DatabaseClient>> {
+  const client = new DatabaseClient("postgresql://user@localhost/testdb");
+  await client.connect();
+  return client;
+}
+
+function findQuery(pgClient: MockPgClient, pattern: string | RegExp) {
+  return pgClient.queries.find((q) =>
+    typeof pattern === "string"
+      ? q.text.includes(pattern)
+      : pattern.test(q.text),
+  );
+}
+
+/**
+ * Set up a MockPgClient so that queries matching a pattern return specific rows.
+ */
+function setupQueryResponses(
+  pgClient: MockPgClient,
+  responses: Array<{
+    pattern: string | RegExp;
+    rows: unknown[];
+    rowCount?: number;
+    command?: string;
+  }>,
+) {
+  const origQuery = pgClient.query.bind(pgClient);
+  pgClient.query = async (text: string, values?: unknown[]) => {
+    for (const r of responses) {
+      const match =
+        typeof r.pattern === "string"
+          ? text.includes(r.pattern)
+          : r.pattern.test(text);
+      if (match) {
+        pgClient.queries.push({ text, values });
+        return {
+          rows: r.rows,
+          rowCount: r.rowCount ?? r.rows.length,
+          command: r.command ?? "SELECT",
+        };
+      }
+    }
+    return origQuery(text, values);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("batch/progress", () => {
+  beforeEach(() => {
+    mockInstances = [];
+  });
+
+  // -----------------------------------------------------------------------
+  // Constants
+  // -----------------------------------------------------------------------
+
+  describe("constants", () => {
+    it("DEFAULT_REPLICATION_LAG_THRESHOLD_SECONDS is 10", () => {
+      expect(DEFAULT_REPLICATION_LAG_THRESHOLD_SECONDS).toBe(10);
+    });
+
+    it("DEFAULT_MAX_DEAD_TUPLE_RATIO is 0.10", () => {
+      expect(DEFAULT_MAX_DEAD_TUPLE_RATIO).toBe(0.10);
+    });
+
+    it("DEFAULT_HEARTBEAT_STALENESS_MS is 5 minutes", () => {
+      expect(DEFAULT_HEARTBEAT_STALENESS_MS).toBe(300_000);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // calculateProgress()
+  // -----------------------------------------------------------------------
+
+  describe("calculateProgress()", () => {
+    it("computes percentage correctly for partial completion", () => {
+      const p = calculateProgress(250, 1000, 5000);
+      expect(p.percentage).toBe(25);
+      expect(p.rowsDone).toBe(250);
+      expect(p.rowsTotal).toBe(1000);
+    });
+
+    it("computes throughput (rows per second)", () => {
+      // 500 rows in 2000ms = 250 rows/sec
+      const p = calculateProgress(500, 1000, 2000);
+      expect(p.rowsPerSecond).toBe(250);
+    });
+
+    it("computes ETA from observed throughput", () => {
+      // 500 done in 2000ms => 250 rows/sec => 500 remaining / 250 = 2s = 2000ms
+      const p = calculateProgress(500, 1000, 2000);
+      expect(p.etaMs).toBe(2000);
+    });
+
+    it("returns null ETA when no rows processed yet", () => {
+      const p = calculateProgress(0, 1000, 0);
+      expect(p.etaMs).toBeNull();
+    });
+
+    it("returns 100% when rowsTotal is 0", () => {
+      const p = calculateProgress(0, 0, 1000);
+      expect(p.percentage).toBe(100);
+    });
+
+    it("clamps rowsDone to rowsTotal when it exceeds total", () => {
+      const p = calculateProgress(1500, 1000, 5000);
+      expect(p.rowsDone).toBe(1000);
+      expect(p.percentage).toBe(100);
+    });
+
+    it("returns ETA of 0 when all rows are done", () => {
+      const p = calculateProgress(1000, 1000, 5000);
+      expect(p.etaMs).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // parseIntervalToSeconds()
+  // -----------------------------------------------------------------------
+
+  describe("parseIntervalToSeconds()", () => {
+    it("parses HH:MM:SS format", () => {
+      expect(parseIntervalToSeconds("00:00:05")).toBe(5);
+    });
+
+    it("parses HH:MM:SS.fractional format", () => {
+      const result = parseIntervalToSeconds("00:00:05.123");
+      expect(result).toBeCloseTo(5.123, 2);
+    });
+
+    it("parses hours and minutes", () => {
+      expect(parseIntervalToSeconds("01:30:00")).toBe(5400);
+    });
+
+    it("parses days prefix", () => {
+      expect(parseIntervalToSeconds("1 day 00:00:00")).toBe(86400);
+    });
+
+    it("returns 0 for null", () => {
+      expect(parseIntervalToSeconds(null)).toBe(0);
+    });
+
+    it("returns 0 for empty string", () => {
+      expect(parseIntervalToSeconds("")).toBe(0);
+    });
+
+    it("parses bare number as seconds", () => {
+      expect(parseIntervalToSeconds("12.5")).toBe(12.5);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // computeDeadTupleRatio()
+  // -----------------------------------------------------------------------
+
+  describe("computeDeadTupleRatio()", () => {
+    it("computes correct ratio", () => {
+      // 100 dead / (900 live + 100 dead) = 0.1
+      expect(computeDeadTupleRatio(100, 900)).toBeCloseTo(0.1, 5);
+    });
+
+    it("returns 0 when both are 0 (empty table)", () => {
+      expect(computeDeadTupleRatio(0, 0)).toBe(0);
+    });
+
+    it("returns 1 when all tuples are dead", () => {
+      expect(computeDeadTupleRatio(1000, 0)).toBe(1);
+    });
+
+    it("returns 0 when no dead tuples", () => {
+      expect(computeDeadTupleRatio(0, 1000)).toBe(0);
+    });
+
+    it("handles large numbers correctly", () => {
+      // 1M dead / 10M total = 0.1
+      const ratio = computeDeadTupleRatio(1_000_000, 9_000_000);
+      expect(ratio).toBeCloseTo(0.1, 5);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // checkHeartbeatStaleness()
+  // -----------------------------------------------------------------------
+
+  describe("checkHeartbeatStaleness()", () => {
+    it("detects stale heartbeat when age exceeds threshold", () => {
+      const now = new Date("2025-01-01T00:10:00Z");
+      const heartbeat = new Date("2025-01-01T00:00:00Z"); // 10 min ago
+      const result = checkHeartbeatStaleness(heartbeat, 300_000, now);
+      expect(result.isStale).toBe(true);
+      expect(result.ageMs).toBe(600_000); // 10 minutes
+    });
+
+    it("detects fresh heartbeat within threshold", () => {
+      const now = new Date("2025-01-01T00:02:00Z");
+      const heartbeat = new Date("2025-01-01T00:00:00Z"); // 2 min ago
+      const result = checkHeartbeatStaleness(heartbeat, 300_000, now);
+      expect(result.isStale).toBe(false);
+      expect(result.ageMs).toBe(120_000);
+    });
+
+    it("treats null heartbeat as always stale", () => {
+      const result = checkHeartbeatStaleness(null, 300_000);
+      expect(result.isStale).toBe(true);
+      expect(result.ageMs).toBe(Infinity);
+    });
+
+    it("uses configurable threshold", () => {
+      const now = new Date("2025-01-01T00:01:30Z");
+      const heartbeat = new Date("2025-01-01T00:00:00Z"); // 90s ago
+      // 60s threshold — 90s is stale
+      expect(checkHeartbeatStaleness(heartbeat, 60_000, now).isStale).toBe(
+        true,
+      );
+      // 120s threshold — 90s is fresh
+      expect(checkHeartbeatStaleness(heartbeat, 120_000, now).isStale).toBe(
+        false,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ProgressMonitor — replication lag
+  // -----------------------------------------------------------------------
+
+  describe("ProgressMonitor.getReplicationLag()", () => {
+    it("returns lag info from pg_stat_replication", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_replication",
+          rows: [{ replay_lag: "00:00:15.000", application_name: "replica1" }],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const lag = await monitor.getReplicationLag();
+
+      expect(lag.replayLagSeconds).toBe(15);
+      expect(lag.exceedsThreshold).toBe(true);
+      expect(lag.thresholdSeconds).toBe(10);
+      expect(lag.replicaName).toBe("replica1");
+    });
+
+    it("returns zero lag when no replicas exist", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "pg_stat_replication", rows: [] },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const lag = await monitor.getReplicationLag();
+
+      expect(lag.replayLagSeconds).toBe(0);
+      expect(lag.exceedsThreshold).toBe(false);
+      expect(lag.replicaName).toBeNull();
+    });
+
+    it("uses configurable threshold", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_replication",
+          rows: [{ replay_lag: "00:00:08.000", application_name: "replica1" }],
+        },
+      ]);
+
+      // 8s lag with 5s threshold => exceeds
+      const monitor = new ProgressMonitor(client, {
+        replicationLagThresholdSeconds: 5,
+      });
+      const lag = await monitor.getReplicationLag();
+
+      expect(lag.exceedsThreshold).toBe(true);
+      expect(lag.thresholdSeconds).toBe(5);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ProgressMonitor — VACUUM pressure
+  // -----------------------------------------------------------------------
+
+  describe("ProgressMonitor.getVacuumPressure()", () => {
+    it("computes dead tuple ratio from pg_stat_user_tables", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_user_tables",
+          rows: [{ n_dead_tup: "150", n_live_tup: "850" }],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const pressure = await monitor.getVacuumPressure("public", "users");
+
+      expect(pressure.deadTuples).toBe(150);
+      expect(pressure.liveTuples).toBe(850);
+      expect(pressure.deadTupleRatio).toBe(0.15);
+      expect(pressure.exceedsThreshold).toBe(true);
+      expect(pressure.tableName).toBe("public.users");
+    });
+
+    it("returns no pressure when table not found in stats", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "pg_stat_user_tables", rows: [] },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const pressure = await monitor.getVacuumPressure(
+        "public",
+        "nonexistent",
+      );
+
+      expect(pressure.deadTupleRatio).toBe(0);
+      expect(pressure.exceedsThreshold).toBe(false);
+    });
+
+    it("uses configurable threshold", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_user_tables",
+          rows: [{ n_dead_tup: "50", n_live_tup: "950" }],
+        },
+      ]);
+
+      // 5% ratio with 3% threshold => exceeds
+      const monitor = new ProgressMonitor(client, {
+        maxDeadTupleRatio: 0.03,
+      });
+      const pressure = await monitor.getVacuumPressure("public", "users");
+
+      expect(pressure.exceedsThreshold).toBe(true);
+      expect(pressure.thresholdRatio).toBe(0.03);
+    });
+
+    it("queries with correct schema and table parameters", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_user_tables",
+          rows: [{ n_dead_tup: "0", n_live_tup: "100" }],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      await monitor.getVacuumPressure("myschema", "orders");
+
+      const q = findQuery(pgClient, "pg_stat_user_tables");
+      expect(q!.values).toEqual(["myschema", "orders"]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ProgressMonitor — heartbeat staleness
+  // -----------------------------------------------------------------------
+
+  describe("ProgressMonitor.checkJobHeartbeat()", () => {
+    it("queries batch_jobs for heartbeat_at", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const recentHeartbeat = new Date();
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "batch_jobs",
+          rows: [{ heartbeat_at: recentHeartbeat }],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const status = await monitor.checkJobHeartbeat(42, 0);
+
+      expect(status.jobId).toBe(42);
+      expect(status.lastHeartbeat).toBe(recentHeartbeat);
+      expect(status.isStale).toBe(false);
+    });
+
+    it("marks missing job as stale", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_jobs", rows: [] },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const status = await monitor.checkJobHeartbeat(999, 0);
+
+      expect(status.isStale).toBe(true);
+      expect(status.ageMs).toBe(Infinity);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ProgressMonitor — pg_stat_activity
+  // -----------------------------------------------------------------------
+
+  describe("ProgressMonitor.getBatchQueries()", () => {
+    it("returns batch queries from pg_stat_activity", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_activity",
+          rows: [
+            {
+              pid: 1234,
+              query: "UPDATE users SET tier = 'gold'",
+              duration_ms: "5000",
+              wait_event_type: null,
+              wait_event: null,
+              state: "active",
+              application_name: "sqlever/batch/backfill",
+            },
+          ],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const queries = await monitor.getBatchQueries();
+
+      expect(queries).toHaveLength(1);
+      expect(queries[0]!.pid).toBe(1234);
+      expect(queries[0]!.query).toBe("UPDATE users SET tier = 'gold'");
+      expect(queries[0]!.durationMs).toBe(5000);
+      expect(queries[0]!.state).toBe("active");
+      expect(queries[0]!.applicationName).toBe("sqlever/batch/backfill");
+    });
+
+    it("returns empty array when no batch queries are running", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "pg_stat_activity", rows: [] },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const queries = await monitor.getBatchQueries();
+
+      expect(queries).toHaveLength(0);
+    });
+
+    it("filters by sqlever application_name", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "pg_stat_activity", rows: [] },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      await monitor.getBatchQueries();
+
+      const q = findQuery(pgClient, "pg_stat_activity");
+      expect(q!.text).toContain("application_name LIKE 'sqlever/%'");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ProgressMonitor — shouldPause (combined check)
+  // -----------------------------------------------------------------------
+
+  describe("ProgressMonitor.shouldPause()", () => {
+    it("returns null when no concerns", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_replication",
+          rows: [{ replay_lag: "00:00:02.000", application_name: "r1" }],
+        },
+        {
+          pattern: "pg_stat_user_tables",
+          rows: [{ n_dead_tup: "10", n_live_tup: "990" }],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const reason = await monitor.shouldPause("public", "users");
+
+      expect(reason).toBeNull();
+    });
+
+    it("returns replication lag reason when lag exceeds threshold", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_replication",
+          rows: [{ replay_lag: "00:00:15.000", application_name: "replica1" }],
+        },
+        {
+          pattern: "pg_stat_user_tables",
+          rows: [{ n_dead_tup: "10", n_live_tup: "990" }],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const reason = await monitor.shouldPause("public", "users");
+
+      expect(reason).toContain("Replication lag");
+      expect(reason).toContain("15.0s");
+      expect(reason).toContain("replica1");
+    });
+
+    it("returns VACUUM pressure reason when ratio exceeds threshold", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_replication",
+          rows: [{ replay_lag: "00:00:02.000", application_name: "r1" }],
+        },
+        {
+          pattern: "pg_stat_user_tables",
+          rows: [{ n_dead_tup: "200", n_live_tup: "800" }],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const reason = await monitor.shouldPause("public", "users");
+
+      expect(reason).toContain("Dead tuple ratio");
+      expect(reason).toContain("20.0%");
+    });
+
+    it("prioritizes replication lag over VACUUM pressure", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      // Both exceed thresholds
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "pg_stat_replication",
+          rows: [{ replay_lag: "00:00:20.000", application_name: "r1" }],
+        },
+        {
+          pattern: "pg_stat_user_tables",
+          rows: [{ n_dead_tup: "500", n_live_tup: "500" }],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const reason = await monitor.shouldPause("public", "users");
+
+      // Replication lag is checked first
+      expect(reason).toContain("Replication lag");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ProgressMonitor — findStaleWorkers
+  // -----------------------------------------------------------------------
+
+  describe("ProgressMonitor.findStaleWorkers()", () => {
+    it("returns stale workers from batch_jobs", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      const staleDate = new Date(Date.now() - 600_000); // 10 min ago
+
+      setupQueryResponses(pgClient, [
+        {
+          pattern: "batch_jobs",
+          rows: [{ id: 1, heartbeat_at: staleDate }],
+        },
+      ]);
+
+      const monitor = new ProgressMonitor(client);
+      const stale = await monitor.findStaleWorkers();
+
+      expect(stale).toHaveLength(1);
+      expect(stale[0]!.jobId).toBe(1);
+      expect(stale[0]!.isStale).toBe(true);
+    });
+
+    it("passes staleness threshold to the query", async () => {
+      const client = await makeClient();
+      const pgClient = mockInstances[0]!;
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_jobs", rows: [] },
+      ]);
+
+      const monitor = new ProgressMonitor(client, {
+        heartbeatStalenessMs: 60_000,
+      });
+      await monitor.findStaleWorkers();
+
+      const q = findQuery(pgClient, "batch_jobs");
+      expect(q!.values).toContain(60_000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/batch/progress.ts` implementing SPEC Section 5.5 batch job progress monitoring
- **Row counting**: `calculateProgress()` computes rows done/total, percentage, ETA from observed throughput
- **Replication lag**: queries `pg_stat_replication.replay_lag`, pauses batch when lag exceeds configurable threshold (default 10s)
- **VACUUM pressure**: queries `pg_stat_user_tables.n_dead_tup`, computes dead tuple ratio `n_dead_tup/(n_live_tup+n_dead_tup)`, pauses when >10% (configurable via `sqlever.toml` `[batch] max_dead_tuple_ratio`)
- **Heartbeat staleness**: detects dead workers when heartbeat exceeds threshold (default 5min), handles OOM kill / network partition
- **pg_stat_activity**: shows current batch queries with duration, wait events, and state
- Combined `shouldPause()` method checks replication lag then VACUUM pressure
- Pure functions (`calculateProgress`, `parseIntervalToSeconds`, `computeDeadTupleRatio`, `checkHeartbeatStaleness`) separated from DB-dependent `ProgressMonitor` class for testability

## Test plan

- [x] 44 unit tests covering all five monitoring dimensions (exceeds 15-test minimum)
- [x] Progress calculation: percentage, throughput, ETA, edge cases (0 rows, overflow)
- [x] Interval parsing: HH:MM:SS, fractional seconds, days, null/empty, bare numbers
- [x] Dead tuple ratio: normal ratio, empty table, all-dead, no-dead, large numbers
- [x] Heartbeat staleness: stale detection, fresh detection, null heartbeat, configurable threshold
- [x] Replication lag monitor: lag info from pg_stat_replication, no replicas, custom threshold
- [x] VACUUM pressure monitor: ratio from pg_stat_user_tables, missing table, custom threshold, query params
- [x] Heartbeat monitor: job heartbeat check, missing job, stale workers query
- [x] pg_stat_activity: batch queries, empty results, application_name filter
- [x] Combined shouldPause: no concerns, lag pause, vacuum pause, priority ordering
- [x] All 2111 existing tests continue to pass

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)