### PR TITLE
refactor: rename no-transaction to auto-commit (Postgres always has transactions)

### DIFF
--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -27,9 +27,10 @@ on identical migration plans and comparing results:
    versioned path (e.g., `deploy/foo@bar.sql`). Fixed to use correct versioned
    script paths.
 
-4. **Revert ignoring `no-transaction` directive** (`35ffc53`) -- The
-   `-- sqlever:no-transaction` pragma was honored during deploy but silently
-   ignored during revert. Fixed to respect the directive in both directions.
+4. **Revert ignoring `auto-commit` directive** (`35ffc53`) -- The
+   `-- sqlever:auto-commit` (formerly `no-transaction`) pragma was honored during
+   deploy but silently ignored during revert. Fixed to respect the directive in
+   both directions.
 
 5. **Advisory lock leak on revert --to** (`6c861de`) -- When `revert --to` hit
    a validation error, the advisory lock was not released. Fixed to always

--- a/spec/SPEC-CHANGELOG.md
+++ b/spec/SPEC-CHANGELOG.md
@@ -62,7 +62,7 @@ Round 4 expert review findings addressed (convergence check). Same four reviewer
 
 - SA003: clarified that `USING` clause presence always triggers SA003 regardless of the safe cast allowlist
 - SA001: confirmed it does NOT fire when a `DEFAULT` is present (that case is SA002/SA002b territory)
-- `sqlever.*` schema creation: clarified that the `sqlever` schema is created on first non-transactional deploy (not just expand/contract and batched DML)
+- `sqlever.*` schema creation: clarified that the `sqlever` schema is created on first auto-commit deploy (not just expand/contract and batched DML)
 - Version bumped to 0.6
 
 ## [SPEC 0.5] — 2026-03-20
@@ -91,7 +91,7 @@ Round 3 expert review findings addressed. Same four reviewers: PG internals expe
 
 - **`--mode all` is NOT a single transaction in Sqitch:** Sqitch's `_deploy_all` uses per-change transactions with explicit revert on failure, NOT a single wrapping transaction. Documented accurately. sqlever's true single-transaction `--mode all` is a sqlever improvement.
 
-- **`-- sqitch-no-transaction` does NOT exist in Sqitch:** No evidence found in Sqitch source. Changed to `-- sqlever:no-transaction` as a sqlever-only convention. SA020 reference updated.
+- **`-- sqitch-no-transaction` does NOT exist in Sqitch:** No evidence found in Sqitch source. Changed to `-- sqlever:auto-commit` as a sqlever-only convention (legacy `-- sqlever:no-transaction` also accepted). SA020 reference updated.
 
 - **Sqitch uses `LOCK TABLE changes IN EXCLUSIVE MODE`, not advisory locks:** Documented that sqlever's advisory lock approach is a sqlever improvement providing stronger coordination (spans full deploy session vs. per-transaction table lock).
 
@@ -105,7 +105,7 @@ Round 3 expert review findings addressed. Same four reviewers: PG internals expe
 
 - **Hybrid rule interface convention documented:** Hybrid rules check `context.db !== undefined` internally. Suppression filtering happens in analyzer entry point after rules return findings. Rules may produce multiple findings from one statement.
 
-- **`--mode all` + non-transactional partial state documented:** Non-transactional changes that committed before a later failure remain deployed. `sqlever status` reports partial state correctly.
+- **`--mode all` + auto-commit partial state documented:** Auto-commit changes that committed before a later failure remain deployed. `sqlever status` reports partial state correctly.
 
 - **`--strict` and `error_on_warn` relationship documented:** `--strict` is the CLI equivalent of `error_on_warn = true` in config.
 
@@ -131,7 +131,7 @@ Round 2 expert review findings addressed. Four reviewers: PG internals expert, S
 
 ### Critical fixes
 
-- **Advisory lock design resolved:** Resolved xact vs session lock contradiction. Use `pg_advisory_lock` (session-level) as default — only option that works across multi-transaction deploys (`--mode change`) and non-transactional changes. Lock key: `pg_advisory_lock(hashtext('sqlever_deploy_' || project_name))`. Require direct connections for deploy (not PgBouncer in transaction mode). Apply to revert/rebase/checkout too, not just deploy.
+- **Advisory lock design resolved:** Resolved xact vs session lock contradiction. Use `pg_advisory_lock` (session-level) as default — only option that works across multi-transaction deploys (`--mode change`) and auto-commit changes. Lock key: `pg_advisory_lock(hashtext('sqlever_deploy_' || project_name))`. Require direct connections for deploy (not PgBouncer in transaction mode). Apply to revert/rebase/checkout too, not just deploy.
 
 - **`now()` is STABLE, not VOLATILE:** Removed `now()` from SA002 volatile examples — `now()` returns transaction start time and is classified STABLE. Corrected Problem 1 example text. Correct volatile examples: `random()`, `gen_random_uuid()`, `clock_timestamp()`, `txid_current()`. Updated SA002 test fixtures accordingly.
 
@@ -149,11 +149,11 @@ Round 2 expert review findings addressed. Four reviewers: PG internals expert, S
 
 - **Hybrid rule classification introduced:** New `type: "hybrid"` for rules with both static and connected concerns. SA009 (static: NOT VALID detection; connected: index check), SA017 (static: fire on SET NOT NULL; connected: check for CHECK constraint), SA018 (static: fire on ADD PRIMARY KEY; connected: check for pre-existing index).
 
-- **`--mode all` + non-transactional behavior specified:** Non-transactional changes break the transaction (COMMIT before, execute, BEGIN after). Warning emitted when `--mode all` used with non-transactional changes.
+- **`--mode all` + auto-commit behavior specified:** Auto-commit changes break the transaction (COMMIT before, execute, BEGIN after). Warning emitted when `--mode all` used with auto-commit changes.
 
-- **Non-transactional write-ahead tracking:** Before executing non-transactional DDL, write "pending" record to `sqlever.pending_changes`. After success, update to "complete" and write sqitch tracking. On next deploy, check for pending non-transactional changes and verify state.
+- **Auto-commit write-ahead tracking:** Before executing auto-commit DDL, write "pending" record to `sqlever.pending_changes`. After success, update to "complete" and write sqitch tracking. On next deploy, check for pending auto-commit changes and verify state.
 
-- **`--no-transaction` is a script comment in Sqitch:** Fixed — Sqitch uses `-- sqitch-no-transaction` comment in deploy script first line. sqlever supports both the script comment (Sqitch compat) and plan file pragma.
+- **`--auto-commit` (was `--no-transaction`) is a script comment convention in sqlever:** Fixed — Sqitch uses `-- sqitch-no-transaction` comment in deploy script first line. sqlever uses `-- sqlever:auto-commit` as the preferred directive, with `-- sqlever:no-transaction` accepted for backward compatibility.
 
 - **Inline suppression scoping specified:** Unclosed block extends to EOF with warning, single-line comment attaches to preceding statement, comma-separated rule IDs supported, unknown rules produce warning, `all` not supported.
 
@@ -175,7 +175,7 @@ Round 2 expert review findings addressed. Four reviewers: PG internals expert, S
 
 - **idle_in_transaction_session_timeout:** Changed from 0 (unlimited) to configurable generous value (default 10 minutes).
 
-- **Non-transactional statement_timeout:** Separate configurable timeout (default 4 hours) for non-transactional DDL.
+- **Auto-commit statement_timeout:** Separate configurable timeout (default 4 hours) for auto-commit DDL.
 
 - **Lock retry for CI:** Added `--lock-retries N` with exponential backoff (default 0 = no retry).
 
@@ -201,7 +201,7 @@ Comprehensive update based on expert review from four specialists: PG internals 
 
 ### Critical fixes
 
