### PR TITLE
F2: Batch worker — execution loop with throttling

### DIFF
--- a/src/batch/worker.ts
+++ b/src/batch/worker.ts
@@ -1,0 +1,378 @@
+// src/batch/worker.ts — Batch execution loop for batched DML jobs
+//
+// Implements the batch worker described in SPEC Section 5.5:
+//
+// - Dequeues jobs via SKIP LOCKED from the queue
+// - Executes DML (UPDATE/DELETE with LIMIT based on batch_size)
+// - Commits per-batch transactions independently
+// - Updates heartbeat at the start of each batch
+// - Tracks last processed PK for resume (retried jobs resume from
+//   where they stopped, not from the beginning)
+// - Sleeps for a configured interval between batches
+// - Repeats until no more rows or paused/cancelled
+//
+// Connection requirement: the batch worker requires a direct PostgreSQL
+// connection (not PgBouncer in transaction mode) because it uses
+// session-level settings and the connection must persist across sleep
+// intervals (DD13).
+//
+// SET statements (lock_timeout, statement_timeout, search_path) are
+// re-issued at the start of each batch transaction as a safety measure
+// (DD13, DD14).
+//
+// Inspired by GitLab BatchedMigration framework.
+
+import type { DatabaseClient, QueryResult } from "../db/client";
+import type { BatchJob, PartitionId } from "./queue";
+import { BatchQueue } from "./queue";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Status of a worker after processing. */
+export type WorkerStatus =
+  | "completed"   // All rows processed
+  | "paused"      // Externally paused
+  | "cancelled"   // Externally cancelled
+  | "failed"      // Error during batch execution
+  | "no_work";    // No pending jobs in the queue
+
+/** Result returned when the worker finishes. */
+export interface WorkerResult {
+  status: WorkerStatus;
+  jobId: number | null;
+  batchesProcessed: number;
+  totalRowsAffected: number;
+  lastPk: string | null;
+  error?: string;
+}
+
+/** Per-batch configuration options (SPEC Section 5.5). */
+export interface BatchWorkerConfig {
+  /** Rows per batch (LIMIT clause value). Default: from job. */
+  batchSize?: number;
+  /** Pause between batches in milliseconds. Default: from job. */
+  sleepMs?: number;
+  /** Per-batch lock_timeout in milliseconds. Default: 5000 (5s). */
+  lockTimeoutMs?: number;
+  /** Per-batch statement_timeout in milliseconds. Default: 0 (disabled). */
+  statementTimeoutMs?: number;
+  /** Schema search_path to set per batch. Default: "public". */
+  searchPath?: string;
+  /** Schema for the batch queue tables. Default: "sqlever". */
+  schema?: string;
+}
+
+/**
+ * Callback that checks whether the worker should pause or cancel.
+ * Called between batches. Returns "continue", "pause", or "cancel".
+ */
+export type SignalCheckFn = () =>
+  | "continue"
+  | "pause"
+  | "cancel"
+  | Promise<"continue" | "pause" | "cancel">;
+
+/**
+ * DML executor: a function that executes the batch DML statement.
+ *
+ * Receives:
+ * - `db`: the DatabaseClient (inside an active transaction)
+ * - `job`: the current BatchJob (for table_name, batch_size, etc.)
+ * - `lastPk`: the last processed PK (null on first batch)
+ *
+ * Must return:
+ * - `rowsAffected`: number of rows modified in this batch
+ * - `lastPk`: the PK of the last row processed (for resume tracking)
+ *
+ * The DML should use:
+ * - WHERE pk > $lastPk (or no PK filter if lastPk is null)
+ * - ORDER BY pk
+ * - LIMIT $batchSize
+ */
+export type DmlExecutor = (
+  db: DatabaseClient,
+  job: BatchJob,
+  lastPk: string | null,
+) => Promise<{ rowsAffected: number; lastPk: string | null }>;
+
+/**
+ * Sleep function — injectable for testing. Default: real setTimeout.
+ */
+export type SleepFn = (ms: number) => Promise<void>;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default lock_timeout per batch (5 seconds). */
+export const DEFAULT_LOCK_TIMEOUT_MS = 5_000;
+
+/** Default statement_timeout per batch (disabled). */
+export const DEFAULT_STATEMENT_TIMEOUT_MS = 0;
+
+/** Default search_path. */
+export const DEFAULT_SEARCH_PATH = "public";
+
+// ---------------------------------------------------------------------------
+// BatchWorker
+// ---------------------------------------------------------------------------
+
+/**
+ * Batch execution loop for batched DML jobs (SPEC Section 5.5).
+ *
+ * The worker:
+ * 1. Dequeues the next pending job via SKIP LOCKED
+ * 2. For each batch:
+ *    a. BEGIN transaction
+ *    b. Re-issue SET statements (lock_timeout, statement_timeout,
+ *       search_path) as a safety measure
+ *    c. Execute the DML via the provided DmlExecutor
+ *    d. Update the job's last_pk and heartbeat
+ *    e. COMMIT
+ *    f. Sleep for the configured interval
+ *    g. Check for pause/cancel signals
+ * 3. When DML returns 0 rows, mark job as done
+ * 4. On error, mark job as failed (or dead if retries exhausted)
+ */
+export class BatchWorker {
+  private db: DatabaseClient;
+  private queue: BatchQueue;
+  private config: Required<
+    Pick<
+      BatchWorkerConfig,
+      "lockTimeoutMs" | "statementTimeoutMs" | "searchPath" | "schema"
+    >
+  > &
+    Pick<BatchWorkerConfig, "batchSize" | "sleepMs">;
+  private dmlExecutor: DmlExecutor;
+  private signalCheck: SignalCheckFn;
+  private sleepFn: SleepFn;
+
+  constructor(
+    db: DatabaseClient,
+    dmlExecutor: DmlExecutor,
+    options: BatchWorkerConfig = {},
+    signalCheck?: SignalCheckFn,
+    sleepFn?: SleepFn,
+  ) {
+    this.db = db;
+    this.dmlExecutor = dmlExecutor;
+    this.signalCheck = signalCheck ?? (() => "continue");
+    this.sleepFn = sleepFn ?? defaultSleep;
+
+    this.config = {
+      batchSize: options.batchSize,
+      sleepMs: options.sleepMs,
+      lockTimeoutMs: options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS,
+      statementTimeoutMs:
+        options.statementTimeoutMs ?? DEFAULT_STATEMENT_TIMEOUT_MS,
+      searchPath: options.searchPath ?? DEFAULT_SEARCH_PATH,
+      schema: options.schema ?? "sqlever",
+    };
+
+    this.queue = new BatchQueue(db, { schema: this.config.schema });
+  }
+
+  /**
+   * Run the batch execution loop.
+   *
+   * Dequeues a job and processes it batch-by-batch until completion,
+   * pause, cancel, or error.
+   */
+  async run(): Promise<WorkerResult> {
+    // 1. Dequeue the next pending job
+    const job = await this.queue.dequeueJob();
+    if (!job) {
+      return {
+        status: "no_work",
+        jobId: null,
+        batchesProcessed: 0,
+        totalRowsAffected: 0,
+        lastPk: null,
+      };
+    }
+
+    // Resolve effective config: explicit config overrides > job defaults
+    const batchSize = this.config.batchSize ?? job.batch_size;
+    const sleepMs = this.config.sleepMs ?? job.sleep_ms;
+
+    let batchesProcessed = 0;
+    let totalRowsAffected = 0;
+    let lastPk = job.last_pk; // Resume from where the job left off
+
+    try {
+      // 2. Batch loop
+      while (true) {
+        // 2a. Check for external signals before starting a batch
+        const signal = await this.signalCheck();
+        if (signal === "pause") {
+          // Transition to failed with a pause message so it can be resumed
+          await this.queue.failJob(
+            job.id,
+            job.partition_id,
+            "Paused by operator",
+          );
+          return {
+            status: "paused",
+            jobId: job.id,
+            batchesProcessed,
+            totalRowsAffected,
+            lastPk,
+          };
+        }
+        if (signal === "cancel") {
+          await this.queue.failJob(
+            job.id,
+            job.partition_id,
+            "Cancelled by operator",
+          );
+          return {
+            status: "cancelled",
+            jobId: job.id,
+            batchesProcessed,
+            totalRowsAffected,
+            lastPk,
+          };
+        }
+
+        // 2b. Execute one batch inside a transaction
+        const batchResult = await this.executeBatch(job, lastPk, batchSize);
+
+        batchesProcessed++;
+        totalRowsAffected += batchResult.rowsAffected;
+        lastPk = batchResult.lastPk ?? lastPk;
+
+        // 2c. Update heartbeat and last_pk in the job row
+        await this.queue.updateHeartbeat(job.id, job.partition_id);
+        await this.updateJobProgress(job.id, job.partition_id, lastPk);
+
+        // 2d. If no rows affected, we are done
+        if (batchResult.rowsAffected === 0) {
+          await this.queue.completeJob(job.id, job.partition_id, lastPk ?? undefined);
+          return {
+            status: "completed",
+            jobId: job.id,
+            batchesProcessed,
+            totalRowsAffected,
+            lastPk,
+          };
+        }
+
+        // 2e. Sleep between batches
+        await this.sleepFn(sleepMs);
+      }
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      try {
+        await this.queue.failJob(job.id, job.partition_id, errorMessage);
+      } catch {
+        // If we can't even fail the job, swallow and report the original error
+      }
+      return {
+        status: "failed",
+        jobId: job.id,
+        batchesProcessed,
+        totalRowsAffected,
+        lastPk,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Execute a single batch inside a transaction.
+   *
+   * 1. BEGIN
+   * 2. Re-issue SET statements (lock_timeout, statement_timeout,
+   *    search_path) as a safety measure (DD13)
+   * 3. Execute the DML via the DmlExecutor
+   * 4. COMMIT
+   */
+  private async executeBatch(
+    job: BatchJob,
+    lastPk: string | null,
+    batchSize: number,
+  ): Promise<{ rowsAffected: number; lastPk: string | null }> {
+    // Use the DatabaseClient's transaction wrapper: BEGIN + COMMIT/ROLLBACK
+    return this.db.transaction(async (txClient) => {
+      // Re-issue SET statements at the start of each batch transaction
+      // as a safety measure (DD13, SPEC Section 5.5)
+      await this.applyBatchSettings(txClient);
+
+      // Execute the actual DML
+      const result = await this.dmlExecutor(
+        txClient,
+        { ...job, batch_size: batchSize },
+        lastPk,
+      );
+
+      return result;
+    });
+  }
+
+  /**
+   * Re-issue SET statements at the start of each batch transaction.
+   *
+   * Per DD13 and SPEC Section 5.5: SET statements (lock_timeout,
+   * statement_timeout, search_path) are re-issued as a safety measure
+   * because session-level settings may be lost or leaked when using
+   * connection poolers.
+   */
+  private async applyBatchSettings(db: DatabaseClient): Promise<void> {
+    await db.query(`SET lock_timeout = ${this.config.lockTimeoutMs}`);
+    await db.query(
+      `SET statement_timeout = ${this.config.statementTimeoutMs}`,
+    );
+    await db.query(`SET search_path = ${quoteIdentList(this.config.searchPath)}`);
+  }
+
+  /**
+   * Update the last_pk on the job row to track progress for resume.
+   */
+  private async updateJobProgress(
+    jobId: number,
+    partitionId: PartitionId,
+    lastPk: string | null,
+  ): Promise<void> {
+    if (lastPk === null) return;
+
+    const schema = quoteIdent(this.config.schema);
+    await this.db.query(
+      `UPDATE ${schema}."batch_jobs"
+       SET last_pk = $1, updated_at = now()
+       WHERE id = $2 AND partition_id = $3`,
+      [lastPk, jobId, partitionId],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+/** Default sleep implementation using setTimeout. */
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Simple SQL identifier quoting. Double-quotes the identifier and
+ * escapes any embedded double quotes.
+ */
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Quote a comma-separated list of schema names for SET search_path.
+ * Each schema name is individually quoted.
+ */
+function quoteIdentList(schemas: string): string {
+  return schemas
+    .split(",")
+    .map((s) => s.trim())
+    .map(quoteIdent)
+    .join(", ");
+}

--- a/tests/unit/batch-worker.test.ts
+++ b/tests/unit/batch-worker.test.ts
@@ -1,0 +1,1020 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock pg/lib/client — identical pattern to batch-queue.test.ts
+// ---------------------------------------------------------------------------
+
+let mockInstances: MockPgClient[] = [];
+
+class MockPgClient {
+  options: Record<string, unknown>;
+  queries: Array<{ text: string; values?: unknown[] }> = [];
+  connected = false;
+  ended = false;
+  queryResults: Record<string, { rows: unknown[]; rowCount: number; command: string }> = {};
+  queryShouldFail: Record<string, Error> = {};
+
+  constructor(options: Record<string, unknown>) {
+    this.options = options;
+    mockInstances.push(this);
+  }
+
+  async connect() {
+    this.connected = true;
+  }
+
+  async query(text: string, values?: unknown[]) {
+    this.queries.push({ text, values });
+    if (this.queryShouldFail[text]) {
+      throw this.queryShouldFail[text];
+    }
+    return (
+      this.queryResults[text] ?? { rows: [], rowCount: 0, command: "SELECT" }
+    );
+  }
+
+  async end() {
+    this.ended = true;
+    this.connected = false;
+  }
+}
+
+mock.module("pg/lib/client", () => ({
+  default: MockPgClient,
+  __esModule: true,
+}));
+
+const { DatabaseClient } = await import("../../src/db/client");
+const {
+  BatchQueue,
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_SLEEP_MS,
+  DEFAULT_MAX_RETRIES,
+} = await import("../../src/batch/queue");
+
+const {
+  BatchWorker,
+  DEFAULT_LOCK_TIMEOUT_MS,
+  DEFAULT_STATEMENT_TIMEOUT_MS,
+  DEFAULT_SEARCH_PATH,
+} = await import("../../src/batch/worker");
+
+import type { BatchJob, PartitionId } from "../../src/batch/queue";
+import type {
+  DmlExecutor,
+  SignalCheckFn,
+  WorkerResult,
+  BatchWorkerConfig,
+} from "../../src/batch/worker";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeClient(): Promise<InstanceType<typeof DatabaseClient>> {
+  const client = new DatabaseClient("postgresql://user@localhost/testdb");
+  await client.connect();
+  return client;
+}
+
+function latestPgClient(): MockPgClient {
+  return mockInstances[mockInstances.length - 1]!;
+}
+
+function findQuery(pgClient: MockPgClient, pattern: string | RegExp) {
+  return pgClient.queries.find((q) =>
+    typeof pattern === "string"
+      ? q.text.includes(pattern)
+      : pattern.test(q.text),
+  );
+}
+
+function allQueriesMatching(pgClient: MockPgClient, pattern: string | RegExp) {
+  return pgClient.queries.filter((q) =>
+    typeof pattern === "string"
+      ? q.text.includes(pattern)
+      : pattern.test(q.text),
+  );
+}
+
+/** Create a mock job row for test returns. */
+function mockJob(overrides: Partial<BatchJob> = {}): BatchJob {
+  return {
+    id: 1,
+    name: "backfill_tiers",
+    status: "running",
+    partition_id: 0 as PartitionId,
+    table_name: "users",
+    batch_size: DEFAULT_BATCH_SIZE,
+    sleep_ms: DEFAULT_SLEEP_MS,
+    last_pk: null,
+    attempt: 1,
+    max_retries: DEFAULT_MAX_RETRIES,
+    error_message: null,
+    heartbeat_at: new Date(),
+    created_at: new Date("2025-01-01"),
+    updated_at: new Date("2025-01-01"),
+    ...overrides,
+  };
+}
+
+/**
+ * Set up a MockPgClient so that queries matching a pattern return specific
+ * rows. The response is consumed on first match and subsequent matches
+ * for the same pattern cycle through.
+ */
+function setupQueryResponses(
+  pgClient: MockPgClient,
+  responses: Array<{
+    pattern: string | RegExp;
+    rows: unknown[];
+    rowCount?: number;
+    command?: string;
+  }>,
+) {
+  const origQuery = pgClient.query.bind(pgClient);
+  pgClient.query = async (text: string, values?: unknown[]) => {
+    for (const r of responses) {
+      const match =
+        typeof r.pattern === "string"
+          ? text.includes(r.pattern)
+          : r.pattern.test(text);
+      if (match) {
+        pgClient.queries.push({ text, values });
+        return {
+          rows: r.rows,
+          rowCount: r.rowCount ?? r.rows.length,
+          command: r.command ?? "SELECT",
+        };
+      }
+    }
+    return origQuery(text, values);
+  };
+}
+
+/** No-op sleep for tests. */
+const instantSleep = async (_ms: number) => {};
+
+/** DML executor that returns a fixed number of rows affected per call. */
+function fixedDml(
+  schedule: Array<{ rowsAffected: number; lastPk: string | null }>,
+): DmlExecutor {
+  let callIndex = 0;
+  return async (_db, _job, _lastPk) => {
+    const result = schedule[callIndex] ?? { rowsAffected: 0, lastPk: null };
+    callIndex++;
+    return result;
+  };
+}
+
+/** DML executor that throws on the Nth call. */
+function failingDml(failOnCall: number, errorMsg: string): DmlExecutor {
+  let callIndex = 0;
+  return async (_db, _job, _lastPk) => {
+    callIndex++;
+    if (callIndex === failOnCall) {
+      throw new Error(errorMsg);
+    }
+    return { rowsAffected: 100, lastPk: String(callIndex * 100) };
+  };
+}
+
+/**
+ * Set up standard query responses for a worker run.
+ * This sets up the dequeue, heartbeat, progress update, and completion queries.
+ */
+function setupWorkerQueries(
+  pgClient: MockPgClient,
+  job: BatchJob,
+  extraResponses: Array<{
+    pattern: string | RegExp;
+    rows: unknown[];
+    rowCount?: number;
+    command?: string;
+  }> = [],
+) {
+  setupQueryResponses(pgClient, [
+    // getActivePartition
+    { pattern: "batch_queue_meta", rows: [{ value: String(job.partition_id) }] },
+    // dequeueJob (SKIP LOCKED)
+    { pattern: "FOR UPDATE SKIP LOCKED", rows: [job] },
+    // BEGIN/COMMIT
+    { pattern: "BEGIN", rows: [], command: "BEGIN" },
+    { pattern: "COMMIT", rows: [], command: "COMMIT" },
+    { pattern: "ROLLBACK", rows: [], command: "ROLLBACK" },
+    // SET statements (batch settings)
+    { pattern: "SET lock_timeout", rows: [] },
+    { pattern: "SET statement_timeout", rows: [] },
+    { pattern: "SET search_path", rows: [] },
+    // updateHeartbeat
+    {
+      pattern: "heartbeat_at = now()",
+      rows: [],
+      rowCount: 1,
+      command: "UPDATE",
+    },
+    // updateJobProgress (last_pk update)
+    {
+      pattern: /UPDATE.*last_pk = \$1/,
+      rows: [],
+      rowCount: 1,
+      command: "UPDATE",
+    },
+    // completeJob: getJob (SELECT) then transition (UPDATE)
+    { pattern: "SELECT *", rows: [{ ...job, status: "running" }] },
+    {
+      pattern: /UPDATE.*status = \$3/,
+      rows: [{ ...job, status: "done" }],
+      rowCount: 1,
+      command: "UPDATE",
+    },
+    // failJob: this is also used for pause/cancel
+    ...extraResponses,
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("batch/worker", () => {
+  beforeEach(() => {
+    mockInstances = [];
+  });
+
+  // -----------------------------------------------------------------------
+  // Constants
+  // -----------------------------------------------------------------------
+
+  describe("constants", () => {
+    it("DEFAULT_LOCK_TIMEOUT_MS is 5000 (5 seconds)", () => {
+      expect(DEFAULT_LOCK_TIMEOUT_MS).toBe(5_000);
+    });
+
+    it("DEFAULT_STATEMENT_TIMEOUT_MS is 0 (disabled)", () => {
+      expect(DEFAULT_STATEMENT_TIMEOUT_MS).toBe(0);
+    });
+
+    it("DEFAULT_SEARCH_PATH is 'public'", () => {
+      expect(DEFAULT_SEARCH_PATH).toBe("public");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // No work available
+  // -----------------------------------------------------------------------
+
+  describe("no pending jobs", () => {
+    it("returns no_work when queue is empty", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [] },
+      ]);
+
+      const dml = fixedDml([]);
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      const result = await worker.run();
+
+      expect(result.status).toBe("no_work");
+      expect(result.jobId).toBeNull();
+      expect(result.batchesProcessed).toBe(0);
+      expect(result.totalRowsAffected).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic batch execution
+  // -----------------------------------------------------------------------
+
+  describe("batch execution loop", () => {
+    it("processes batches until DML returns 0 rows", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      // 3 batches of 100 rows, then 0 (done)
+      const dml = fixedDml([
+        { rowsAffected: 100, lastPk: "100" },
+        { rowsAffected: 100, lastPk: "200" },
+        { rowsAffected: 100, lastPk: "300" },
+        { rowsAffected: 0, lastPk: null },
+      ]);
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      const result = await worker.run();
+
+      expect(result.status).toBe("completed");
+      expect(result.jobId).toBe(1);
+      expect(result.batchesProcessed).toBe(4);
+      expect(result.totalRowsAffected).toBe(300);
+      expect(result.lastPk).toBe("300");
+    });
+
+    it("completes immediately when first batch returns 0 rows", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const dml = fixedDml([{ rowsAffected: 0, lastPk: null }]);
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      const result = await worker.run();
+
+      expect(result.status).toBe("completed");
+      expect(result.batchesProcessed).toBe(1);
+      expect(result.totalRowsAffected).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // PK resume tracking (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  describe("PK resume tracking", () => {
+    it("resumes from job's last_pk when retrying", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+
+      // Job was previously interrupted at PK "500"
+      const job = mockJob({ last_pk: "500" });
+      setupWorkerQueries(pgClient, job);
+
+      let receivedLastPk: string | null = null;
+      const dml: DmlExecutor = async (_db, _job, lastPk) => {
+        receivedLastPk = lastPk;
+        return { rowsAffected: 0, lastPk: null };
+      };
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      await worker.run();
+
+      // The DML executor should have received "500" as the starting PK
+      expect(receivedLastPk).toBe("500");
+    });
+
+    it("passes updated lastPk to successive batch calls", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const receivedPks: Array<string | null> = [];
+      let callIndex = 0;
+      const dml: DmlExecutor = async (_db, _job, lastPk) => {
+        receivedPks.push(lastPk);
+        callIndex++;
+        if (callIndex <= 3) {
+          return { rowsAffected: 50, lastPk: String(callIndex * 50) };
+        }
+        return { rowsAffected: 0, lastPk: null };
+      };
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      await worker.run();
+
+      expect(receivedPks).toEqual([null, "50", "100", "150"]);
+    });
+
+    it("updates last_pk in job row after each batch", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const dml = fixedDml([
+        { rowsAffected: 100, lastPk: "100" },
+        { rowsAffected: 0, lastPk: null },
+      ]);
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      await worker.run();
+
+      // Verify a last_pk update query was issued
+      const pkUpdate = allQueriesMatching(pgClient, /last_pk = \$1/);
+      expect(pkUpdate.length).toBeGreaterThanOrEqual(1);
+      // The first update should have set last_pk to "100"
+      const firstUpdate = pkUpdate.find(
+        (q) => q.values && q.values[0] === "100",
+      );
+      expect(firstUpdate).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // SET statements per batch (DD13, SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  describe("per-batch SET statements", () => {
+    it("re-issues SET lock_timeout at the start of each batch", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const dml = fixedDml([
+        { rowsAffected: 50, lastPk: "50" },
+        { rowsAffected: 0, lastPk: null },
+      ]);
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        { lockTimeoutMs: 3000 },
+        undefined,
+        instantSleep,
+      );
+      await worker.run();
+
+      const setQueries = allQueriesMatching(pgClient, "SET lock_timeout");
+      // Should have at least 2 SET lock_timeout queries (one per batch)
+      // plus the one from initial session setup
+      expect(setQueries.length).toBeGreaterThanOrEqual(2);
+      // Verify the value used
+      const batchSet = setQueries.find((q) => q.text.includes("3000"));
+      expect(batchSet).toBeDefined();
+    });
+
+    it("re-issues SET statement_timeout at the start of each batch", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const dml = fixedDml([{ rowsAffected: 0, lastPk: null }]);
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        { statementTimeoutMs: 30000 },
+        undefined,
+        instantSleep,
+      );
+      await worker.run();
+
+      const setQueries = allQueriesMatching(pgClient, "SET statement_timeout");
+      const batchSet = setQueries.find((q) => q.text.includes("30000"));
+      expect(batchSet).toBeDefined();
+    });
+
+    it("re-issues SET search_path at the start of each batch", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const dml = fixedDml([{ rowsAffected: 0, lastPk: null }]);
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        { searchPath: "myschema" },
+        undefined,
+        instantSleep,
+      );
+      await worker.run();
+
+      const setQueries = allQueriesMatching(pgClient, "SET search_path");
+      const batchSet = setQueries.find((q) => q.text.includes("myschema"));
+      expect(batchSet).toBeDefined();
+    });
+
+    it("uses default search_path of 'public' when not configured", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const dml = fixedDml([{ rowsAffected: 0, lastPk: null }]);
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      await worker.run();
+
+      const setQueries = allQueriesMatching(pgClient, "SET search_path");
+      const batchSet = setQueries.find((q) => q.text.includes("public"));
+      expect(batchSet).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Per-batch transactions (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  describe("per-batch transactions", () => {
+    it("wraps each batch in BEGIN/COMMIT", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const dml = fixedDml([
+        { rowsAffected: 100, lastPk: "100" },
+        { rowsAffected: 0, lastPk: null },
+      ]);
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      await worker.run();
+
+      const begins = allQueriesMatching(pgClient, "BEGIN");
+      const commits = allQueriesMatching(pgClient, "COMMIT");
+      // At least 2 batches -> 2 BEGINs and 2 COMMITs
+      expect(begins.length).toBeGreaterThanOrEqual(2);
+      expect(commits.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Heartbeat updates (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  describe("heartbeat updates", () => {
+    it("updates heartbeat after each batch", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const dml = fixedDml([
+        { rowsAffected: 100, lastPk: "100" },
+        { rowsAffected: 100, lastPk: "200" },
+        { rowsAffected: 0, lastPk: null },
+      ]);
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      await worker.run();
+
+      const heartbeats = allQueriesMatching(pgClient, "heartbeat_at = now()");
+      // Should have at least 3 heartbeat updates (one per batch)
+      expect(heartbeats.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Sleep/throttling (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  describe("throttling behavior", () => {
+    it("sleeps for configured interval between batches", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ sleep_ms: 200 });
+
+      setupWorkerQueries(pgClient, job);
+
+      const sleepCalls: number[] = [];
+      const trackingSleep = async (ms: number) => {
+        sleepCalls.push(ms);
+      };
+
+      const dml = fixedDml([
+        { rowsAffected: 100, lastPk: "100" },
+        { rowsAffected: 100, lastPk: "200" },
+        { rowsAffected: 0, lastPk: null },
+      ]);
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        {},
+        undefined,
+        trackingSleep,
+      );
+      await worker.run();
+
+      // Sleep called between batches (not after the final 0-row batch)
+      // Batches: [100 rows -> sleep] [100 rows -> sleep] [0 rows -> done]
+      expect(sleepCalls.length).toBe(2);
+      expect(sleepCalls[0]).toBe(200);
+      expect(sleepCalls[1]).toBe(200);
+    });
+
+    it("uses config sleepMs over job sleep_ms", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ sleep_ms: 200 });
+
+      setupWorkerQueries(pgClient, job);
+
+      const sleepCalls: number[] = [];
+      const trackingSleep = async (ms: number) => {
+        sleepCalls.push(ms);
+      };
+
+      const dml = fixedDml([
+        { rowsAffected: 100, lastPk: "100" },
+        { rowsAffected: 0, lastPk: null },
+      ]);
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        { sleepMs: 500 },
+        undefined,
+        trackingSleep,
+      );
+      await worker.run();
+
+      expect(sleepCalls[0]).toBe(500);
+    });
+
+    it("does not sleep after the final batch (0 rows)", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const sleepCalls: number[] = [];
+      const trackingSleep = async (ms: number) => {
+        sleepCalls.push(ms);
+      };
+
+      const dml = fixedDml([{ rowsAffected: 0, lastPk: null }]);
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        {},
+        undefined,
+        trackingSleep,
+      );
+      await worker.run();
+
+      // No sleep because the first batch returned 0 rows -> immediate done
+      expect(sleepCalls.length).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Configurable batch_size (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  describe("configurable batch_size", () => {
+    it("passes config batchSize to DML executor over job default", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ batch_size: 1000 });
+
+      setupWorkerQueries(pgClient, job);
+
+      let receivedBatchSize = 0;
+      const dml: DmlExecutor = async (_db, receivedJob, _lastPk) => {
+        receivedBatchSize = receivedJob.batch_size;
+        return { rowsAffected: 0, lastPk: null };
+      };
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        { batchSize: 250 },
+        undefined,
+        instantSleep,
+      );
+      await worker.run();
+
+      expect(receivedBatchSize).toBe(250);
+    });
+
+    it("falls back to job batch_size when config does not specify", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ batch_size: 777 });
+
+      setupWorkerQueries(pgClient, job);
+
+      let receivedBatchSize = 0;
+      const dml: DmlExecutor = async (_db, receivedJob, _lastPk) => {
+        receivedBatchSize = receivedJob.batch_size;
+        return { rowsAffected: 0, lastPk: null };
+      };
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      await worker.run();
+
+      expect(receivedBatchSize).toBe(777);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Pause signal (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  describe("pause signal", () => {
+    it("stops processing when signal returns pause", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ attempt: 1, max_retries: 3 });
+
+      // For failJob, we need the SELECT and UPDATE for the fail transition
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [job] },
+        { pattern: "BEGIN", rows: [], command: "BEGIN" },
+        { pattern: "COMMIT", rows: [], command: "COMMIT" },
+        { pattern: "SET lock_timeout", rows: [] },
+        { pattern: "SET statement_timeout", rows: [] },
+        { pattern: "SET search_path", rows: [] },
+        { pattern: "heartbeat_at = now()", rows: [], rowCount: 1, command: "UPDATE" },
+        { pattern: /last_pk = \$1/, rows: [], rowCount: 1, command: "UPDATE" },
+        // failJob needs: getJob (SELECT) -> transition (UPDATE)
+        { pattern: "SELECT *", rows: [{ ...job, status: "running" }] },
+        { pattern: /status = \$3/, rows: [{ ...job, status: "failed" }], rowCount: 1, command: "UPDATE" },
+      ]);
+
+      let callCount = 0;
+      const signalCheck: SignalCheckFn = () => {
+        callCount++;
+        // Pause on second check (after first batch completes)
+        return callCount >= 2 ? "pause" : "continue";
+      };
+
+      const dml = fixedDml([
+        { rowsAffected: 100, lastPk: "100" },
+        { rowsAffected: 100, lastPk: "200" }, // should not reach
+      ]);
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        {},
+        signalCheck,
+        instantSleep,
+      );
+      const result = await worker.run();
+
+      expect(result.status).toBe("paused");
+      expect(result.batchesProcessed).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cancel signal (SPEC Section 5.5)
+  // -----------------------------------------------------------------------
+
+  describe("cancel signal", () => {
+    it("stops processing when signal returns cancel", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ attempt: 1, max_retries: 3 });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [job] },
+        // failJob: getJob then transition
+        { pattern: "SELECT *", rows: [{ ...job, status: "running" }] },
+        { pattern: /status = \$3/, rows: [{ ...job, status: "failed" }], rowCount: 1, command: "UPDATE" },
+      ]);
+
+      const signalCheck: SignalCheckFn = () => "cancel";
+
+      const dml = fixedDml([]);
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        {},
+        signalCheck,
+        instantSleep,
+      );
+      const result = await worker.run();
+
+      expect(result.status).toBe("cancelled");
+      expect(result.batchesProcessed).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("marks job as failed when DML throws an error", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ attempt: 1, max_retries: 3 });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [job] },
+        { pattern: "BEGIN", rows: [], command: "BEGIN" },
+        { pattern: "ROLLBACK", rows: [], command: "ROLLBACK" },
+        { pattern: "SET lock_timeout", rows: [] },
+        { pattern: "SET statement_timeout", rows: [] },
+        { pattern: "SET search_path", rows: [] },
+        // failJob: getJob then transition
+        { pattern: "SELECT *", rows: [{ ...job, status: "running" }] },
+        { pattern: /status = \$3/, rows: [{ ...job, status: "failed" }], rowCount: 1, command: "UPDATE" },
+      ]);
+
+      const dml = failingDml(1, "deadlock detected");
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      const result = await worker.run();
+
+      expect(result.status).toBe("failed");
+      expect(result.error).toBe("deadlock detected");
+      expect(result.jobId).toBe(1);
+    });
+
+    it("reports error message in the result", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ attempt: 1, max_retries: 3 });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [job] },
+        { pattern: "BEGIN", rows: [], command: "BEGIN" },
+        { pattern: "ROLLBACK", rows: [], command: "ROLLBACK" },
+        { pattern: "SET lock_timeout", rows: [] },
+        { pattern: "SET statement_timeout", rows: [] },
+        { pattern: "SET search_path", rows: [] },
+        { pattern: "SELECT *", rows: [{ ...job, status: "running" }] },
+        { pattern: /status = \$3/, rows: [{ ...job, status: "failed" }], rowCount: 1, command: "UPDATE" },
+      ]);
+
+      const dml = failingDml(1, "statement timeout exceeded");
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      const result = await worker.run();
+
+      expect(result.error).toBe("statement timeout exceeded");
+    });
+
+    it("preserves partial progress on failure", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ attempt: 1, max_retries: 3 });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [job] },
+        { pattern: "BEGIN", rows: [], command: "BEGIN" },
+        { pattern: "COMMIT", rows: [], command: "COMMIT" },
+        { pattern: "ROLLBACK", rows: [], command: "ROLLBACK" },
+        { pattern: "SET lock_timeout", rows: [] },
+        { pattern: "SET statement_timeout", rows: [] },
+        { pattern: "SET search_path", rows: [] },
+        { pattern: "heartbeat_at = now()", rows: [], rowCount: 1, command: "UPDATE" },
+        { pattern: /last_pk = \$1/, rows: [], rowCount: 1, command: "UPDATE" },
+        { pattern: "SELECT *", rows: [{ ...job, status: "running" }] },
+        { pattern: /status = \$3/, rows: [{ ...job, status: "failed" }], rowCount: 1, command: "UPDATE" },
+      ]);
+
+      // Succeeds twice, then fails on 3rd call
+      const dml = failingDml(3, "connection lost");
+
+      const worker = new BatchWorker(client, dml, {}, undefined, instantSleep);
+      const result = await worker.run();
+
+      expect(result.status).toBe("failed");
+      expect(result.batchesProcessed).toBe(2);
+      expect(result.totalRowsAffected).toBe(200);
+      expect(result.lastPk).toBe("200");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Config overrides
+  // -----------------------------------------------------------------------
+
+  describe("configuration", () => {
+    it("uses custom schema for queue operations", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [] },
+      ]);
+
+      const dml = fixedDml([]);
+      const worker = new BatchWorker(
+        client,
+        dml,
+        { schema: "custom_schema" },
+        undefined,
+        instantSleep,
+      );
+      const result = await worker.run();
+
+      expect(result.status).toBe("no_work");
+      // Verify the queue was constructed with the custom schema by
+      // checking that queries reference it
+      const schemaQ = findQuery(pgClient, "custom_schema");
+      expect(schemaQ).toBeDefined();
+    });
+
+    it("accepts all config options without error", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [] },
+      ]);
+
+      const config: BatchWorkerConfig = {
+        batchSize: 500,
+        sleepMs: 50,
+        lockTimeoutMs: 10000,
+        statementTimeoutMs: 60000,
+        searchPath: "app,public",
+        schema: "sqlever",
+      };
+
+      const dml = fixedDml([]);
+      const worker = new BatchWorker(
+        client,
+        dml,
+        config,
+        undefined,
+        instantSleep,
+      );
+      const result = await worker.run();
+      expect(result.status).toBe("no_work");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Signal check is async-safe
+  // -----------------------------------------------------------------------
+
+  describe("async signal check", () => {
+    it("supports async signal check functions", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob({ attempt: 1, max_retries: 3 });
+
+      setupQueryResponses(pgClient, [
+        { pattern: "batch_queue_meta", rows: [{ value: "0" }] },
+        { pattern: "FOR UPDATE SKIP LOCKED", rows: [job] },
+        { pattern: "SELECT *", rows: [{ ...job, status: "running" }] },
+        { pattern: /status = \$3/, rows: [{ ...job, status: "failed" }], rowCount: 1, command: "UPDATE" },
+      ]);
+
+      const signalCheck: SignalCheckFn = async () => {
+        // Simulate async check (e.g., reading a file or querying DB)
+        return "cancel";
+      };
+
+      const dml = fixedDml([]);
+      const worker = new BatchWorker(
+        client,
+        dml,
+        {},
+        signalCheck,
+        instantSleep,
+      );
+      const result = await worker.run();
+
+      expect(result.status).toBe("cancelled");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Search path quoting
+  // -----------------------------------------------------------------------
+
+  describe("search_path quoting", () => {
+    it("quotes multi-schema search_path correctly", async () => {
+      const client = await makeClient();
+      const pgClient = latestPgClient();
+      const job = mockJob();
+
+      setupWorkerQueries(pgClient, job);
+
+      const dml = fixedDml([{ rowsAffected: 0, lastPk: null }]);
+
+      const worker = new BatchWorker(
+        client,
+        dml,
+        { searchPath: "app,public" },
+        undefined,
+        instantSleep,
+      );
+      await worker.run();
+
+      const setQueries = allQueriesMatching(pgClient, "SET search_path");
+      // Should have quoted both schemas
+      const multiSchemaSet = setQueries.find(
+        (q) => q.text.includes('"app"') && q.text.includes('"public"'),
+      );
+      expect(multiSchemaSet).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `src/batch/worker.ts`: the batch execution loop described in SPEC Section 5.5 and issue #103
- Dequeues jobs via `SKIP LOCKED`, executes DML in per-batch transactions with independent commits, tracks last processed PK for resume on retry, sleeps between batches, and checks for pause/cancel signals
- Re-issues `SET lock_timeout`, `SET statement_timeout`, `SET search_path` at the start of each batch transaction as a safety measure (DD13)
- Configurable per job: `batch_size`, `sleep_interval`, `lock_timeout`, `statement_timeout`, `search_path`
- Injectable `DmlExecutor` callback, `SignalCheckFn` for pause/cancel, and `SleepFn` for testability
- 29 tests covering: batch execution loop, PK resume tracking, per-batch SET statements, per-batch transactions, heartbeat updates, throttling/sleep behavior, configurable batch_size, pause/cancel signals, error handling with partial progress preservation, async signal checks, search_path quoting, and custom schema support

## Test plan

- [x] All 29 new tests pass (`bun test tests/unit/batch-worker.test.ts`)
- [x] All 63 existing batch-queue tests still pass (no regressions)
- [x] Tests cover: no-work case, multi-batch completion, immediate completion, PK resume from prior run, successive PK passing, last_pk persistence, SET re-issuance, BEGIN/COMMIT wrapping, heartbeat updates, sleep timing, config overrides, pause signal, cancel signal, DML errors, partial progress on failure, async signals, multi-schema search_path quoting

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)