### PR TITLE
security: audit findings — fix SQL injection risks, validate paths

### DIFF
--- a/src/commands/rework.ts
+++ b/src/commands/rework.ts
@@ -198,6 +198,16 @@ export async function runRework(
     process.exit(1);
   }
 
+  // Validate change name format (same rules as `add` — prevents path traversal)
+  if (!/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(opts.name)) {
+    error(
+      `Error: invalid change name '${opts.name}'. ` +
+      "Names must start with a letter or underscore and contain only " +
+      "letters, digits, underscores, and hyphens.",
+    );
+    process.exit(1);
+  }
+
   // Load config if not provided
   const cfg = config ?? loadConfig(opts.topDir, undefined, environment);
 

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -222,6 +222,21 @@ export function runShow(
     process.exit(1);
   }
 
+  // Validate name format for script types to prevent path traversal.
+  // Change names used in file paths must not contain path separators.
+  // Tag names and change metadata lookups are safe (string comparison only).
+  if (
+    (opts.type === "deploy" || opts.type === "revert" || opts.type === "verify") &&
+    !/^[a-zA-Z_][a-zA-Z0-9_@.-]*$/.test(opts.name)
+  ) {
+    error(
+      `Error: invalid change name '${opts.name}'. ` +
+      "Names must start with a letter or underscore and contain only " +
+      "letters, digits, underscores, hyphens, dots, and @.",
+    );
+    process.exit(1);
+  }
+
   // Load config if not provided
   const cfg = config ?? loadConfig(opts.topDir, undefined, undefined);
   const topDir = resolve(opts.topDir ?? cfg.core.top_dir);

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -182,10 +182,25 @@ export class DatabaseClient {
 
     const appName = `sqlever/${command}/${project}`;
 
-    // Use a single SET command batch for efficiency. Each SET is a
-    // separate statement because PostgreSQL doesn't support multi-SET.
-    // Numeric timeouts are safe to interpolate (they are validated ints),
-    // but application_name is user-controlled text, so we use
+    // SECURITY: Validate that all timeout values are safe non-negative
+    // integers before interpolating them into SQL. This prevents SQL
+    // injection if a caller ever passes a non-numeric value.
+    const timeouts = [
+      { name: "statement_timeout", value: statementTimeout },
+      { name: "lock_timeout", value: lockTimeout },
+      { name: "idle_in_transaction_session_timeout", value: idleInTransactionSessionTimeout },
+    ];
+
+    for (const { name, value } of timeouts) {
+      if (!Number.isFinite(value) || value < 0 || !Number.isInteger(value)) {
+        throw new Error(
+          `Invalid session setting: ${name} must be a non-negative integer, got ${value}`,
+        );
+      }
+    }
+
+    // Numeric timeouts are validated ints above, safe to interpolate.
+    // application_name is user-controlled text, so we use
     // set_config() with a parameterized query to avoid SQL injection.
     const statements = [
       `SET statement_timeout = ${statementTimeout}`,

--- a/src/expand-contract/tracker.ts
+++ b/src/expand-contract/tracker.ts
@@ -438,32 +438,31 @@ export class ExpandContractTracker {
    * Compares the total row count against the count of rows where the
    * new column is NOT NULL (i.e., has been backfilled).
    *
+   * SECURITY: Identifiers (schema, table, column) are escaped via
+   * escapeIdentifier() which double-quotes and escapes embedded quotes.
+   * The source_filter field is intentionally ignored — it previously
+   * allowed raw SQL injection. Callers that need filtered backfill
+   * checks should implement the filtering in their own migration SQL.
+   *
    * @param input - Table and column information
    * @returns Backfill status with counts and completion flag
    */
   async checkBackfill(input: BackfillCheckInput): Promise<BackfillStatus> {
-    // We use quote_ident() on the server side to safely handle identifiers,
-    // but since we're building a dynamic query client-side, we validate
-    // identifiers here and use them directly. This is safe because
-    // identifiers are constrained to valid PostgreSQL names.
     const schema = this.escapeIdentifier(input.table_schema);
     const table = this.escapeIdentifier(input.table_name);
     const column = this.escapeIdentifier(input.new_column);
 
-    // Count total rows (optionally filtered by source)
-    let totalSql = `SELECT COUNT(*)::int AS cnt FROM ${schema}.${table}`;
-    if (input.source_filter) {
-      totalSql += ` WHERE ${input.source_filter}`;
-    }
+    // SECURITY: source_filter is not used — it was a raw SQL injection
+    // vector. All queries use only escaped identifiers.
+
+    // Count total rows
+    const totalSql = `SELECT COUNT(*)::int AS cnt FROM ${schema}.${table}`;
 
     const totalResult = await this.db.query<{ cnt: number }>(totalSql);
     const total_rows = totalResult.rows[0]?.cnt ?? 0;
 
     // Count backfilled rows (new column IS NOT NULL)
-    let backfilledSql = `SELECT COUNT(*)::int AS cnt FROM ${schema}.${table} WHERE ${column} IS NOT NULL`;
-    if (input.source_filter) {
-      backfilledSql += ` AND ${input.source_filter}`;
-    }
+    const backfilledSql = `SELECT COUNT(*)::int AS cnt FROM ${schema}.${table} WHERE ${column} IS NOT NULL`;
 
     const backfilledResult = await this.db.query<{ cnt: number }>(backfilledSql);
     const backfilled_rows = backfilledResult.rows[0]?.cnt ?? 0;

--- a/src/includes/snapshot.ts
+++ b/src/includes/snapshot.ts
@@ -13,7 +13,7 @@
 // When the git history is unavailable (no repo, file never committed),
 // falls back to HEAD (current working tree).
 
-import { execSync, type ExecSyncOptions } from "node:child_process";
+import { execFileSync, type ExecSyncOptions } from "node:child_process";
 import { dirname, join, resolve, normalize } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
 
@@ -166,6 +166,10 @@ export function findIncludes(content: string): IncludeDirective[] {
 /**
  * Execute a git command synchronously and return stdout.
  * Returns undefined on any error (not a git repo, file doesn't exist, etc.).
+ *
+ * Uses execFileSync (not execSync) to avoid shell interpretation of
+ * arguments. This prevents command injection via crafted file paths,
+ * commit hashes, or timestamps that might contain shell metacharacters.
  */
 function gitExec(
   args: string[],
@@ -178,7 +182,7 @@ function gitExec(
       timeout: 10_000,
       maxBuffer: 10 * 1024 * 1024, // 10 MB — generous for large SQL files
     };
-    const result = execSync(`git ${args.join(" ")}`, opts);
+    const result = execFileSync("git", args, opts);
     return result.toString();
   } catch {
     return undefined;

--- a/src/psql.ts
+++ b/src/psql.ts
@@ -226,7 +226,15 @@ export function buildPsqlCommand(
   // When lockTimeout is set, prepend a -c "SET lock_timeout = '<ms>ms'"
   // command before the script file. psql executes -c commands in order,
   // so the SET takes effect before the script runs.
+  //
+  // SECURITY: Validate that lockTimeout is a safe non-negative integer
+  // before interpolating into the SQL command string.
   if (options.lockTimeout != null && options.lockTimeout >= 0) {
+    if (!Number.isFinite(options.lockTimeout) || !Number.isInteger(options.lockTimeout)) {
+      throw new Error(
+        `Invalid lock timeout: ${options.lockTimeout}. Must be a non-negative integer.`,
+      );
+    }
     args.push("-c", `SET lock_timeout = '${options.lockTimeout}ms'`);
   }
 

--- a/tests/unit/expand-contract-tracker.test.ts
+++ b/tests/unit/expand-contract-tracker.test.ts
@@ -873,7 +873,10 @@ describe("ExpandContractTracker", () => {
       expect(result.is_complete).toBe(true);
     });
 
-    it("includes source_filter in queries when provided", async () => {
+    it("ignores source_filter to prevent SQL injection", async () => {
+      // SECURITY: source_filter was removed because it allowed raw SQL
+      // injection. This test verifies that even when provided, it is
+      // not included in the generated queries.
       const db = await createConnectedClient();
       const tracker = new ExpandContractTracker(db);
       const pgClient = getPgClient();
@@ -891,17 +894,15 @@ describe("ExpandContractTracker", () => {
         source_filter: "name IS NOT NULL",
       });
 
-      // Both queries should include the source filter
+      // Neither query should include the source_filter text
       const countQueries = pgClient.queries.filter((q) =>
         q.text.includes("COUNT(*)"),
       );
       expect(countQueries.length).toBeGreaterThanOrEqual(2);
 
-      const totalQuery = countQueries.find((q) => !q.text.includes("IS NOT NULL AND"));
-      expect(totalQuery?.text).toContain("WHERE name IS NOT NULL");
-
-      const backfilledQuery = countQueries.find((q) => q.text.includes("IS NOT NULL AND"));
-      expect(backfilledQuery?.text).toContain("AND name IS NOT NULL");
+      for (const query of countQueries) {
+        expect(query.text).not.toContain("name IS NOT NULL");
+      }
     });
 
     it("escapes identifiers to prevent SQL injection", async () => {


### PR DESCRIPTION
## Summary

Security audit of the sqlever codebase covering SQL injection, command injection, password exposure, path traversal, and subprocess safety. Six vulnerabilities found and fixed across 6 source files.

### Findings and fixes

- **CRITICAL — Command injection in `gitExec()`** (`src/includes/snapshot.ts`): Used `execSync` with string concatenation (`git ${args.join(" ")}`), allowing shell metacharacter injection via crafted file paths, commit hashes, or timestamps. Fixed by switching to `execFileSync` which bypasses the shell.

- **HIGH — SQL injection via `source_filter`** (`src/expand-contract/tracker.ts`): The `checkBackfill()` method interpolated `input.source_filter` directly into SQL queries (`WHERE ${input.source_filter}`). This is a textbook SQL injection vector. Fixed by removing `source_filter` usage from generated queries entirely.

- **MEDIUM — Unvalidated numeric interpolation in session settings** (`src/db/client.ts`): `statementTimeout`, `lockTimeout`, and `idleInTransactionSessionTimeout` were interpolated into SQL SET statements without validation. Added explicit checks that values are non-negative finite integers before interpolation.

- **MEDIUM — Unvalidated `lockTimeout` in psql command builder** (`src/psql.ts`): `buildPsqlCommand()` interpolated `lockTimeout` into a `-c "SET lock_timeout = '${ms}ms'"` argument without type validation. Added integer validation.

- **LOW — Missing name validation in rework command** (`src/commands/rework.ts`): Unlike `add` which validates change names against `^[a-zA-Z_][a-zA-Z0-9_-]*$`, `rework` accepted any string, allowing path traversal when constructing file paths like `deploy/${name}.sql`. Added the same validation regex.

- **LOW — Missing name validation in show command** (`src/commands/show.ts`): `resolveScriptPath()` used `changeName` in `join(topDir, scriptDir, changeName + ".sql")` without validation. Added name format check for script display types (deploy/revert/verify).

### What was audited and found clean

- **SQL injection in registry queries**: All 20+ queries in `src/db/registry.ts` use parameterized statements (`$1`, `$2`, ...). No string interpolation.
- **Password exposure**: Passwords are correctly masked via `maskUri()` in all log output. psql receives passwords via `PGPASSWORD` env var, never command-line args. The `extractPassword()` function strips passwords from URIs before adding them to the args array.
- **Subprocess safety**: `spawn()` is used with array arguments (not shell strings) throughout. `.psqlrc` is disabled via both env var and `--no-psqlrc` flag. `ON_ERROR_STOP=1` is always set.
- **Change name validation in `add` command**: Already validates with strict regex.
- **DBLab client**: Uses `encodeURIComponent()` for clone IDs in URL paths.

## Test plan

- [x] All 2626 existing tests pass (0 failures, 37 skipped)
- [x] Security edge case tests (37 tests) all pass
- [x] Updated tracker test to verify `source_filter` is now ignored
- [x] No new type errors in changed files (pre-existing type errors in analysis rules are unrelated)


🤖 Generated with [Claude Code](https://claude.com/claude-code)