-- **Non-transactional DDL support (C1):** Added `--no-transaction` flag to `sqlever add` and plan file pragma. Deploy data flow updated to execute non-transactional changes without `BEGIN`/`COMMIT` wrapper. Tracking updates happen in a separate transaction. Covers `CREATE INDEX CONCURRENTLY`, `DROP INDEX CONCURRENTLY`, `ALTER TYPE ADD VALUE` (PG < 12), `REINDEX CONCURRENTLY`. Added SA020 rule to detect `CONCURRENTLY` inside transactional deploys.
+- **Auto-commit DDL support (C1):** Added `--auto-commit` flag to `sqlever add` and plan file pragma. Deploy data flow updated to execute auto-commit changes without `BEGIN`/`COMMIT` wrapper. Tracking updates happen in a separate transaction. Covers `CREATE INDEX CONCURRENTLY`, `DROP INDEX CONCURRENTLY`, `ALTER TYPE ADD VALUE` (PG < 12), `REINDEX CONCURRENTLY`. Added SA020 rule to detect `CONCURRENTLY` inside transactional deploys.
 
 - **Advisory locks for deploy coordination (C2):** Deploy data flow now acquires `pg_advisory_xact_lock` (or `pg_advisory_lock`) before executing changes. Second concurrent deploy exits with code 4. Crash recovery: PG auto-releases advisory locks on disconnect. Added integration tests for concurrent deploy scenarios.
 
@@ -293,7 +293,7 @@ Comprehensive update based on expert review from four specialists: PG internals 
 - Registry schema creation specified (IF NOT EXISTS + advisory lock for concurrent first-deploy)
 - Added OPEN markers for: change ID algorithm, script_hash computation, search_path handling, logical replication + expand/contract, PGQ vs SKIP LOCKED queue design, comprehensive SA003 safe-cast list
 - Added `preprocess.ts` to architecture for psql metacommand handling
-- Test fixtures expanded: `reworked/`, `cross-project/`, `conflicts/`, `non-transactional/`
+- Test fixtures expanded: `reworked/`, `cross-project/`, `conflicts/`, `auto-commit/`
 - Dry-run mode: explicitly documented what it does and does NOT guarantee
 
 ## [SPEC 0.2] — 2026-03-20

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -58,7 +58,7 @@ https://github.com/pgq/pgq — 3-partition rotating queue table, entirely inside
 
 ### pg_index_pilot
 
-https://gitlab.com/postgres-ai/postgresai/-/tree/main/components/index_pilot — pure PL/pgSQL tool for managing `REINDEX INDEX CONCURRENTLY` operations. Key design patterns relevant to sqlever: (1) write-ahead tracking with three-state lifecycle (`in_progress` → `completed` | `failed`) for crash recovery of non-transactional DDL, (2) advisory lock coordination using schema OID and `pg_try_advisory_lock()` to prevent concurrent operations, (3) invalid index cleanup by checking `pg_index.indisvalid` and dropping `_ccnew` suffixed indexes left by failed `REINDEX CONCURRENTLY`, (4) explicit pre-DDL commit to release held locks before executing concurrent DDL. These patterns informed sqlever's non-transactional write-ahead tracking and `sqlever.pending_changes` design.
+https://gitlab.com/postgres-ai/postgresai/-/tree/main/components/index_pilot — pure PL/pgSQL tool for managing `REINDEX INDEX CONCURRENTLY` operations. Key design patterns relevant to sqlever: (1) write-ahead tracking with three-state lifecycle (`in_progress` → `completed` | `failed`) for crash recovery of auto-commit DDL, (2) advisory lock coordination using schema OID and `pg_try_advisory_lock()` to prevent concurrent operations, (3) invalid index cleanup by checking `pg_index.indisvalid` and dropping `_ccnew` suffixed indexes left by failed `REINDEX CONCURRENTLY`, (4) explicit pre-DDL commit to release held locks before executing concurrent DDL. These patterns informed sqlever's auto-commit write-ahead tracking and `sqlever.pending_changes` design.
 
 ### Atlas (Ariga)
 
@@ -154,7 +154,7 @@ All Sqitch commands must be supported with identical flags and semantics:
 | Command | Description |
 |---------|-------------|
 | `sqlever init [project]` | Initialize project, create `sqitch.conf` and `sqitch.plan` |
-| `sqlever add <name> [-n note] [-r dep] [--conflict dep]` | Add new change (supports `--no-transaction` pragma) |
+| `sqlever add <name> [-n note] [-r dep] [--conflict dep]` | Add new change (supports `--auto-commit` pragma) |
 | `sqlever deploy [target] [--to change] [--mode [all\|change\|tag]]` | Deploy changes |
 | `sqlever revert [target] [--to change] [-y]` | Revert changes |
 | `sqlever verify [target] [--from change] [--to change]` | Run verify scripts |
@@ -426,7 +426,7 @@ Analyze migration SQL before deploy and flag dangerous patterns. Moved from v1.1
 | `SA017` | error | hybrid | `ALTER COLUMN ... SET NOT NULL` (existing column) | Static: fires on any `SET NOT NULL` (on PG < 12, full table scan under `AccessExclusiveLock`; on PG 12+, metadata-only if a valid CHECK constraint exists). Connected: checks catalog for existing valid `CHECK (col IS NOT NULL)` constraint and suppresses if found. Recommend three-step: add CHECK NOT VALID, validate, then SET NOT NULL. |
 | `SA018` | warn | hybrid | `ADD PRIMARY KEY` without pre-existing index | Static: fires on `ADD PRIMARY KEY` without `USING INDEX` clause (`ALTER TABLE` takes `AccessExclusiveLock`, and the implicit index creation extends lock duration). Connected: checks catalog for pre-existing unique index on the PK columns and suppresses if found. Safe pattern: create index concurrently first, then `ADD CONSTRAINT ... USING INDEX`. |
 | `SA019` | warn | static | `REINDEX` without `CONCURRENTLY` | Takes `AccessExclusiveLock`. PG 12+ supports `REINDEX CONCURRENTLY`. |
-| `SA020` | error | static | `CREATE INDEX CONCURRENTLY`, `DROP INDEX CONCURRENTLY`, or `REINDEX CONCURRENTLY` inside transactional deploy | Cannot run inside a transaction block — will fail at runtime. Change must be marked non-transactional. In project mode: checks plan file for non-transactional marker. In standalone mode: warns on any `CONCURRENTLY` usage with message "Ensure this runs outside a transaction block." Also recognizes `-- sqlever:no-transaction` script comment (sqlever-only convention, see non-transactional changes below). |
+| `SA020` | error | static | `CREATE INDEX CONCURRENTLY`, `DROP INDEX CONCURRENTLY`, or `REINDEX CONCURRENTLY` inside transactional deploy | Cannot run inside a transaction block — will fail at runtime. Change must be marked auto-commit. In project mode: checks plan file for auto-commit marker. In standalone mode: warns on any `CONCURRENTLY` usage with message "Ensure this runs outside a transaction block." Also recognizes `-- sqlever:auto-commit` script comment (sqlever-only convention, see auto-commit changes below). Legacy `-- sqlever:no-transaction` is also accepted. |
 | `SA021` | warn | static | `LOCK TABLE` (any mode) | Explicit locking in migrations is a code smell and dangerous in production. |
 
 **SA003 safe cast allowlist:** The following type changes are known to be safe (no table rewrite, binary-compatible):
@@ -744,7 +744,7 @@ Depth beats breadth. Sqitch's multi-DB support is one reason it can't do PG-spec
 
 We use the existing Sqitch tables (`sqitch.changes`, etc.) rather than our own schema. Reason: zero migration cost for existing Sqitch users. A team can `alias sqitch=sqlever` and evaluate us before committing. This is the adoption path.
 
