### PR TITLE
test: fill regression test gaps for 10 oracle-found bugs

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -891,7 +891,7 @@ export async function executeDeploy(
  * keeps `<name>.sql`. This function inspects the plan for duplicate
  * change names and resolves the correct script name for each version.
  */
-function buildScriptNameMap(plan: Plan): Map<string, string> {
+export function buildScriptNameMap(plan: Plan): Map<string, string> {
   const map = new Map<string, string>();
 
   // Group change indices by name to detect reworks

--- a/tests/fixtures/config/top-dir-only.conf
+++ b/tests/fixtures/config/top-dir-only.conf
@@ -1,0 +1,3 @@
+[core]
+	engine = pg
+	top_dir = ./db

--- a/tests/fixtures/known-change-ids.json
+++ b/tests/fixtures/known-change-ids.json
@@ -206,5 +206,53 @@
       "note": ""
     },
     "expected_id": "c4654d467e7dda87dfa38849527a57603656123f"
+  },
+
+  "planner_trailing_space": {
+    "_comment": "Bug 8 regression: planner name with trailing space",
+    "input": {
+      "project": "compat",
+      "change": "trailing_space_planner",
+      "parent": "f5abb43c365b611ccf0968e3e0f250c567197941",
+      "planner_name": "User ",
+      "planner_email": "user@example.com",
+      "planned_at": "2024-07-04T00:09:00Z",
+      "requires": [],
+      "conflicts": [],
+      "note": ""
+    },
+    "expected_id": "6f645fb133f61590e01aa1b81f236121dba46f7d"
+  },
+
+  "note_with_newline": {
+    "_comment": "Bug 9 regression: note containing literal newline character",
+    "input": {
+      "project": "compat",
+      "change": "note_with_newline",
+      "parent": "f5abb43c365b611ccf0968e3e0f250c567197941",
+      "planner_name": "Ada Lovelace",
+      "planner_email": "ada@example.com",
+      "planned_at": "2024-07-04T00:10:00Z",
+      "requires": [],
+      "conflicts": [],
+      "note": "Line one\nLine two"
+    },
+    "expected_id": "6b8f41ba73711a2b7df06d7c6bc228f03434f131"
+  },
+
+  "whitespace_only_planner": {
+    "_comment": "Bug 10 regression: planner name is whitespace only",
+    "input": {
+      "project": "compat",
+      "change": "whitespace_planner",
+      "parent": "f5abb43c365b611ccf0968e3e0f250c567197941",
+      "planner_name": " ",
+      "planner_email": "space@example.com",
+      "planned_at": "2024-07-04T00:11:00Z",
+      "requires": [],
+      "conflicts": [],
+      "note": ""
+    },
+    "expected_id": "80bcda5432fc1bce038badd68ea41c8064e5281a"
   }
 }

