### PR TITLE
F4: batch CLI commands — add, list, status, pause, resume, cancel, retry

### DIFF
--- a/src/batch/queue.ts
+++ b/src/batch/queue.ts
@@ -29,7 +29,7 @@ import type { DatabaseClient } from "../db/client";
 // ---------------------------------------------------------------------------
 
 /** Job status values matching the lifecycle in SPEC Section 5.5. */
-export type JobStatus = "pending" | "running" | "done" | "failed" | "dead";
+export type JobStatus = "pending" | "running" | "paused" | "done" | "failed" | "dead" | "cancelled";
 
 /** Which partition a job lives in. */
 export type PartitionId = 0 | 1 | 2;
@@ -90,11 +90,13 @@ export const PARTITION_COUNT = 3;
 
 /** Valid status transitions. Maps current status -> allowed next statuses. */
 export const VALID_TRANSITIONS: Record<JobStatus, readonly JobStatus[]> = {
-  pending: ["running"],
-  running: ["done", "failed", "dead"],
+  pending: ["running", "cancelled"],
+  running: ["done", "failed", "dead", "paused", "cancelled"],
+  paused: ["running", "cancelled"],
   failed: ["running", "dead"],
   dead: ["running"],
   done: [],
+  cancelled: [],
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -131,7 +133,7 @@ CREATE TABLE IF NOT EXISTS ${s}.batch_jobs (
   updated_at    timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY (id, partition_id),
   CONSTRAINT batch_jobs_status_check
-    CHECK (status IN ('pending', 'running', 'done', 'failed', 'dead')),
+    CHECK (status IN ('pending', 'running', 'paused', 'done', 'failed', 'dead', 'cancelled')),
   CONSTRAINT batch_jobs_partition_id_check
     CHECK (partition_id IN (0, 1, 2))
 ) PARTITION BY LIST (partition_id);
@@ -415,6 +417,62 @@ export class BatchQueue {
   }
 
   /**
+   * Pause a running job. Transitions running -> paused.
+   */
+  async pauseJob(jobId: number, partitionId: PartitionId): Promise<BatchJob> {
+    return this.transitionJob(jobId, partitionId, "paused");
+  }
+
+  /**
+   * Resume a paused job. Transitions paused -> running.
+   */
+  async resumeJob(jobId: number, partitionId: PartitionId): Promise<BatchJob> {
+    const result = await this.db.query<BatchJob>(
+      `UPDATE ${this.qualifiedName("batch_jobs")}
+       SET status = 'running',
+           heartbeat_at = now(),
+           updated_at = now()
+       WHERE id = $1 AND partition_id = $2 AND status = 'paused'
+       RETURNING *`,
+      [jobId, partitionId],
+    );
+
+    if (result.rows.length === 0) {
+      // Check if job exists to provide a better error
+      const current = await this.getJob(jobId, partitionId);
+      if (!current) {
+        throw new Error(`Job ${jobId} not found in partition ${partitionId}`);
+      }
+      throw new Error(
+        `Cannot resume job ${jobId}: status is '${current.status}', expected 'paused'`,
+      );
+    }
+
+    return result.rows[0]!;
+  }
+
+  /**
+   * Cancel a job. Transitions pending/running/paused -> cancelled.
+   */
+  async cancelJob(jobId: number, partitionId: PartitionId): Promise<BatchJob> {
+    return this.transitionJob(jobId, partitionId, "cancelled");
+  }
+
+  /**
+   * Look up a job by name. Returns the first matching job (most recent).
+   */
+  async getJobByName(name: string): Promise<BatchJob | null> {
+    const result = await this.db.query<BatchJob>(
+      `SELECT * FROM ${this.qualifiedName("batch_jobs")}
+       WHERE name = $1
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [name],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  /**
    * Update heartbeat for a running job.
    */
   async updateHeartbeat(
@@ -532,9 +590,11 @@ export class BatchQueue {
     const counts: Record<JobStatus, number> = {
       pending: 0,
       running: 0,
+      paused: 0,
       done: 0,
       failed: 0,
       dead: 0,
+      cancelled: 0,
     };
 
     for (const row of result.rows) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { parseExplainArgs, runExplain } from "./commands/explain";
 import { runDoctor } from "./commands/doctor";
 import { runDiff } from "./commands/diff";
 import { parseReviewArgs, runReviewCommand } from "./commands/review";
+import { runBatch } from "./commands/batch";
 
 // ---------------------------------------------------------------------------
 // Command registry — all commands from SPEC R1 plus sqlever extensions
@@ -467,6 +468,15 @@ export function main(argv: string[] = process.argv.slice(2)): void {
     runReviewCommand(reviewOpts)
       .then((result) => { if (result.exitCode !== 0) process.exit(result.exitCode); })
       .catch((err: unknown) => { process.stderr.write(`sqlever review: ${err instanceof Error ? err.message : String(err)}\n`); process.exit(1); });
+    return;
+  }
+
+  if (args.command === "batch") {
+    runBatch(args).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`sqlever batch: ${msg}\n`);
+      process.exit(1);
+    });
     return;
   }
 

--- a/src/commands/batch.ts
+++ b/src/commands/batch.ts
@@ -1,0 +1,581 @@
+// src/commands/batch.ts — CLI for batch job management (SPEC Section 5.5)
+//
+// Subcommands:
+//   sqlever batch add <name> --table <t> --batch-size 500 --sleep 100ms
+//   sqlever batch list
+//   sqlever batch status <name>
+//   sqlever batch pause <name>
+//   sqlever batch resume <name>
+//   sqlever batch cancel <name>
+//   sqlever batch retry <name>
+//
+// All subcommands support --format json for machine-readable output.
+
+import type { ParsedArgs } from "../cli";
+import type { BatchJob } from "../batch/queue";
+import { info, error as logError, json as jsonOut, table } from "../output";
+
+// ---------------------------------------------------------------------------
+// Subcommand argument types
+// ---------------------------------------------------------------------------
+
+export interface BatchAddArgs {
+  name: string;
+  table: string;
+  batchSize: number;
+  sleepMs: number;
+  maxRetries: number;
+}
+
+export interface BatchNameArgs {
+  name: string;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+/** Batch subcommands recognized by the router. */
+export const BATCH_SUBCOMMANDS = [
+  "add",
+  "list",
+  "status",
+  "pause",
+  "resume",
+  "cancel",
+  "retry",
+] as const;
+
+export type BatchSubcommand = (typeof BATCH_SUBCOMMANDS)[number];
+
+/**
+ * Parse the `--sleep` value, which may include a unit suffix.
+ * Accepts: "100", "100ms", "2s", "2sec"
+ * Returns milliseconds.
+ */
+export function parseSleepValue(raw: string): number {
+  const trimmed = raw.trim().toLowerCase();
+
+  // Match number + optional unit
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*(ms|s|sec)?$/);
+  if (!match) {
+    throw new Error(
+      `Invalid --sleep value '${raw}'. Expected a number with optional unit (e.g., 100, 100ms, 2s).`,
+    );
+  }
+
+  const value = parseFloat(match[1]!);
+  const unit = match[2] ?? "ms"; // default to milliseconds
+
+  if (unit === "s" || unit === "sec") {
+    return Math.round(value * 1000);
+  }
+  return Math.round(value);
+}
+
+/**
+ * Parse the argv rest array for the `batch add` subcommand.
+ */
+export function parseBatchAddArgs(rest: string[]): BatchAddArgs {
+  let name: string | undefined;
+  let tableName: string | undefined;
+  let batchSize = 1000;
+  let sleepMs = 100;
+  let maxRetries = 3;
+
+  let i = 0;
+  while (i < rest.length) {
+    const arg = rest[i]!;
+
+    if (arg === "--table" || arg === "-t") {
+      tableName = rest[++i];
+      if (!tableName) {
+        throw new Error("--table requires a value");
+      }
+      i++;
+      continue;
+    }
+
+    if (arg === "--batch-size") {
+      const val = rest[++i];
+      if (!val) throw new Error("--batch-size requires a value");
+      batchSize = parseInt(val, 10);
+      if (isNaN(batchSize) || batchSize <= 0) {
+        throw new Error(
+          `Invalid --batch-size '${val}'. Must be a positive integer.`,
+        );
+      }
+      i++;
+      continue;
+    }
+
+    if (arg === "--sleep") {
+      const val = rest[++i];
+      if (!val) throw new Error("--sleep requires a value");
+      sleepMs = parseSleepValue(val);
+      i++;
+      continue;
+    }
+
+    if (arg === "--max-retries") {
+      const val = rest[++i];
+      if (!val) throw new Error("--max-retries requires a value");
+      maxRetries = parseInt(val, 10);
+      if (isNaN(maxRetries) || maxRetries < 0) {
+        throw new Error(
+          `Invalid --max-retries '${val}'. Must be a non-negative integer.`,
+        );
+      }
+      i++;
+      continue;
+    }
+
+    // Skip --format (handled by top-level parser)
+    if (arg === "--format") {
+      i += 2;
+      continue;
+    }
+
+    // First non-flag argument is the name
+    if (!name && !arg.startsWith("-")) {
+      name = arg;
+      i++;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!name) {
+    throw new Error("Missing required argument: <name>");
+  }
+  if (!tableName) {
+    throw new Error("Missing required option: --table <table_name>");
+  }
+
+  return { name, table: tableName, batchSize, sleepMs, maxRetries };
+}
+
+/**
+ * Parse the argv rest array for subcommands that take a single name argument.
+ * Used by: status, pause, resume, cancel, retry
+ */
+export function parseBatchNameArgs(rest: string[]): BatchNameArgs {
+  let name: string | undefined;
+
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i]!;
+
+    // Skip --format (handled by top-level parser)
+    if (arg === "--format") {
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    if (!name) {
+      name = arg;
+      continue;
+    }
+
+    throw new Error(`Unexpected argument: ${arg}`);
+  }
+
+  if (!name) {
+    throw new Error("Missing required argument: <name>");
+  }
+
+  return { name };
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a single batch job for text output.
+ */
+export function formatJobText(job: BatchJob): string {
+  const lines: string[] = [];
+  lines.push(`Name:        ${job.name}`);
+  lines.push(`Status:      ${job.status}`);
+  lines.push(`Table:       ${job.table_name}`);
+  lines.push(`Batch size:  ${job.batch_size}`);
+  lines.push(`Sleep:       ${job.sleep_ms}ms`);
+  lines.push(`Attempt:     ${job.attempt}/${job.max_retries}`);
+  if (job.last_pk !== null) {
+    lines.push(`Last PK:     ${job.last_pk}`);
+  }
+  if (job.error_message) {
+    lines.push(`Error:       ${job.error_message}`);
+  }
+  if (job.heartbeat_at) {
+    lines.push(`Heartbeat:   ${formatTimestamp(job.heartbeat_at)}`);
+  }
+  lines.push(`Created:     ${formatTimestamp(job.created_at)}`);
+  lines.push(`Updated:     ${formatTimestamp(job.updated_at)}`);
+  return lines.join("\n");
+}
+
+/**
+ * Format a list of batch jobs as a table for text output.
+ */
+export function formatJobListText(jobs: BatchJob[]): string {
+  if (jobs.length === 0) {
+    return "No batch jobs found.";
+  }
+
+  const headers = ["NAME", "STATUS", "TABLE", "BATCH_SIZE", "ATTEMPT", "UPDATED"];
+  const rows = jobs.map((j) => [
+    j.name,
+    j.status,
+    j.table_name,
+    String(j.batch_size),
+    `${j.attempt}/${j.max_retries}`,
+    formatTimestamp(j.updated_at),
+  ]);
+
+  return formatTextTable(headers, rows);
+}
+
+/**
+ * Format a batch job as a JSON-serializable object.
+ */
+export function formatJobJson(job: BatchJob): Record<string, unknown> {
+  return {
+    name: job.name,
+    status: job.status,
+    table: job.table_name,
+    batch_size: job.batch_size,
+    sleep_ms: job.sleep_ms,
+    attempt: job.attempt,
+    max_retries: job.max_retries,
+    last_pk: job.last_pk,
+    error_message: job.error_message,
+    heartbeat_at: job.heartbeat_at ? formatTimestamp(job.heartbeat_at) : null,
+    created_at: formatTimestamp(job.created_at),
+    updated_at: formatTimestamp(job.updated_at),
+  };
+}
+
+/**
+ * Format a timestamp as ISO string.
+ */
+function formatTimestamp(d: Date | string): string {
+  if (d instanceof Date) return d.toISOString();
+  return String(d);
+}
+
+/**
+ * Format a simple text table with aligned columns.
+ */
+function formatTextTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((h) => h.length);
+  for (const row of rows) {
+    for (let i = 0; i < headers.length; i++) {
+      const cell = row[i] ?? "";
+      if (cell.length > widths[i]!) {
+        widths[i] = cell.length;
+      }
+    }
+  }
+
+  const pad = (s: string, w: number) =>
+    s + " ".repeat(Math.max(0, w - s.length));
+
+  const lines: string[] = [];
+  lines.push(headers.map((h, i) => pad(h, widths[i]!)).join("  "));
+  lines.push(widths.map((w) => "-".repeat(w)).join("  "));
+  for (const row of rows) {
+    lines.push(
+      headers.map((_, i) => pad(row[i] ?? "", widths[i]!)).join("  "),
+    );
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+const BATCH_HELP = `sqlever batch — Manage batched background data migrations
+
+Usage:
+  sqlever batch <subcommand> [options]
+
+Subcommands:
+  add <name> --table <t>   Register a new batch job
+  list                     Show all jobs and their state
+  status <name>            Show detailed status for a job
+  pause <name>             Pause a running job
+  resume <name>            Resume a paused job
+  cancel <name>            Cancel a job
+  retry <name>             Retry a failed/dead job
+
+Options for 'add':
+  --table, -t <name>       Target table (required)
+  --batch-size <n>         Rows per batch (default: 1000)
+  --sleep <duration>       Sleep between batches (default: 100ms)
+  --max-retries <n>        Max retry attempts (default: 3)
+
+Global options:
+  --format json            Output as JSON
+`;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Route a batch subcommand to the appropriate handler.
+ *
+ * This is the main entry point called from cli.ts.
+ * It parses the first element of args.rest as the subcommand and
+ * dispatches accordingly.
+ */
+export async function runBatch(args: ParsedArgs): Promise<void> {
+  const subcommand = args.rest[0];
+  const subRest = args.rest.slice(1);
+
+  if (!subcommand || args.help) {
+    process.stdout.write(BATCH_HELP);
+    return;
+  }
+
+  if (!BATCH_SUBCOMMANDS.includes(subcommand as BatchSubcommand)) {
+    logError(`sqlever batch: unknown subcommand '${subcommand}'`);
+    process.stdout.write(BATCH_HELP);
+    process.exit(1);
+  }
+
+  const format = args.format;
+
+  switch (subcommand as BatchSubcommand) {
+    case "add":
+      return handleBatchAdd(subRest, format);
+    case "list":
+      return handleBatchList(subRest, format);
+    case "status":
+      return handleBatchStatus(subRest, format);
+    case "pause":
+      return handleBatchPause(subRest, format);
+    case "resume":
+      return handleBatchResume(subRest, format);
+    case "cancel":
+      return handleBatchCancel(subRest, format);
+    case "retry":
+      return handleBatchRetry(subRest, format);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers — each connects to DB, calls queue, outputs result
+// ---------------------------------------------------------------------------
+
+async function getQueue() {
+  const { DatabaseClient } = await import("../db/client");
+  const { BatchQueue } = await import("../batch/queue");
+
+  const dbUri =
+    process.env.SQLEVER_DB_URI ?? process.env.DATABASE_URL ?? "";
+  if (!dbUri) {
+    throw new Error(
+      "No database URI configured. Set SQLEVER_DB_URI or DATABASE_URL, or use --db-uri.",
+    );
+  }
+
+  const client = new DatabaseClient(dbUri, {
+    command: "batch",
+  });
+  await client.connect();
+
+  const queue = new BatchQueue(client);
+  await queue.ensureSchema();
+
+  return { queue, client };
+}
+
+async function handleBatchAdd(
+  rest: string[],
+  format: "text" | "json",
+): Promise<void> {
+  const addArgs = parseBatchAddArgs(rest);
+
+  const { queue, client } = await getQueue();
+  try {
+    const job = await queue.createJob({
+      name: addArgs.name,
+      tableName: addArgs.table,
+      batchSize: addArgs.batchSize,
+      sleepMs: addArgs.sleepMs,
+      maxRetries: addArgs.maxRetries,
+    });
+
+    if (format === "json") {
+      jsonOut(formatJobJson(job));
+    } else {
+      info(`Batch job '${job.name}' created.`);
+      info(formatJobText(job));
+    }
+  } finally {
+    await client.disconnect();
+  }
+}
+
+async function handleBatchList(
+  rest: string[],
+  format: "text" | "json",
+): Promise<void> {
+  // list takes no positional args, only --format
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i]!;
+    if (arg === "--format") {
+      i++;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+    throw new Error(`Unexpected argument: ${arg}`);
+  }
+
+  const { queue, client } = await getQueue();
+  try {
+    const jobs = await queue.listJobs();
+
+    if (format === "json") {
+      jsonOut(jobs.map(formatJobJson));
+    } else {
+      info(formatJobListText(jobs));
+    }
+  } finally {
+    await client.disconnect();
+  }
+}
+
+async function handleBatchStatus(
+  rest: string[],
+  format: "text" | "json",
+): Promise<void> {
+  const nameArgs = parseBatchNameArgs(rest);
+
+  const { queue, client } = await getQueue();
+  try {
+    const job = await queue.getJobByName(nameArgs.name);
+    if (!job) {
+      throw new Error(`Batch job '${nameArgs.name}' not found.`);
+    }
+
+    if (format === "json") {
+      jsonOut(formatJobJson(job));
+    } else {
+      info(formatJobText(job));
+    }
+  } finally {
+    await client.disconnect();
+  }
+}
+
+async function handleBatchPause(
+  rest: string[],
+  format: "text" | "json",
+): Promise<void> {
+  const nameArgs = parseBatchNameArgs(rest);
+
+  const { queue, client } = await getQueue();
+  try {
+    const job = await queue.getJobByName(nameArgs.name);
+    if (!job) {
+      throw new Error(`Batch job '${nameArgs.name}' not found.`);
+    }
+
+    const updated = await queue.pauseJob(job.id, job.partition_id);
+
+    if (format === "json") {
+      jsonOut(formatJobJson(updated));
+    } else {
+      info(`Batch job '${updated.name}' paused.`);
+    }
+  } finally {
+    await client.disconnect();
+  }
+}
+
+async function handleBatchResume(
+  rest: string[],
+  format: "text" | "json",
+): Promise<void> {
+  const nameArgs = parseBatchNameArgs(rest);
+
+  const { queue, client } = await getQueue();
+  try {
+    const job = await queue.getJobByName(nameArgs.name);
+    if (!job) {
+      throw new Error(`Batch job '${nameArgs.name}' not found.`);
+    }
+
+    const updated = await queue.resumeJob(job.id, job.partition_id);
+
+    if (format === "json") {
+      jsonOut(formatJobJson(updated));
+    } else {
+      info(`Batch job '${updated.name}' resumed.`);
+    }
+  } finally {
+    await client.disconnect();
+  }
+}
+
+async function handleBatchCancel(
+  rest: string[],
+  format: "text" | "json",
+): Promise<void> {
+  const nameArgs = parseBatchNameArgs(rest);
+
+  const { queue, client } = await getQueue();
+  try {
+    const job = await queue.getJobByName(nameArgs.name);
+    if (!job) {
+      throw new Error(`Batch job '${nameArgs.name}' not found.`);
+    }
+
+    const updated = await queue.cancelJob(job.id, job.partition_id);
+
+    if (format === "json") {
+      jsonOut(formatJobJson(updated));
+    } else {
+      info(`Batch job '${updated.name}' cancelled.`);
+    }
+  } finally {
+    await client.disconnect();
+  }
+}
+
+async function handleBatchRetry(
+  rest: string[],
+  format: "text" | "json",
+): Promise<void> {
+  const nameArgs = parseBatchNameArgs(rest);
+
+  const { queue, client } = await getQueue();
+  try {
+    const job = await queue.getJobByName(nameArgs.name);
+    if (!job) {
+      throw new Error(`Batch job '${nameArgs.name}' not found.`);
+    }
+
+    const updated = await queue.retryJob(job.id, job.partition_id);
+
+    if (format === "json") {
+      jsonOut(formatJobJson(updated));
+    } else {
+      info(`Batch job '${updated.name}' retried (now running).`);
+    }
+  } finally {
+    await client.disconnect();
+  }
+}

--- a/tests/unit/batch-commands.test.ts
+++ b/tests/unit/batch-commands.test.ts
@@ -1,0 +1,451 @@
+import { describe, it, expect } from "bun:test";
+
+import {
+  parseBatchAddArgs,
+  parseBatchNameArgs,
+  parseSleepValue,
+  formatJobText,
+  formatJobListText,
+  formatJobJson,
+  BATCH_SUBCOMMANDS,
+} from "../../src/commands/batch";
+
+import type { BatchJob, PartitionId } from "../../src/batch/queue";
+import { DEFAULT_BATCH_SIZE, DEFAULT_SLEEP_MS, DEFAULT_MAX_RETRIES } from "../../src/batch/queue";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockJob(overrides: Partial<BatchJob> = {}): BatchJob {
+  return {
+    id: 1,
+    name: "backfill_tiers",
+    status: "pending",
+    partition_id: 0 as PartitionId,
+    table_name: "users",
+    batch_size: DEFAULT_BATCH_SIZE,
+    sleep_ms: DEFAULT_SLEEP_MS,
+    last_pk: null,
+    attempt: 0,
+    max_retries: DEFAULT_MAX_RETRIES,
+    error_message: null,
+    heartbeat_at: null,
+    created_at: new Date("2025-01-01T00:00:00Z"),
+    updated_at: new Date("2025-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseSleepValue
+// ---------------------------------------------------------------------------
+
+describe("parseSleepValue()", () => {
+  it("parses plain number as milliseconds", () => {
+    expect(parseSleepValue("100")).toBe(100);
+  });
+
+  it("parses value with ms suffix", () => {
+    expect(parseSleepValue("200ms")).toBe(200);
+  });
+
+  it("parses value with s suffix (seconds to ms)", () => {
+    expect(parseSleepValue("2s")).toBe(2000);
+  });
+
+  it("parses value with sec suffix", () => {
+    expect(parseSleepValue("3sec")).toBe(3000);
+  });
+
+  it("handles whitespace", () => {
+    expect(parseSleepValue("  500ms  ")).toBe(500);
+  });
+
+  it("throws on invalid format", () => {
+    expect(() => parseSleepValue("abc")).toThrow("Invalid --sleep value");
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseSleepValue("")).toThrow("Invalid --sleep value");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBatchAddArgs
+// ---------------------------------------------------------------------------
+
+describe("parseBatchAddArgs()", () => {
+  it("parses minimal add args (name + --table)", () => {
+    const result = parseBatchAddArgs(["my_job", "--table", "users"]);
+    expect(result.name).toBe("my_job");
+    expect(result.table).toBe("users");
+    expect(result.batchSize).toBe(1000);
+    expect(result.sleepMs).toBe(100);
+    expect(result.maxRetries).toBe(3);
+  });
+
+  it("parses all options", () => {
+    const result = parseBatchAddArgs([
+      "backfill_tier",
+      "--table", "users",
+      "--batch-size", "500",
+      "--sleep", "200ms",
+      "--max-retries", "5",
+    ]);
+    expect(result.name).toBe("backfill_tier");
+    expect(result.table).toBe("users");
+    expect(result.batchSize).toBe(500);
+    expect(result.sleepMs).toBe(200);
+    expect(result.maxRetries).toBe(5);
+  });
+
+  it("parses --table with short flag -t", () => {
+    const result = parseBatchAddArgs(["my_job", "-t", "orders"]);
+    expect(result.table).toBe("orders");
+  });
+
+  it("throws when name is missing", () => {
+    expect(() => parseBatchAddArgs(["--table", "users"])).toThrow(
+      "Missing required argument: <name>",
+    );
+  });
+
+  it("throws when --table is missing", () => {
+    expect(() => parseBatchAddArgs(["my_job"])).toThrow(
+      "Missing required option: --table",
+    );
+  });
+
+  it("throws on invalid --batch-size", () => {
+    expect(() =>
+      parseBatchAddArgs(["my_job", "--table", "t", "--batch-size", "-1"]),
+    ).toThrow("Invalid --batch-size");
+  });
+
+  it("throws on non-numeric --batch-size", () => {
+    expect(() =>
+      parseBatchAddArgs(["my_job", "--table", "t", "--batch-size", "abc"]),
+    ).toThrow("Invalid --batch-size");
+  });
+
+  it("throws on unknown option", () => {
+    expect(() =>
+      parseBatchAddArgs(["my_job", "--table", "t", "--unknown"]),
+    ).toThrow("Unknown option: --unknown");
+  });
+
+  it("skips --format flag (handled by top-level parser)", () => {
+    const result = parseBatchAddArgs([
+      "my_job",
+      "--table", "users",
+      "--format", "json",
+    ]);
+    expect(result.name).toBe("my_job");
+    expect(result.table).toBe("users");
+  });
+
+  it("parses --sleep with seconds", () => {
+    const result = parseBatchAddArgs([
+      "my_job",
+      "--table", "users",
+      "--sleep", "2s",
+    ]);
+    expect(result.sleepMs).toBe(2000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseBatchNameArgs
+// ---------------------------------------------------------------------------
+
+describe("parseBatchNameArgs()", () => {
+  it("parses a single name argument", () => {
+    const result = parseBatchNameArgs(["my_job"]);
+    expect(result.name).toBe("my_job");
+  });
+
+  it("throws when name is missing", () => {
+    expect(() => parseBatchNameArgs([])).toThrow(
+      "Missing required argument: <name>",
+    );
+  });
+
+  it("throws on unexpected extra arguments", () => {
+    expect(() => parseBatchNameArgs(["job1", "job2"])).toThrow(
+      "Unexpected argument: job2",
+    );
+  });
+
+  it("throws on unknown flags", () => {
+    expect(() => parseBatchNameArgs(["--unknown"])).toThrow(
+      "Unknown option: --unknown",
+    );
+  });
+
+  it("skips --format flag", () => {
+    const result = parseBatchNameArgs(["my_job", "--format", "json"]);
+    expect(result.name).toBe("my_job");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BATCH_SUBCOMMANDS
+// ---------------------------------------------------------------------------
+
+describe("BATCH_SUBCOMMANDS", () => {
+  it("includes all 7 subcommands", () => {
+    expect(BATCH_SUBCOMMANDS).toHaveLength(7);
+    expect(BATCH_SUBCOMMANDS).toContain("add");
+    expect(BATCH_SUBCOMMANDS).toContain("list");
+    expect(BATCH_SUBCOMMANDS).toContain("status");
+    expect(BATCH_SUBCOMMANDS).toContain("pause");
+    expect(BATCH_SUBCOMMANDS).toContain("resume");
+    expect(BATCH_SUBCOMMANDS).toContain("cancel");
+    expect(BATCH_SUBCOMMANDS).toContain("retry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatJobText
+// ---------------------------------------------------------------------------
+
+describe("formatJobText()", () => {
+  it("formats a basic job", () => {
+    const job = mockJob();
+    const text = formatJobText(job);
+    expect(text).toContain("Name:        backfill_tiers");
+    expect(text).toContain("Status:      pending");
+    expect(text).toContain("Table:       users");
+    expect(text).toContain("Batch size:  1000");
+    expect(text).toContain("Sleep:       100ms");
+    expect(text).toContain("Attempt:     0/3");
+  });
+
+  it("includes last_pk when present", () => {
+    const job = mockJob({ last_pk: "99999" });
+    const text = formatJobText(job);
+    expect(text).toContain("Last PK:     99999");
+  });
+
+  it("excludes last_pk when null", () => {
+    const job = mockJob({ last_pk: null });
+    const text = formatJobText(job);
+    expect(text).not.toContain("Last PK:");
+  });
+
+  it("includes error message when present", () => {
+    const job = mockJob({ error_message: "OOM killed" });
+    const text = formatJobText(job);
+    expect(text).toContain("Error:       OOM killed");
+  });
+
+  it("includes heartbeat when present", () => {
+    const job = mockJob({ heartbeat_at: new Date("2025-06-15T12:00:00Z") });
+    const text = formatJobText(job);
+    expect(text).toContain("Heartbeat:");
+    expect(text).toContain("2025-06-15");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatJobListText
+// ---------------------------------------------------------------------------
+
+describe("formatJobListText()", () => {
+  it("returns 'No batch jobs found.' for empty list", () => {
+    const text = formatJobListText([]);
+    expect(text).toBe("No batch jobs found.");
+  });
+
+  it("formats a table with headers", () => {
+    const jobs = [mockJob(), mockJob({ id: 2, name: "backfill_orders", table_name: "orders" })];
+    const text = formatJobListText(jobs);
+    expect(text).toContain("NAME");
+    expect(text).toContain("STATUS");
+    expect(text).toContain("TABLE");
+    expect(text).toContain("backfill_tiers");
+    expect(text).toContain("backfill_orders");
+    expect(text).toContain("users");
+    expect(text).toContain("orders");
+  });
+
+  it("includes separator line", () => {
+    const jobs = [mockJob()];
+    const text = formatJobListText(jobs);
+    const lines = text.split("\n");
+    // Second line should be all dashes and spaces
+    expect(lines[1]).toMatch(/^[-\s]+$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatJobJson
+// ---------------------------------------------------------------------------
+
+describe("formatJobJson()", () => {
+  it("returns a plain object with expected keys", () => {
+    const job = mockJob();
+    const json = formatJobJson(job);
+    expect(json.name).toBe("backfill_tiers");
+    expect(json.status).toBe("pending");
+    expect(json.table).toBe("users");
+    expect(json.batch_size).toBe(1000);
+    expect(json.sleep_ms).toBe(100);
+    expect(json.attempt).toBe(0);
+    expect(json.max_retries).toBe(3);
+    expect(json.last_pk).toBeNull();
+    expect(json.error_message).toBeNull();
+    expect(json.heartbeat_at).toBeNull();
+  });
+
+  it("formats timestamps as ISO strings", () => {
+    const job = mockJob();
+    const json = formatJobJson(job);
+    expect(json.created_at).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  it("includes heartbeat_at when present", () => {
+    const job = mockJob({ heartbeat_at: new Date("2025-06-15T12:00:00Z") });
+    const json = formatJobJson(job);
+    expect(json.heartbeat_at).toBe("2025-06-15T12:00:00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI subprocess tests (batch subcommand routing)
+// ---------------------------------------------------------------------------
+
+const CWD = import.meta.dir + "/../..";
+
+async function run(
+  ...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", "run", "src/cli.ts", ...args], {
+    cwd: CWD,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("sqlever batch (CLI subprocess)", () => {
+  it("shows help when no subcommand given", async () => {
+    const { stdout, exitCode } = await run("batch");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("sqlever batch");
+    expect(stdout).toContain("Subcommands:");
+    expect(stdout).toContain("add");
+    expect(stdout).toContain("list");
+    expect(stdout).toContain("status");
+    expect(stdout).toContain("pause");
+    expect(stdout).toContain("resume");
+    expect(stdout).toContain("cancel");
+    expect(stdout).toContain("retry");
+  });
+
+  it("shows help with --help flag (top-level handler)", async () => {
+    const { stdout, exitCode } = await run("batch", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("sqlever batch");
+  });
+
+  it("reports error for unknown subcommand", async () => {
+    const { stderr, exitCode } = await run("batch", "nonexistent");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("unknown subcommand");
+    expect(stderr).toContain("nonexistent");
+  });
+
+  it("reports error for add without required args", async () => {
+    // 'add' with no args fails because of missing name/table, but the error
+    // comes from parseBatchAddArgs (requires DB connection for the actual
+    // operation, but arg parsing happens first).
+    const { stderr, exitCode } = await run("batch", "add");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Missing required argument: <name>");
+  });
+
+  it("reports error for add with name but no --table", async () => {
+    const { stderr, exitCode } = await run("batch", "add", "my_job");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Missing required option: --table");
+  });
+
+  it("reports error for status without name", async () => {
+    const { stderr, exitCode } = await run("batch", "status");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Missing required argument: <name>");
+  });
+
+  it("reports error for pause without name", async () => {
+    const { stderr, exitCode } = await run("batch", "pause");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Missing required argument: <name>");
+  });
+
+  it("reports error for resume without name", async () => {
+    const { stderr, exitCode } = await run("batch", "resume");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Missing required argument: <name>");
+  });
+
+  it("reports error for cancel without name", async () => {
+    const { stderr, exitCode } = await run("batch", "cancel");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Missing required argument: <name>");
+  });
+
+  it("reports error for retry without name", async () => {
+    const { stderr, exitCode } = await run("batch", "retry");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Missing required argument: <name>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue state extension tests (paused/cancelled transitions)
+// ---------------------------------------------------------------------------
+
+describe("extended job status transitions", () => {
+  // These test the VALID_TRANSITIONS map additions
+  it("running -> paused is valid", async () => {
+    const { isValidTransition } = await import("../../src/batch/queue");
+    expect(isValidTransition("running", "paused")).toBe(true);
+  });
+
+  it("paused -> running is valid (resume)", async () => {
+    const { isValidTransition } = await import("../../src/batch/queue");
+    expect(isValidTransition("paused", "running")).toBe(true);
+  });
+
+  it("running -> cancelled is valid", async () => {
+    const { isValidTransition } = await import("../../src/batch/queue");
+    expect(isValidTransition("running", "cancelled")).toBe(true);
+  });
+
+  it("pending -> cancelled is valid", async () => {
+    const { isValidTransition } = await import("../../src/batch/queue");
+    expect(isValidTransition("pending", "cancelled")).toBe(true);
+  });
+
+  it("paused -> cancelled is valid", async () => {
+    const { isValidTransition } = await import("../../src/batch/queue");
+    expect(isValidTransition("paused", "cancelled")).toBe(true);
+  });
+
+  it("cancelled -> running is not valid (terminal state)", async () => {
+    const { isValidTransition } = await import("../../src/batch/queue");
+    expect(isValidTransition("cancelled", "running")).toBe(false);
+  });
+
+  it("done -> paused is not valid", async () => {
+    const { isValidTransition } = await import("../../src/batch/queue");
+    expect(isValidTransition("done", "paused")).toBe(false);
+  });
+});

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -309,7 +309,7 @@ describe("unknown commands", () => {
 
 describe("command stubs", () => {
   // "help" is handled specially (not a stub); "init", "add", "deploy", "log", "revert", "verify", "tag", "rework", "show", "status", "plan", and "analyze" are implemented — exclude them
-  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "deploy" && c !== "log" && c !== "revert" && c !== "verify" && c !== "tag" && c !== "rework" && c !== "show" && c !== "status" && c !== "plan" && c !== "analyze" && c !== "explain" && c !== "diff" && c !== "review");
+  const STUB_COMMANDS = ALL_COMMANDS.filter((c) => c !== "help" && c !== "init" && c !== "add" && c !== "deploy" && c !== "log" && c !== "revert" && c !== "verify" && c !== "tag" && c !== "rework" && c !== "show" && c !== "status" && c !== "plan" && c !== "analyze" && c !== "explain" && c !== "diff" && c !== "review" && c !== "batch");
 
   for (const cmd of STUB_COMMANDS) {
     test(`'${cmd}' prints not-yet-implemented and exits 1`, async () => {


### PR DESCRIPTION
## Summary
- Create `src/commands/batch.ts` with full CLI subcommand routing for `sqlever batch` (add, list, status, pause, resume, cancel, retry)
- Extend `src/batch/queue.ts` with `paused`/`cancelled` states and new methods: `pauseJob`, `resumeJob`, `cancelJob`, `getJobByName`
- Wire `batch` into the main CLI router in `src/cli.ts` as a first-class subcommand with its own arg parsing
- All subcommands support `--format json` for machine-readable output
- 51 tests covering argument parsing, sleep value parsing, text/JSON formatters, subprocess CLI routing, and state transition validation

Closes #105

## Test plan
- [x] `parseSleepValue()` handles ms, s, sec units and rejects invalid input (7 tests)
- [x] `parseBatchAddArgs()` validates name, --table, --batch-size, --sleep, --max-retries (10 tests)
- [x] `parseBatchNameArgs()` validates single name arg, rejects extras (5 tests)
- [x] `formatJobText()` renders all fields including optional last_pk, error, heartbeat (5 tests)
- [x] `formatJobListText()` renders table with headers and handles empty list (3 tests)
- [x] `formatJobJson()` produces correct JSON structure with ISO timestamps (3 tests)
- [x] CLI subprocess: help display, unknown subcommand error, missing arg errors for all 7 subcommands (11 tests)
- [x] Extended state transitions: paused/cancelled validity checks (7 tests)
- [x] Existing batch-queue and CLI tests still pass (112 tests)
- [x] Full test suite: 2080 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)