-**`sqlever.*` schema:** When sqlever-specific features are used, a separate `sqlever.*` schema is created. This includes non-transactional deploy (which uses `sqlever.pending_changes` for write-ahead tracking), expand/contract, and batched DML. The schema is created on first use of any of these features — for example, on the first deploy that includes a non-transactional change. The `sqlever.*` schema is independent of `sqitch.*` and can be safely dropped if reverting to Sqitch (advanced features will stop working, but core migration tracking is unaffected).
+**`sqlever.*` schema:** When sqlever-specific features are used, a separate `sqlever.*` schema is created. This includes auto-commit deploy (which uses `sqlever.pending_changes` for write-ahead tracking), expand/contract, and batched DML. The schema is created on first use of any of these features — for example, on the first deploy that includes an auto-commit change. The `sqlever.*` schema is independent of `sqitch.*` and can be safely dropped if reverting to Sqitch (advanced features will stop working, but core migration tracking is unaffected).
 
 ### DD4 — SQL parser
 
@@ -808,7 +808,7 @@ Sqitch also sets `ON_ERROR_STOP=1` when invoking psql, which aborts on the first
 
 **Implications:**
 - psql must be installed on the deploy machine. The `--db-client` flag specifies the psql path (default: `psql` from `$PATH`).
-- sqlever sets `ON_ERROR_STOP=1`, disables `.psqlrc` (via `PSQLRC=/dev/null` and `--no-psqlrc`), and passes `--single-transaction` or not depending on `--mode` and `--no-transaction`.
+- sqlever sets `ON_ERROR_STOP=1`, disables `.psqlrc` (via `PSQLRC=/dev/null` and `--no-psqlrc`), and passes `--single-transaction` or not depending on `--mode` and `--auto-commit`.
 - `--set key=value` is passed directly to psql as `-v key=value`, preserving full psql variable interpolation (`:variable`, `:'variable'`, `:{?variable}`).
 - Error handling: sqlever parses psql's stderr for error messages and exit code for success/failure. Structured error extraction is best-effort — psql does not emit machine-readable errors.
 - `node-postgres` (`pg` package) is still used for tracking table operations (`sqitch.*`, `sqlever.*`), advisory locks, schema introspection, and batch DML. It is NOT used for executing migration scripts.
@@ -829,7 +829,7 @@ If using psql, Sqitch does NOT wrap deploy scripts in a transaction managed by S
 **The problem:** Most production PostgreSQL deployments use PgBouncer for connection pooling. PgBouncer in transaction mode has significant implications for sqlever:
 
 - `pg_advisory_lock` (session-level) does not work through PgBouncer in transaction mode — the lock is tied to the backend connection, which PgBouncer may reassign between transactions.
-- `pg_advisory_xact_lock` (transaction-level) releases at transaction end — it cannot span the entire deploy in `--mode change` (each change is a separate transaction) or across non-transactional changes. This makes it unsuitable for deploy coordination.
+- `pg_advisory_xact_lock` (transaction-level) releases at transaction end — it cannot span the entire deploy in `--mode change` (each change is a separate transaction) or across auto-commit changes. This makes it unsuitable for deploy coordination.
 - Session-level `SET` commands (`lock_timeout`, `statement_timeout`, `search_path`) may leak to other connections or be lost between transactions.
 - The batch worker's sleep interval between batches causes the connection to return to the pool; the next batch may run on a different backend.
 
@@ -844,7 +844,7 @@ If using psql, Sqitch does NOT wrap deploy scripts in a transaction managed by S
 
 Deploy connections should set:
 - `application_name = 'sqlever/<command>/<project>'` — e.g., `sqlever/deploy/myproject`. Visible in `pg_stat_activity`, critical for DBAs diagnosing lock contention or long-running queries during incidents.
-- `statement_timeout = 0` (or a configurable high value) — migrations are inherently long-running; a global `statement_timeout` (common in production, e.g., 30s) will kill legitimate operations like `VALIDATE CONSTRAINT`. For non-transactional DDL (e.g., `CREATE INDEX CONCURRENTLY`), a separate configurable timeout applies (default: 4 hours, configurable via `sqlever.toml` `[deploy] non_transactional_statement_timeout`). This prevents indefinite hangs while allowing legitimately long operations.
+- `statement_timeout = 0` (or a configurable high value) — migrations are inherently long-running; a global `statement_timeout` (common in production, e.g., 30s) will kill legitimate operations like `VALIDATE CONSTRAINT`. For auto-commit DDL (e.g., `CREATE INDEX CONCURRENTLY`), a separate configurable timeout applies (default: 4 hours, configurable via `sqlever.toml` `[deploy] auto_commit_statement_timeout`). This prevents indefinite hangs while allowing legitimately long operations.
 - `idle_in_transaction_session_timeout` — set to a configurable generous value (default: 10 minutes), not unlimited. This provides a safety net against hung deploy processes (e.g., operator walks away during a TUI prompt) without interfering with normal operation. Configurable via `sqlever.toml` `[deploy] idle_in_transaction_session_timeout`.
 - `lock_timeout` — set by the lock timeout guard (5.9), per-migration configurable.
 - `search_path` — respect the database/role default (Sqitch-compatible behavior). Sqitch does not set `search_path`; sqlever follows suit. Override available via `sqlever.toml` `[deploy] search_path` for teams that want explicit control.
@@ -969,7 +969,7 @@ sqlever deploy
       → run static analysis
       → if error: abort (unless --force)
       → if warn: print, continue
-      → if change is non-transactional:
+      → if change is auto-commit:
           → execute deploy script WITHOUT transaction wrapper
           → on success: BEGIN; update sqitch.changes, sqitch.events, sqitch.dependencies; COMMIT
           → on failure: report error, note that partial DDL may remain (e.g., INVALID index)
@@ -985,9 +985,9 @@ sqlever deploy
 
 **Advisory lock release:** `pg_advisory_unlock()` must be called on ALL exit paths — successful completion, deploy failure (analysis block, script error, verification failure), and user abort. Disconnect-based release (PG automatically releases session-level advisory locks on disconnect) is the safety net for crashes, not the primary unlock mechanism. Implementations must use a `finally`-style pattern to ensure the unlock call is always reached.
 
-**Non-transactional changes:** sqlever marks non-transactional changes via a plan file pragma added by `sqlever add --no-transaction`. Additionally, sqlever recognizes a `-- sqlever:no-transaction` comment on the first line of the deploy script as a sqlever-only convention. **Note:** Sqitch does NOT have a `-- sqitch-no-transaction` convention — no evidence of this mechanism exists in the Sqitch source code. Sqitch always wraps changes in `begin_work`/`finish_work`. The script comment convention is a sqlever-only innovation for standalone linter mode (SA020 detection) and should not be described as Sqitch-compatible. During deploy, non-transactional changes execute without `BEGIN`/`COMMIT` wrapping. A separate configurable `statement_timeout` applies to non-transactional DDL (default: 4 hours, configurable via `sqlever.toml` `[deploy] non_transactional_statement_timeout`).
+**Auto-commit changes:** sqlever marks auto-commit changes via a plan file pragma added by `sqlever add --auto-commit`. Additionally, sqlever recognizes a `-- sqlever:auto-commit` comment on the first line of the deploy script as a sqlever-only convention. The legacy `-- sqlever:no-transaction` directive is also accepted for backward compatibility. **Note:** Sqitch does NOT have a `-- sqitch-no-transaction` convention — no evidence of this mechanism exists in the Sqitch source code. Sqitch always wraps changes in `begin_work`/`finish_work`. The script comment convention is a sqlever-only innovation for standalone linter mode (SA020 detection) and should not be described as Sqitch-compatible. During deploy, auto-commit changes execute without `BEGIN`/`COMMIT` wrapping (each statement commits via its own implicit transaction). A separate configurable `statement_timeout` applies to auto-commit DDL (default: 4 hours, configurable via `sqlever.toml` `[deploy] auto_commit_statement_timeout`).
 