--- a/tests/unit/config-merge.test.ts
+++ b/tests/unit/config-merge.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { loadConfig, mergeConfs } from "../../src/config/index";
 import {
   parseSqitchConf,
@@ -283,5 +286,54 @@ describe("mergeConfs", () => {
 
     const allTags = confGetAll(merged, "deploy.tag");
     expect(allTags).toEqual(["v4", "v5"]); // v1, v2, v3 are gone
+  });
+});
+
+// ---------------------------------------------------------------------------
+// top_dir applied to default paths
+// ---------------------------------------------------------------------------
+
+describe("top_dir applied to default paths", () => {
+  it("top_dir is applied to default plan_file path", () => {
+    // Create a temporary project directory with a sqitch.conf that sets
+    // top_dir but does NOT set plan_file, deploy_dir, etc.
+    const dir = join(tmpdir(), `sqlever-top-dir-test-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "sqitch.conf"),
+      "[core]\n\tengine = pg\n\ttop_dir = ./db\n",
+      "utf-8",
+    );
+
+    try {
+      const config = loadConfig(dir, {}, {});
+      // When top_dir=./db and no explicit plan_file, the default plan_file
+      // should be resolved relative to top_dir: ./db/sqitch.plan
+      expect(config.core.plan_file).toBe("db/sqitch.plan");
+      // Similarly, deploy_dir should be under top_dir
+      expect(config.core.deploy_dir).toBe("db/deploy");
+      expect(config.core.revert_dir).toBe("db/revert");
+      expect(config.core.verify_dir).toBe("db/verify");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("explicit plan_file overrides top_dir-based default", () => {
+    const dir = join(tmpdir(), `sqlever-top-dir-override-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "sqitch.conf"),
+      "[core]\n\tengine = pg\n\ttop_dir = ./db\n\tplan_file = custom.plan\n",
+      "utf-8",
+    );
+
+    try {
+      const config = loadConfig(dir, {}, {});
+      // Explicit plan_file should NOT have top_dir prepended
+      expect(config.core.plan_file).toBe("custom.plan");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/deploy.test.ts
+++ b/tests/unit/deploy.test.ts
@@ -66,7 +66,7 @@ mock.module("pg/lib/client", () => ({
 }));
 
 // Type imports (these work statically)
-import type { DeployOptions, DeployDeps } from "../../src/commands/deploy";
+import type { DeployOptions, DeployDeps, buildScriptNameMap as BuildScriptNameMapType } from "../../src/commands/deploy";
 import type { SpawnFn, PsqlRunResult } from "../../src/psql";
 
 // Import after mocking
@@ -78,6 +78,7 @@ const {
   projectLockKey,
   isNonTransactional,
   parseDeployOptions,
+  buildScriptNameMap,
   ADVISORY_LOCK_NAMESPACE,
   EXIT_CONCURRENT_DEPLOY,
   EXIT_DEPLOY_FAILED,
@@ -86,6 +87,7 @@ const {
 } = await import("../../src/commands/deploy");
 const { loadConfig } = await import("../../src/config/index");
 const { PsqlRunner } = await import("../../src/psql");
+const { parsePlan: parsePlanFn } = await import("../../src/plan/parser");
 const { ShutdownManager } = await import("../../src/signals");
 
 // ---------------------------------------------------------------------------
@@ -1323,6 +1325,59 @@ create_schema 2025-01-01T00:00:00Z Test User <test@example.com> # Schema
 
     it("throws when --lock-timeout is missing its value", () => {
       expect(() => parseDeployOptions(makeArgs(["--lock-timeout"]))).toThrow("--lock-timeout requires a value");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildScriptNameMap — rework filename resolution
+  // -----------------------------------------------------------------------
+
+  describe("buildScriptNameMap()", () => {
+    it("maps non-reworked changes to their plain name", () => {
+      const plan = parsePlanFn(`%syntax-version=1.0.0
+%project=myproject
+
+create_schema 2025-01-01T00:00:00Z Test User <test@example.com> # Create schema
+add_users 2025-01-02T00:00:00Z Test User <test@example.com> # Add users table
+`);
+      const map = buildScriptNameMap(plan);
+      for (const change of plan.changes) {
+        expect(map.get(change.change_id)).toBe(change.name);
+      }
+    });
+
+    it("maps earlier reworked change to name@tag, latest to plain name", () => {
+      const plan = parsePlanFn(`%syntax-version=1.0.0
+%project=myproject
+
+add_users 2025-01-01T00:00:00Z Test User <test@example.com> # v1
+@v1.0 2025-01-02T00:00:00Z Test User <test@example.com> # tag v1.0
+add_users [add_users@v1.0] 2025-02-01T00:00:00Z Test User <test@example.com> # v2
+`);
+      const map = buildScriptNameMap(plan);
+      // First occurrence (original) should be add_users@v1.0
+      expect(map.get(plan.changes[0]!.change_id)).toBe("add_users@v1.0");
+      // Second occurrence (reworked/latest) should be plain add_users
+      expect(map.get(plan.changes[1]!.change_id)).toBe("add_users");
+    });
+
+    it("handles multiple reworks with different tags", () => {
+      const plan = parsePlanFn(`%syntax-version=1.0.0
+%project=myproject
+
+add_users 2025-01-01T00:00:00Z Test User <test@example.com> # v1
+@v1.0 2025-01-02T00:00:00Z Test User <test@example.com> # tag v1.0
+add_users [add_users@v1.0] 2025-02-01T00:00:00Z Test User <test@example.com> # v2
+@v2.0 2025-02-02T00:00:00Z Test User <test@example.com> # tag v2.0
+add_users [add_users@v2.0] 2025-03-01T00:00:00Z Test User <test@example.com> # v3
+`);
+      const map = buildScriptNameMap(plan);
+      // First occurrence -> add_users@v1.0
+      expect(map.get(plan.changes[0]!.change_id)).toBe("add_users@v1.0");
+      // Second occurrence -> add_users@v2.0
+      expect(map.get(plan.changes[1]!.change_id)).toBe("add_users@v2.0");
+      // Third occurrence (latest) -> plain add_users
+      expect(map.get(plan.changes[2]!.change_id)).toBe("add_users");
     });
   });
 });

--- a/tests/unit/sqitch-compat-deep.test.ts
+++ b/tests/unit/sqitch-compat-deep.test.ts
@@ -415,6 +415,27 @@ describe("change ID computation against known-change-ids.json", () => {
     const idWithoutNote = computeChangeId(inputWithoutNote as ChangeIdInput);
     expect(idWithoutNote).toBe(idWithEmptyNote);
   });
+
+  // 15. Planner name with trailing space (Bug 8 regression guard)
+  it("15: planner name with trailing space matches expected SHA-1", () => {
+    const entry = getEntry("planner_trailing_space");
+    const id = computeChangeId(entry.input as ChangeIdInput);
+    expect(id).toBe(entry.expected_id);
+  });
+
+  // 16. Note containing newline (Bug 9 regression guard)
+  it("16: note with embedded newline matches expected SHA-1", () => {
+    const entry = getEntry("note_with_newline");
+    const id = computeChangeId(entry.input as ChangeIdInput);
+    expect(id).toBe(entry.expected_id);
+  });
+
+  // 17. Whitespace-only planner name (Bug 10 regression guard)
+  it("17: whitespace-only planner name matches expected SHA-1", () => {
+    const entry = getEntry("whitespace_only_planner");
+    const id = computeChangeId(entry.input as ChangeIdInput);
+    expect(id).toBe(entry.expected_id);
+  });
 });
 
 // =========================================================================

--- a/tests/unit/topo-sort.test.ts
+++ b/tests/unit/topo-sort.test.ts
@@ -187,6 +187,16 @@ describe("topologicalSort", () => {
     expect(sorted).toEqual(["A", "B"]);
   });
 
+  it("handles @tag dependency references", () => {
+    // change_b requires change_a@v1.0 — the @v1.0 suffix must be stripped
+    const changes = [
+      makeChange("change_a"),
+      makeChange("change_b", { requires: ["change_a@v1.0"] }),
+    ];
+    const result = topologicalSort(changes);
+    expect(result.map((c) => c.name)).toEqual(["change_a", "change_b"]);
+  });
+
   it("self-referencing change throws CycleError", () => {
     const changes = [makeChange("A", { requires: ["A"] })];
     expect(() => topologicalSort(changes)).toThrow(CycleError);
@@ -297,6 +307,15 @@ describe("validateDependencies", () => {
 
   it("handles changes with no deps", () => {
     const changes = [makeChange("A"), makeChange("B")];
+    expect(() => validateDependencies(changes, [])).not.toThrow();
+  });
+
+  it("handles @tag references — suffix stripped before lookup", () => {
+    const changes = [
+      makeChange("change_a"),
+      makeChange("change_b", { requires: ["change_a@v1.0"] }),
+    ];
+    // Should not throw — change_a exists, @v1.0 suffix stripped
     expect(() => validateDependencies(changes, [])).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Closes test coverage gaps identified in issue #148:

- **Gap 1 (Bug 2):** `@tag` dependency references in `topologicalSort` and `validateDependencies` -- verifies that `name@tag` suffix is stripped before graph lookup
- **Gap 2 (Bug 3):** `buildScriptNameMap` unit tests -- verifies correct filename resolution for original vs reworked changes (function exported for direct testing)
- **Gap 3 (Bug 6):** `top_dir` applied to default paths -- verifies that `plan_file`, `deploy_dir`, `revert_dir`, `verify_dir` resolve relative to `top_dir` when not explicitly configured
- **Gap 4 (Bugs 8/9/10):** SHA-1 known-good fixtures for whitespace/escape edge cases -- trailing space in planner name, `\n` in note text, whitespace-only planner name

## Test plan

- [x] All 4 new test groups pass locally (`bun test`)
- [x] Full suite: 2636 pass, 0 fail
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)