### PR TITLE
fix: compat tests — Sqitch Docker can't find sqitch.plan

### DIFF
--- a/tests/compat/handoff.test.ts
+++ b/tests/compat/handoff.test.ts
@@ -16,7 +16,7 @@
 //   - PostgreSQL reachable at localhost:5417 (docker compose up)
 
 import { describe, test, expect, beforeEach, afterEach, beforeAll } from "bun:test";
-import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
@@ -52,7 +52,11 @@ function sqitchDbUri(dbName: string): string {
 // ---------------------------------------------------------------------------
 
 async function makeTempDir(): Promise<string> {
-  return mkdtemp(join(tmpdir(), "sqlever-handoff-"));
+  const dir = await mkdtemp(join(tmpdir(), "sqlever-handoff-"));
+  // mkdtemp creates 0700 dirs; Sqitch's Docker image runs as uid 1024
+  // ("sqitch"), which needs read+execute access to the mounted volume.
+  await chmod(dir, 0o755);
+  return dir;
 }
 
 /**
@@ -211,15 +215,19 @@ describe.skipIf(!hasDocker || !hasPg)("compat: mid-deploy handoff", () => {
     const dockerDbUri = sqitchDbUri(dbName);
     const localDbUri = pgUri(dbName);
 
-    // We need to update sqitch.conf to set the engine target for Sqitch.
-    // Sqitch Docker needs a db:pg:// URI via its config.
+    // Rewrite sqitch.conf for Docker: the original has an absolute
+    // host-path top_dir which is meaningless inside the container.
+    // Write a clean conf with engine target so Sqitch can find the plan
+    // at /repo/sqitch.plan (the volume-mounted working directory).
     const confPath = join(tmpDir, "sqitch.conf");
-    const existingConf = await readFile(confPath, "utf-8");
-    const updatedConf = existingConf + `
-[engine "pg"]
-\ttarget = ${dockerDbUri}
-`;
-    await writeFile(confPath, updatedConf);
+    await writeFile(confPath, [
+      "[core]",
+      "\tengine = pg",
+      "",
+      '[engine "pg"]',
+      `\ttarget = ${dockerDbUri}`,
+      "",
+    ].join("\n"));
 
     // 2. Deploy changes 1-5 with Sqitch (Docker)
     const sqitchDeployResult = runSqitchDocker(
@@ -312,14 +320,16 @@ describe.skipIf(!hasDocker || !hasPg)("compat: mid-deploy handoff", () => {
     const dockerDbUri = sqitchDbUri(dbName);
     const localDbUri = pgUri(dbName);
 
-    // Update sqitch.conf with engine target for Sqitch
+    // Rewrite sqitch.conf for Docker (see comment in test 1 above).
     const confPath = join(tmpDir, "sqitch.conf");
-    const existingConf = await readFile(confPath, "utf-8");
-    const updatedConf = existingConf + `
-[engine "pg"]
-\ttarget = ${dockerDbUri}
-`;
-    await writeFile(confPath, updatedConf);
+    await writeFile(confPath, [
+      "[core]",
+      "\tengine = pg",
+      "",
+      '[engine "pg"]',
+      `\ttarget = ${dockerDbUri}`,
+      "",
+    ].join("\n"));
 
     // 2. Deploy all 10 changes with sqlever
     const deployResult = await runSqlever(

--- a/tests/compat/oracle.test.ts
+++ b/tests/compat/oracle.test.ts
@@ -18,7 +18,7 @@
 // Timestamp tolerance: 5 seconds (committed_at will differ between runs)
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
@@ -609,8 +609,11 @@ describe.skipIf(!hasDocker || !hasPg)("compat: sqitch oracle", () => {
       timeout: 120_000,
     });
 
-    // Create temp project directory
+    // Create temp project directory.
+    // mkdtemp creates 0700 dirs; Sqitch's Docker image runs as uid 1024
+    // ("sqitch"), which needs read+execute access to the mounted volume.
     projectDir = await mkdtemp(join(tmpdir(), "sqlever-oracle-"));
+    await chmod(projectDir, 0o755);
 
     // Create both databases
     await createDb(sqitchDb);


### PR DESCRIPTION
## Summary

Fixes the CI compat test failures where Sqitch Docker reported "Plan file sqitch.plan does not exist."

Two root causes:

- **chmod temp directories to 0755** after `mkdtemp` in both `handoff.test.ts` and `oracle.test.ts`. Node's `mkdtemp` creates 0700 directories, but the `sqitch/sqitch` Docker image runs as uid 1024 (`sqitch`), which cannot traverse a directory owned by a different user with mode 0700. This caused Sqitch to report "Plan file sqitch.plan does not exist" because it couldn't even stat files in the mounted volume.

- **Rewrite sqitch.conf instead of appending** in `handoff.test.ts`. The `sqlever init --top-dir /tmp/xxx` command writes `top_dir = /tmp/xxx` (an absolute host path) into sqitch.conf. Inside the Docker container, that host path doesn't exist, so Sqitch looks for the plan at a nonexistent location. The fix writes a clean sqitch.conf without `top_dir`, letting Sqitch default to the working directory (`/repo`, where the volume is mounted).

- The `runSqitchDocker` function correctly passes subcommand args without a redundant `sqitch` prefix (the Docker image's entrypoint is `/bin/sqitch`).

### Remaining issues

After these fixes, the Sqitch Docker commands now succeed (deploy, status, log). However, downstream sqlever bugs are now exposed:

1. **handoff test 1**: sqlever deploy of changes 6-10 fails (exit code 1) after Sqitch successfully deploys changes 1-5. Previously masked by the Sqitch deploy failure.
2. **handoff test 2**: Sqitch status reports "Cannot find this change in sqitch.plan" — likely a change_id mismatch between what sqlever records and what the plan file contains.
3. **oracle test**: sqlever deploy fails with `Change "add_users" requires "add_users@v1.0", which is not in the plan or deployed` — a rework dependency resolution bug in sqlever.

These are separate issues from the Docker configuration fix in this PR.

## Test plan

- [x] CI compat job: Sqitch Docker no longer reports "Plan file sqitch.plan does not exist"
- [x] Sqitch deploy succeeds in handoff test 1 (was failing with exit 2)
- [x] Sqitch deploy succeeds in oracle test (was failing with exit 2)
- [ ] Remaining sqlever-side failures need separate fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)