-**Non-transactional write-ahead tracking:** Before executing non-transactional DDL, sqlever writes a "pending" record to `sqlever.pending_changes` (in its own committed transaction). After the DDL succeeds, the record is updated to "complete" and the sqitch tracking tables are updated. On the next deploy, sqlever checks for any "pending" non-transactional changes and verifies their state before deciding to skip or retry. This handles the case where sqlever crashes between DDL execution and tracking table update. **Note:** `sqlever.pending_changes` reads and writes are protected by the same session-level deploy advisory lock (DD13). The advisory lock prevents concurrent deploys from simultaneously reading or acting on pending records — without it, two processes could both attempt to verify and resolve the same pending change.
+**Auto-commit write-ahead tracking:** Before executing auto-commit DDL, sqlever writes a "pending" record to `sqlever.pending_changes` (in its own committed transaction). After the DDL succeeds, the record is updated to "complete" and the sqitch tracking tables are updated. On the next deploy, sqlever checks for any "pending" auto-commit changes and verifies their state before deciding to skip or retry. This handles the case where sqlever crashes between DDL execution and tracking table update. **Note:** `sqlever.pending_changes` reads and writes are protected by the same session-level deploy advisory lock (DD13). The advisory lock prevents concurrent deploys from simultaneously reading or acting on pending records — without it, two processes could both attempt to verify and resolve the same pending change.
 
 **`sqlever.pending_changes` schema:**
 ```sql
@@ -1003,18 +1003,18 @@ CREATE TABLE sqlever.pending_changes (
 );
 ```
 
-**Non-transactional verify logic:** When sqlever finds a "pending" record on the next deploy, it verifies the change's state. For index operations (`CREATE INDEX CONCURRENTLY`), sqlever checks `pg_index.indisvalid` to determine if the index was successfully created. For other DDL, sqlever runs the change's verify script (if one exists). Automated verification only works for known DDL patterns — for arbitrary DDL without a verify script, sqlever reports the pending state and requires manual resolution.
+**Auto-commit verify logic:** When sqlever finds a "pending" record on the next deploy, it verifies the change's state. For index operations (`CREATE INDEX CONCURRENTLY`), sqlever checks `pg_index.indisvalid` to determine if the index was successfully created. For other DDL, sqlever runs the change's verify script (if one exists). Automated verification only works for known DDL patterns — for arbitrary DDL without a verify script, sqlever reports the pending state and requires manual resolution.
 
-Failure recovery for non-transactional DDL is fundamentally different: a failed `CREATE INDEX CONCURRENTLY` leaves an `INVALID` index that must be cleaned up. The error message must include the exact command to drop the INVALID index before retrying.
+Failure recovery for auto-commit DDL is fundamentally different: a failed `CREATE INDEX CONCURRENTLY` leaves an `INVALID` index that must be cleaned up. The error message must include the exact command to drop the INVALID index before retrying.
 
-**`ALTER TYPE ... ADD VALUE` note:** On PG < 12, `ALTER TYPE ... ADD VALUE` cannot run inside a transaction block and must be marked non-transactional. On PG 12+, it can run inside a transaction, but the new enum value is **not usable within the same transaction** — an `INSERT` using the new value in the same transaction will fail. If a deploy script does `ALTER TYPE ... ADD VALUE 'x'` followed by `INSERT ... VALUES ('x')`, they must be in separate changes or the change must be non-transactional.
+**`ALTER TYPE ... ADD VALUE` note:** On PG < 12, `ALTER TYPE ... ADD VALUE` cannot run inside a transaction block and must be marked auto-commit. On PG 12+, it can run inside a transaction, but the new enum value is **not usable within the same transaction** — an `INSERT` using the new value in the same transaction will fail. If a deploy script does `ALTER TYPE ... ADD VALUE 'x'` followed by `INSERT ... VALUES ('x')`, they must be in separate changes or the change must be auto-commit.
 
 **Transaction scope by `--mode`:**
 - `change` (default): each change in its own transaction (as shown above).
 - `all`: all changes in a single transaction. Failure rolls back everything including tracking table updates. Note: this is a sqlever improvement — Sqitch uses per-change transactions with explicit revert on failure (see DD12).
 - `tag`: changes grouped by tag, each tag-group in a single transaction.
 
-Non-transactional changes always execute outside any transaction regardless of `--mode`. In `--mode all`, non-transactional changes break the surrounding transaction: sqlever issues `COMMIT` before the non-transactional DDL, executes it, then issues `BEGIN` to continue with subsequent changes. This means `--mode all` cannot guarantee atomicity when non-transactional changes are present. If a transactional change fails after a non-transactional change has already committed, the non-transactional DDL remains deployed (its tracking update was committed separately). The subsequent transactional changes roll back, including their tracking records. This leaves a partially-deployed state where `sqlever status` correctly reports which changes are deployed and which are not. sqlever emits a warning at the start of deploy when `--mode all` is used with a plan containing non-transactional changes.
+Auto-commit changes always execute outside any explicit transaction regardless of `--mode`. In `--mode all`, auto-commit changes break the surrounding transaction: sqlever issues `COMMIT` before the auto-commit DDL, executes it, then issues `BEGIN` to continue with subsequent changes. This means `--mode all` cannot guarantee atomicity when auto-commit changes are present. If a transactional change fails after an auto-commit change has already committed, the auto-commit DDL remains deployed (its tracking update was committed separately). The subsequent transactional changes roll back, including their tracking records. This leaves a partially-deployed state where `sqlever status` correctly reports which changes are deployed and which are not. sqlever emits a warning at the start of deploy when `--mode all` is used with a plan containing auto-commit changes.
 
 ---
 
@@ -1105,14 +1105,14 @@ PG < 14 is best-effort/untested. Version-aware rules (SA002b) still fire based o
 |---------|-------------|
 | `init` | Creates sqitch.conf, sqitch.plan, deploy/ revert/ verify/ dirs |
 | `add` | Creates correctly named files, appends to plan, handles `-r` deps and `--conflict` |
-| `add --no-transaction` | Plan entry contains no-transaction pragma |
+| `add --auto-commit` | Plan entry contains auto-commit pragma |
 | `deploy` | Executes SQL, updates sqitch.changes + sqitch.events + sqitch.dependencies, correct timestamps |
 | `deploy --to` | Stops at specified change, tracking state correct |
 | `deploy --dry-run` | Zero DB changes (verified via table counts before/after) |
 | `deploy --mode change` | Each change in own transaction, stops on first failure, tracking state consistent |
 | `deploy --mode all` | All changes in single transaction (sqlever improvement over Sqitch's per-change txn + explicit revert), failure rolls back everything |
 | `deploy --mode tag` | Changes grouped by tag, each group in a transaction |
-| `deploy` (non-transactional) | `CREATE INDEX CONCURRENTLY` executes without transaction wrapper, tracking updated separately |
+| `deploy` (auto-commit) | `CREATE INDEX CONCURRENTLY` executes without transaction wrapper, tracking updated separately |
 | `revert` | Reverts in reverse dependency order, updates tracking tables |
 | `revert --to` | Reverts to specified change, not further |
 | `verify` | Runs verify script, PASS/FAIL per change, correct exit code |
@@ -1188,7 +1188,7 @@ The most important test suite. Sqitch is the ground truth. We run identical oper
 | `reworked/` | Changes reworked with `@tag` references |
 | `cross-project/` | Cross-project dependencies (`project:change`) |
 | `conflicts/` | Changes with conflict dependencies |
-| `non-transactional/` | Changes marked `--no-transaction` |
+| `auto-commit/` | Changes marked `--auto-commit` |
 | `mid-deploy/` | Project partially deployed by Sqitch, sqlever continues |
 | `planner-edge-cases/` | Plan entries with commas in planner names (`First,Last,,`), trailing spaces, blank lines mid-plan |
 | `missing-verify/` | Deploy scripts with no corresponding verify file; test `--verify` skips gracefully |
@@ -1247,7 +1247,7 @@ tests/fixtures/analysis/
     trigger/
       concurrent_index_in_transaction.sql       # must trigger
     no_trigger/
-      concurrent_index_no_transaction.sql       # must NOT trigger
+      concurrent_index_auto_commit.sql           # must NOT trigger
     ...
 ```
 
@@ -1413,24 +1413,24 @@ After this phase: drop-in replacement for all Sqitch commands.
 - [ ] Change ID computation: SHA-1 algorithm matching Sqitch byte-for-byte
 - [ ] `src/db/registry.ts`: read/write `sqitch.changes`, `sqitch.events`, `sqitch.tags`, `sqitch.projects`, `sqitch.dependencies`
 - [ ] `sqlever init`: creates sqitch.conf, sqitch.plan, deploy/revert/verify dirs
-- [ ] `sqlever add`: creates migration files, appends to plan (supports `--no-transaction`, `--conflict`)
+- [ ] `sqlever add`: creates migration files, appends to plan (supports `--auto-commit`, `--conflict`)
 - [ ] Tests: plan round-trip, init, add, change ID verification against Sqitch
 
 **Sprint 3 — deploy + revert**
 - [ ] `src/commands/deploy.ts`: topological sort, execute deploy scripts, update tracking
 - [ ] Advisory lock acquisition at deploy start: `pg_try_advisory_lock(<lock_key>)` (non-blocking default) or `pg_advisory_lock(<lock_key>)` with `lock_timeout` (wait mode) — session-level, released on completion or disconnect. Lock key: application-computed stable hash (not `hashtext()`)
-- [ ] Non-transactional change support (execute without BEGIN/COMMIT, track separately)
+- [ ] Auto-commit change support (execute without BEGIN/COMMIT, track separately)
 - [ ] `src/commands/revert.ts`: execute revert scripts in reverse order, update tracking
 - [ ] `--to <change>` flag for both
 - [ ] `--dry-run` flag
 - [ ] `--mode [all|change|tag]` flag with correct transaction boundaries
 - [ ] `--log-only` flag (record as deployed without executing)
 - [ ] `--set` variable substitution
-- [ ] Deploy connection session settings (application_name, statement_timeout=0, idle_in_transaction_session_timeout=10min, non_transactional_statement_timeout=4h)
+- [ ] Deploy connection session settings (application_name, statement_timeout=0, idle_in_transaction_session_timeout=10min, auto_commit_statement_timeout=4h)
 - [ ] Lock timeout guard: auto-prepend `SET lock_timeout` before risky DDL (configurable, enabled by default)
 - [ ] Conflict dependency checking
 - [ ] Partial deploy / revert with dependency validation
-- [ ] Tests: deploy/revert, partial, dry-run, failed deploy recovery, advisory locks, non-transactional deploy
+- [ ] Tests: deploy/revert, partial, dry-run, failed deploy recovery, advisory locks, auto-commit deploy
 
 **Sprint 4 — verify + status + log + remaining commands**
 - [ ] `sqlever verify`: run verify scripts, report pass/fail per change

--- a/src/analysis/rules/SA020.ts
+++ b/src/analysis/rules/SA020.ts
@@ -8,23 +8,25 @@
  * REINDEX CONCURRENTLY usage. These operations cannot run inside a
  * transaction block and will fail at runtime if attempted.
  *
- * In project mode, the analyzer would check the plan file for a
- * non-transactional marker. In standalone mode, this rule warns on
+ * In project mode, the analyzer would check the plan file for an
+ * auto-commit marker. In standalone mode, this rule warns on
  * any CONCURRENTLY usage with guidance to ensure it runs outside a
  * transaction block.
  *
- * Also recognizes the -- sqlever:no-transaction script comment
- * (sqlever-only convention) to suppress the warning.
+ * Also recognizes the -- sqlever:auto-commit (or legacy
+ * -- sqlever:no-transaction) script comment (sqlever-only convention)
+ * to suppress the warning.
  */
 
 import type { Rule, Finding, AnalysisContext } from "../types.js";
 import { offsetToLocation } from "../types.js";
 
 /**
- * Check if the SQL contains a -- sqlever:no-transaction comment.
+ * Check if the SQL contains a -- sqlever:auto-commit or
+ * -- sqlever:no-transaction (legacy) directive comment.
  */
-function hasNoTransactionComment(rawSql: string): boolean {
-  return /--\s*sqlever:no-transaction/i.test(rawSql);
+function hasAutoCommitDirective(rawSql: string): boolean {
+  return /--\s*sqlever:(auto-commit|no-transaction)/i.test(rawSql);
 }
 
 export const SA020: Rule = {
@@ -38,8 +40,8 @@ export const SA020: Rule = {
 
     if (!ast?.stmts) return findings;
 
-    // If the file has a -- sqlever:no-transaction comment, skip
-    if (hasNoTransactionComment(rawSql)) return findings;
+    // If the file has a -- sqlever:auto-commit (or legacy no-transaction) directive, skip
+    if (hasAutoCommitDirective(rawSql)) return findings;
 
     for (const stmtEntry of ast.stmts) {
       const stmt = stmtEntry.stmt;
@@ -60,7 +62,7 @@ export const SA020: Rule = {
           message: `CREATE INDEX CONCURRENTLY "${idxName}" cannot run inside a transaction block.`,
           location,
           suggestion:
-            "Mark this migration as non-transactional, or add a -- sqlever:no-transaction comment. In sqitch, use a non-transactional change.",
+            "Mark this migration as auto-commit, or add a -- sqlever:auto-commit comment. In sqitch, use an auto-commit (non-transactional) change.",
         });
       }
 
@@ -94,7 +96,7 @@ export const SA020: Rule = {
           message: `DROP INDEX CONCURRENTLY ${nameStr} cannot run inside a transaction block.`,
           location,
           suggestion:
-            "Mark this migration as non-transactional, or add a -- sqlever:no-transaction comment. In sqitch, use a non-transactional change.",
+            "Mark this migration as auto-commit, or add a -- sqlever:auto-commit comment. In sqitch, use an auto-commit (non-transactional) change.",
         });
       }
 
@@ -122,7 +124,7 @@ export const SA020: Rule = {
             message: `REINDEX CONCURRENTLY on "${target}" cannot run inside a transaction block.`,
             location,
             suggestion:
-              "Mark this migration as non-transactional, or add a -- sqlever:no-transaction comment. In sqitch, use a non-transactional change.",
+              "Mark this migration as auto-commit, or add a -- sqlever:auto-commit comment. In sqitch, use an auto-commit (non-transactional) change.",
           });
         }
       }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -306,13 +306,24 @@ export function parseDeployOptions(args: ParsedArgs): DeployOptions {
 // ---------------------------------------------------------------------------
 
 /**
- * Check if a deploy script is marked as non-transactional.
- * Looks for `-- sqlever:no-transaction` on the first line.
+ * Check if a deploy script is marked as auto-commit (each statement
+ * commits via its own implicit transaction, vs --single-transaction
+ * which wraps everything in an explicit BEGIN/COMMIT).
+ *
+ * Looks for `-- sqlever:auto-commit` (preferred) or the legacy
+ * `-- sqlever:no-transaction` directive on the first line.
+ * Both are accepted for backward compatibility.
  */
-export function isNonTransactional(scriptContent: string): boolean {
+export function isAutoCommit(scriptContent: string): boolean {
   const firstLine = scriptContent.split("\n")[0] ?? "";
-  return /--\s*sqlever:no-transaction/i.test(firstLine);
+  return /--\s*sqlever:(auto-commit|no-transaction)/i.test(firstLine);
 }
+
+/**
+ * @deprecated Use isAutoCommit() instead.
+ * Kept as an alias for backward compatibility.
+ */
+export const isNonTransactional = isAutoCommit;
 
 /**
  * Resolve the path to a deploy/verify script.
@@ -404,8 +415,8 @@ export async function executeDeploy(
     for (const change of sortedChanges) {
       const sName = dryRunScriptNameMap.get(change.change_id) ?? change.name;
       const deployPath = scriptPath(topDir, deployDir, sName);
-      const noTxn = existsSync(deployPath) && isNonTransactional(readFileSync(deployPath, "utf-8"));
-      const marker = noTxn ? " [no-transaction]" : "";
+      const autoCommit = existsSync(deployPath) && isAutoCommit(readFileSync(deployPath, "utf-8"));
+      const marker = autoCommit ? " [auto-commit]" : "";
       info(`  + ${change.name}${marker}`);
     }
     return { deployed: 0, skipped: 0, dryRun: true };
@@ -622,7 +633,7 @@ export async function executeDeploy(
       }
 
       const scriptContent = readFileSync(deployScript, "utf-8");
-      const noTransaction = isNonTransactional(scriptContent);
+      const autoCommit = isAutoCommit(scriptContent);
       const scriptHash = computeScriptHash(deployScript);
 
       // Resolve lock_timeout for this script
@@ -634,7 +645,7 @@ export async function executeDeploy(
 
       // Determine transaction mode for psql
       // Sqitch does NOT pass --single-transaction by default.
-      const useSingleTransaction = !noTransaction && (options.mode === "all" || options.mode === "tag");
+      const useSingleTransaction = !autoCommit && (options.mode === "all" || options.mode === "tag");
 
       // Mark change as running in TUI
       progress.updateChange(change.name, "running");

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -27,7 +27,7 @@ import {
 import { PsqlRunner, type PsqlRunResult } from "../psql";
 import { ShutdownManager } from "../signals";
 import { info, error as logError, verbose } from "../output";
-import { isNonTransactional } from "./deploy";
+import { isAutoCommit } from "./deploy";
 import { resolveTargetUri } from "./shared";
 
 // ---------------------------------------------------------------------------
@@ -395,7 +395,7 @@ export async function runRevert(
 
       verbose(`Reverting: ${change.name}`);
 
-      // Read revert script to check for no-transaction directive
+      // Read revert script to check for auto-commit directive
       let scriptContent: string;
       try {
         scriptContent = readFileSync(change.revertScriptPath, "utf-8");

--- a/tests/fixtures/analysis/SA020/no_trigger/concurrently_with_no_transaction.sql
+++ b/tests/fixtures/analysis/SA020/no_trigger/concurrently_with_no_transaction.sql
@@ -1,2 +1,2 @@
--- sqlever:no-transaction
+-- sqlever:auto-commit
 CREATE INDEX CONCURRENTLY idx_users_email ON users (email);

--- a/tests/fixtures/edge-cases.sql
+++ b/tests/fixtures/edge-cases.sql
@@ -120,7 +120,7 @@ CREATE TYPE post_status AS ENUM ('draft', 'published', 'archived');
 -- 17. ALTER TABLE with NOT NULL on existing column (dangerous!)
 ALTER TABLE posts ALTER COLUMN title SET NOT NULL;
 
--- 18. CREATE INDEX CONCURRENTLY (non-transactional DDL)
+-- 18. CREATE INDEX CONCURRENTLY (auto-commit DDL)
 CREATE INDEX CONCURRENTLY idx_posts_published
 ON posts (published_at)
 WHERE published_at IS NOT NULL;

--- a/tests/unit/analysis-deep.test.ts
+++ b/tests/unit/analysis-deep.test.ts
@@ -429,7 +429,7 @@ ALTER TABLE users VALIDATE CONSTRAINT chk_age;`;
 });
 
 describe("SA020: CONCURRENTLY in transactional context", () => {
-  test("CIC without no-transaction marker — triggers", () => {
+  test("CIC without auto-commit marker — triggers", () => {
     const ctx = makeContext(
       "CREATE INDEX CONCURRENTLY idx ON users (email);",
     );
@@ -438,8 +438,8 @@ describe("SA020: CONCURRENTLY in transactional context", () => {
     expect(findings[0]!.ruleId).toBe("SA020");
   });
 
-  test("CIC with -- sqlever:no-transaction — no trigger", () => {
-    const sql = `-- sqlever:no-transaction
+  test("CIC with -- sqlever:auto-commit — no trigger", () => {
+    const sql = `-- sqlever:auto-commit
 CREATE INDEX CONCURRENTLY idx ON users (email);`;
     const ctx = makeContext(sql);
     const findings = SA020.check(ctx);
@@ -453,7 +453,7 @@ CREATE INDEX CONCURRENTLY idx ON users (email);`;
   });
 
   test("DROP INDEX CONCURRENTLY with marker — no trigger", () => {
-    const sql = `-- sqlever:no-transaction
+    const sql = `-- sqlever:auto-commit
 DROP INDEX CONCURRENTLY old_idx;`;
     const ctx = makeContext(sql);
     const findings = SA020.check(ctx);

--- a/tests/unit/analysis-rules-11-21.test.ts
+++ b/tests/unit/analysis-rules-11-21.test.ts
@@ -901,20 +901,20 @@ describe("SA020: CONCURRENTLY in transactional context", () => {
     expect(findings).toHaveLength(0);
   });
 
-  test("suppressed by -- sqlever:no-transaction comment", () => {
-    const sql = `-- sqlever:no-transaction
+  test("suppressed by -- sqlever:auto-commit directive", () => {
+    const sql = `-- sqlever:auto-commit
 CREATE INDEX CONCURRENTLY idx ON users (email);`;
     const ctx = makeContext(sql);
     const findings = SA020.check(ctx);
     expect(findings).toHaveLength(0);
   });
 
-  test("includes suggestion about non-transactional", () => {
+  test("includes suggestion about auto-commit", () => {
     const ctx = makeContext(
       "CREATE INDEX CONCURRENTLY idx ON users (email);",
     );
     const findings = SA020.check(ctx);
-    expect(findings[0]!.suggestion).toContain("non-transactional");
+    expect(findings[0]!.suggestion).toContain("auto-commit");
   });
 });
 

--- a/tests/unit/deploy-failures.test.ts
+++ b/tests/unit/deploy-failures.test.ts
@@ -83,6 +83,7 @@ const {
   runDeploy,
   parseDeployOptions,
   projectLockKey,
+  isAutoCommit,
   isNonTransactional,
   ADVISORY_LOCK_NAMESPACE,
   EXIT_CONCURRENT_DEPLOY,
@@ -152,7 +153,7 @@ create_schema 2025-01-01T00:00:00Z Test User <test@example.com> # Create schema
 add_users [nonexistent_thing] 2025-01-02T00:00:00Z Test User <test@example.com> # Add users table
 `;
 
-/** A plan with a single non-transactional change */
+/** A plan with a single auto-commit change */
 const NON_TXN_PLAN = `%syntax-version=1.0.0
 %project=myproject
 
@@ -700,22 +701,26 @@ describe("deploy failure recovery", () => {
   });
 
   // -----------------------------------------------------------------------
-  // 6. Non-transactional change detection (-- sqlever:no-transaction)
+  // 6. Auto-commit change detection (-- sqlever:auto-commit)
   // -----------------------------------------------------------------------
 
-  describe("non-transactional change detection", () => {
-    it("isNonTransactional detects the marker on the first line", () => {
-      expect(isNonTransactional("-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
+  describe("auto-commit change detection", () => {
+    it("isAutoCommit detects the marker on the first line", () => {
+      expect(isAutoCommit("-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
     });
 
-    it("isNonTransactional returns false for second-line marker", () => {
-      expect(isNonTransactional("SELECT 1;\n-- sqlever:no-transaction")).toBe(false);
+    it("isAutoCommit returns false for second-line marker", () => {
+      expect(isAutoCommit("SELECT 1;\n-- sqlever:auto-commit")).toBe(false);
     });
 
-    it("deploys non-transactional script without --single-transaction", async () => {
+    it("isAutoCommit accepts legacy no-transaction directive", () => {
+      expect(isAutoCommit("-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
+    });
+
+    it("deploys auto-commit script without --single-transaction", async () => {
       writePlan(testDir, NON_TXN_PLAN);
       writeDeployScript(testDir, "create_schema", "CREATE SCHEMA myapp;");
-      writeDeployScript(testDir, "add_index", "-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY idx ON users(email);");
+      writeDeployScript(testDir, "add_index", "-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY idx ON users(email);");
 
       const { runner, calls } = createTrackingPsqlRunner();
       const deps = await createDeps();
@@ -731,10 +736,10 @@ describe("deploy failure recovery", () => {
       expect(calls[1]!.args).not.toContain("--single-transaction");
     });
 
-    it("records non-transactional change in tracking tables on success", async () => {
+    it("records auto-commit change in tracking tables on success", async () => {
       writePlan(testDir, NON_TXN_PLAN);
       writeDeployScript(testDir, "create_schema", "CREATE SCHEMA myapp;");
-      writeDeployScript(testDir, "add_index", "-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY idx ON users(email);");
+      writeDeployScript(testDir, "add_index", "-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY idx ON users(email);");
 
       const deps = await createDeps();
       const options = defaultOptions(testDir);
@@ -751,10 +756,10 @@ describe("deploy failure recovery", () => {
       expect(changeInserts[1]!.values![2]).toBe("add_index");
     });
 
-    it("does not record non-transactional change in tracking tables on failure", async () => {
+    it("does not record auto-commit change in tracking tables on failure", async () => {
       writePlan(testDir, NON_TXN_PLAN);
       writeDeployScript(testDir, "create_schema", "CREATE SCHEMA myapp;");
-      writeDeployScript(testDir, "add_index", "-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY idx ON users(email);");
+      writeDeployScript(testDir, "add_index", "-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY idx ON users(email);");
 
       const deps = await createDeps({ failOnScript: "add_index" });
       const options = defaultOptions(testDir);

--- a/tests/unit/deploy-revert-robustness.test.ts
+++ b/tests/unit/deploy-revert-robustness.test.ts
@@ -1,6 +1,6 @@
 // tests/unit/deploy-revert-robustness.test.ts — Deploy/Revert Robustness
 //
-// Comprehensive tests for issue #125: transaction semantics, non-transactional
+// Comprehensive tests for issue #125: transaction semantics, auto-commit
 // DDL handling, advisory lock contention, failure recovery, lock timeout guard,
 // SIGINT/SIGTERM cleanup, and revert robustness.
 
@@ -82,6 +82,7 @@ const {
   executeDeploy,
   runDeploy,
   projectLockKey,
+  isAutoCommit,
   isNonTransactional,
   parseDeployOptions,
   ADVISORY_LOCK_NAMESPACE,
@@ -396,10 +397,10 @@ describe("deploy/revert robustness (issue #125)", () => {
       );
     });
 
-    it("non-transactional change in --mode change skips --single-transaction for that script only", async () => {
+    it("auto-commit change in --mode change skips --single-transaction for that script only", async () => {
       writePlan(testDir, NON_TXN_PLAN);
       writeDeployScript(testDir, "create_schema", "CREATE SCHEMA myapp;");
-      writeDeployScript(testDir, "add_index", "-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY idx ON users(email);");
+      writeDeployScript(testDir, "add_index", "-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY idx ON users(email);");
 
       const { runner, calls } = createTrackingPsqlRunner();
       const deps = await createDeps();
@@ -417,14 +418,14 @@ describe("deploy/revert robustness (issue #125)", () => {
   });
 
   // =========================================================================
-  // 2. Non-transactional handling (7 tests)
+  // 2. Auto-commit handling (7 tests)
   // =========================================================================
 
-  describe("2. Non-transactional handling", () => {
+  describe("2. Auto-commit handling", () => {
     it("CIC script runs without BEGIN (no --single-transaction)", async () => {
       writePlan(testDir, NON_TXN_PLAN);
       writeDeployScript(testDir, "create_schema", "CREATE SCHEMA myapp;");
-      writeDeployScript(testDir, "add_index", "-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY idx ON users(email);");
+      writeDeployScript(testDir, "add_index", "-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY idx ON users(email);");
 
       const { runner, calls } = createTrackingPsqlRunner();
       const deps = await createDeps();
@@ -439,22 +440,27 @@ describe("deploy/revert robustness (issue #125)", () => {
       expect(cicCall!.args).not.toContain("--single-transaction");
     });
 
-    it("detects -- sqlever:no-transaction marker on first line", () => {
-      expect(isNonTransactional("-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
+    it("detects -- sqlever:auto-commit marker on first line", () => {
+      expect(isAutoCommit("-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
     });
 
-    it("detects -- sqlever:no-transaction with extra spacing", () => {
-      expect(isNonTransactional("--  sqlever:no-transaction\nSELECT 1")).toBe(true);
+    it("detects -- sqlever:auto-commit with extra spacing", () => {
+      expect(isAutoCommit("--  sqlever:auto-commit\nSELECT 1")).toBe(true);
     });
 
-    it("detects -- sqlever:no-transaction case-insensitively", () => {
-      expect(isNonTransactional("-- SQLEVER:NO-TRANSACTION\nSELECT 1")).toBe(true);
+    it("detects -- sqlever:auto-commit case-insensitively", () => {
+      expect(isAutoCommit("-- SQLEVER:AUTO-COMMIT\nSELECT 1")).toBe(true);
     });
 
-    it("records non-transactional change in tracking table after success", async () => {
+    it("accepts legacy -- sqlever:no-transaction directive", () => {
+      expect(isAutoCommit("-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
+      expect(isAutoCommit("-- SQLEVER:NO-TRANSACTION\nSELECT 1")).toBe(true);
+    });
+
+    it("records auto-commit change in tracking table after success", async () => {
       writePlan(testDir, NON_TXN_PLAN);
       writeDeployScript(testDir, "create_schema", "CREATE SCHEMA myapp;");
-      writeDeployScript(testDir, "add_index", "-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY idx ON users(email);");
+      writeDeployScript(testDir, "add_index", "-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY idx ON users(email);");
 
       const deps = await createDeps();
       const options = defaultOptions(testDir);
@@ -472,7 +478,7 @@ describe("deploy/revert robustness (issue #125)", () => {
     it("failed CIC leaves no tracking record for that change", async () => {
       writePlan(testDir, NON_TXN_PLAN);
       writeDeployScript(testDir, "create_schema", "CREATE SCHEMA myapp;");
-      writeDeployScript(testDir, "add_index", "-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY idx ON users(email);");
+      writeDeployScript(testDir, "add_index", "-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY idx ON users(email);");
 
       const deps = await createDeps({ failOnScript: "add_index" });
       const options = defaultOptions(testDir);
@@ -492,7 +498,7 @@ describe("deploy/revert robustness (issue #125)", () => {
       // First deploy: add_index fails
       writePlan(testDir, NON_TXN_PLAN);
       writeDeployScript(testDir, "create_schema", "CREATE SCHEMA myapp;");
-      writeDeployScript(testDir, "add_index", "-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY idx ON users(email);");
+      writeDeployScript(testDir, "add_index", "-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY idx ON users(email);");
 
       const deps1 = await createDeps({ failOnScript: "add_index" });
       const options1 = defaultOptions(testDir);

--- a/tests/unit/deploy.test.ts
+++ b/tests/unit/deploy.test.ts
@@ -76,6 +76,7 @@ const {
   executeDeploy,
   runDeploy,
   projectLockKey,
+  isAutoCommit,
   isNonTransactional,
   parseDeployOptions,
   buildScriptNameMap,
@@ -272,28 +273,37 @@ describe("deploy", () => {
   });
 
   // -----------------------------------------------------------------------
-  // isNonTransactional
+  // isAutoCommit
   // -----------------------------------------------------------------------
 
-  describe("isNonTransactional()", () => {
-    it("returns true for scripts with no-transaction comment", () => {
-      expect(isNonTransactional("-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
+  describe("isAutoCommit()", () => {
+    it("returns true for scripts with auto-commit directive", () => {
+      expect(isAutoCommit("-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
     });
 
     it("returns true with varied spacing", () => {
-      expect(isNonTransactional("--  sqlever:no-transaction\nSELECT 1")).toBe(true);
+      expect(isAutoCommit("--  sqlever:auto-commit\nSELECT 1")).toBe(true);
     });
 
     it("returns true case-insensitively", () => {
-      expect(isNonTransactional("-- SQLEVER:NO-TRANSACTION\nSELECT 1")).toBe(true);
+      expect(isAutoCommit("-- SQLEVER:AUTO-COMMIT\nSELECT 1")).toBe(true);
     });
 
     it("returns false for normal scripts", () => {
-      expect(isNonTransactional("CREATE TABLE foo (id int);\n")).toBe(false);
+      expect(isAutoCommit("CREATE TABLE foo (id int);\n")).toBe(false);
     });
 
     it("returns false when comment is not on first line", () => {
-      expect(isNonTransactional("CREATE TABLE foo;\n-- sqlever:no-transaction\n")).toBe(false);
+      expect(isAutoCommit("CREATE TABLE foo;\n-- sqlever:auto-commit\n")).toBe(false);
+    });
+
+    it("supports legacy no-transaction directive for backward compat", () => {
+      expect(isAutoCommit("-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
+    });
+
+    it("isNonTransactional alias works (backward compat)", () => {
+      expect(isNonTransactional("-- sqlever:auto-commit\nSELECT 1")).toBe(true);
+      expect(isNonTransactional("-- sqlever:no-transaction\nSELECT 1")).toBe(true);
     });
   });
 
@@ -796,11 +806,11 @@ describe("deploy", () => {
   });
 
   // -----------------------------------------------------------------------
-  // executeDeploy — non-transactional changes
+  // executeDeploy — auto-commit changes
   // -----------------------------------------------------------------------
 
-  describe("executeDeploy() — non-transactional changes", () => {
-    it("detects no-transaction marker and deploys without --single-transaction", async () => {
+  describe("executeDeploy() — auto-commit changes", () => {
+    it("detects auto-commit marker and deploys without --single-transaction", async () => {
       const plan = `%syntax-version=1.0.0
 %project=myproject
 
@@ -809,7 +819,7 @@ add_index 2025-01-02T00:00:00Z Test User <test@example.com> # Concurrent index
 `;
       writePlan(testDir, plan);
       writeDeployScript(testDir, "create_schema", "CREATE SCHEMA myapp;");
-      writeDeployScript(testDir, "add_index", "-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY idx_users_email ON users(email);");
+      writeDeployScript(testDir, "add_index", "-- sqlever:auto-commit\nCREATE INDEX CONCURRENTLY idx_users_email ON users(email);");
 
       // Track psql invocations
       const calls: Array<{ args: string[] }> = [];

--- a/tests/unit/e2e-deep.test.ts
+++ b/tests/unit/e2e-deep.test.ts
@@ -157,6 +157,7 @@ const { Registry } = await import("../../src/db/registry");
 const {
   executeDeploy,
   projectLockKey,
+  isAutoCommit,
   isNonTransactional,
   ADVISORY_LOCK_NAMESPACE,
   EXIT_CONCURRENT_DEPLOY,

--- a/tests/unit/revert.test.ts
+++ b/tests/unit/revert.test.ts
@@ -51,7 +51,7 @@ const {
 } = await import("../../src/commands/revert");
 const { resolveTargetUri } = await import("../../src/commands/shared");
 const { parseArgs } = await import("../../src/cli");
-const { isNonTransactional } = await import("../../src/commands/deploy");
+const { isAutoCommit, isNonTransactional } = await import("../../src/commands/deploy");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -556,22 +556,28 @@ describe("revert command", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Bug fix: revert ignores -- sqlever:no-transaction directive
+  // Bug fix: revert ignores -- sqlever:auto-commit directive
   // -----------------------------------------------------------------------
 
-  describe("revert respects -- sqlever:no-transaction directive", () => {
-    it("a revert script with -- sqlever:no-transaction should NOT use --single-transaction", () => {
-      const scriptContent = "-- sqlever:no-transaction\nDROP INDEX CONCURRENTLY IF EXISTS idx_foo;\n";
-      expect(isNonTransactional(scriptContent)).toBe(true);
-      // singleTransaction should be !isNonTransactional = false
-      const singleTransaction = !isNonTransactional(scriptContent);
+  describe("revert respects -- sqlever:auto-commit directive", () => {
+    it("a revert script with -- sqlever:auto-commit should NOT use --single-transaction", () => {
+      const scriptContent = "-- sqlever:auto-commit\nDROP INDEX CONCURRENTLY IF EXISTS idx_foo;\n";
+      expect(isAutoCommit(scriptContent)).toBe(true);
+      // singleTransaction should be !isAutoCommit = false
+      const singleTransaction = !isAutoCommit(scriptContent);
       expect(singleTransaction).toBe(false);
+    });
+
+    it("a revert script with legacy -- sqlever:no-transaction should NOT use --single-transaction", () => {
+      const scriptContent = "-- sqlever:no-transaction\nDROP INDEX CONCURRENTLY IF EXISTS idx_foo;\n";
+      expect(isAutoCommit(scriptContent)).toBe(true);
+      expect(isNonTransactional(scriptContent)).toBe(true);
     });
 
     it("a normal revert script should NOT use --single-transaction (matching Sqitch)", () => {
       // Sqitch does NOT pass --single-transaction for revert scripts.
       const scriptContent = "DROP TABLE IF EXISTS foo;\n";
-      expect(isNonTransactional(scriptContent)).toBe(false);
+      expect(isAutoCommit(scriptContent)).toBe(false);
     });
 
     it("revert.ts source does not hardcode singleTransaction: true", () => {


### PR DESCRIPTION
## Summary

- **Renamed all "no-transaction" / "non-transactional" naming to "auto-commit"** throughout the codebase. In Postgres, every statement always runs in a transaction -- the term "no-transaction" is misleading. The correct concept is "auto-commit": each statement commits via its own implicit transaction, vs `--single-transaction` which wraps everything in an explicit `BEGIN`/`COMMIT`.

- **Backward compatible**: the regex now accepts BOTH directives (`sqlever:(auto-commit|no-transaction)`), and `isNonTransactional` is kept as a deprecated alias for `isAutoCommit`.

### What changed

| Before | After |
|--------|-------|
| `-- sqlever:no-transaction` | `-- sqlever:auto-commit` (preferred; old form still accepted) |
| `isNonTransactional()` | `isAutoCommit()` (+ backward-compat alias) |
| `hasNoTransactionComment()` | `hasAutoCommitDirective()` |
| `noTransaction` / `noTxn` variables | `autoCommit` |
| `" [no-transaction]"` display | `" [auto-commit]"` |
| `--no-transaction` in spec/docs | `--auto-commit` |
| `non-transactional` in prose | `auto-commit` |
| `non_transactional_statement_timeout` | `auto_commit_statement_timeout` |

### Files modified (15)

- `src/commands/deploy.ts` -- core `isAutoCommit()` function + alias
- `src/commands/revert.ts` -- updated import and comment
- `src/analysis/rules/SA020.ts` -- `hasAutoCommitDirective()`, updated suggestions
- `spec/SPEC.md` -- all prose and tables updated
- `spec/SPEC-CHANGELOG.md` -- all changelog entries updated
- `RELEASE_NOTES_v0.2.0.md` -- updated directive name
- `tests/unit/deploy.test.ts` -- new tests + backward compat tests
- `tests/unit/deploy-failures.test.ts` -- updated names + backward compat test
- `tests/unit/deploy-revert-robustness.test.ts` -- updated names + legacy test
- `tests/unit/revert.test.ts` -- updated names + legacy backward compat test
- `tests/unit/analysis-rules-11-21.test.ts` -- updated assertions
- `tests/unit/analysis-deep.test.ts` -- updated test descriptions
- `tests/unit/e2e-deep.test.ts` -- updated import
- `tests/fixtures/analysis/SA020/no_trigger/concurrently_with_no_transaction.sql` -- uses new directive
- `tests/fixtures/edge-cases.sql` -- updated comment

## Test plan

- [x] `bun test` passes: 2631 pass, 37 skip, 0 fail
- [x] New backward-compat tests verify `-- sqlever:no-transaction` still works
- [x] `isNonTransactional` alias still works for any external consumers
- [x] SA020 suppression works with both `auto-commit` and `no-transaction` directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)