### PR TITLE
refactor: standardize CLI patterns — async/await, exit codes, error messages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,30 +28,30 @@ import { runBatch } from "./commands/batch";
 
 /** Description for each supported command, used in --help output. */
 const COMMANDS: Record<string, string> = {
-  init: "Initialize project, create sqitch.conf and sqitch.plan",
+  init: "Initialize a new project directory",
   add: "Add a new migration change",
-  deploy: "Deploy changes to a database",
-  revert: "Revert changes from a database",
-  verify: "Run verify scripts against a database",
-  status: "Show deployment status",
-  log: "Show deployment history",
-  tag: "Tag the current deployment state",
-  rework: "Rework an existing change",
-  rebase: "Revert then re-deploy changes",
+  deploy: "Deploy pending changes to a database",
+  revert: "Revert deployed changes from a database",
+  verify: "Verify deployed changes against a database",
+  status: "Show current deployment status",
+  log: "Show deployment event history",
+  tag: "Tag the latest change in the plan",
+  rework: "Rework an existing change in the plan",
+  rebase: "Revert and re-deploy changes",
   bundle: "Package project for distribution",
-  checkout: "Deploy/revert changes to match a VCS branch",
-  show: "Display change/tag details or script contents",
-  plan: "Display plan contents",
-  upgrade: "Upgrade the registry schema to current version",
-  engine: "Manage database engines",
-  target: "Manage deploy targets",
-  config: "Read/write configuration",
-  analyze: "Analyze migration SQL for dangerous patterns",
-  explain: "Explain what a migration does in plain language",
-  review: "Review migrations for issues",
+  checkout: "Deploy or revert to match a VCS branch",
+  show: "Show change, tag, or script details",
+  plan: "Show the contents of the plan file",
+  upgrade: "Upgrade the registry schema",
+  engine: "Manage database engine configuration",
+  target: "Manage deploy target configuration",
+  config: "Get or set configuration values",
+  analyze: "Analyze migration SQL for risky patterns",
+  explain: "Explain a migration in plain language",
+  review: "Review migrations for common issues",
   batch: "Manage batched background data migrations",
   diff: "Show differences between plan states",
-  doctor: "Validate project setup, plan file, and script consistency",
+  doctor: "Check project setup for problems",
   help: "Show help for a command",
 };
 
@@ -257,7 +257,7 @@ function stubHandler(command: string): never {
 // Main
 // ---------------------------------------------------------------------------
 
-export function main(argv: string[] = process.argv.slice(2)): void {
+export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv);
 
   // --version takes precedence (matches Sqitch behavior)
@@ -309,179 +309,122 @@ export function main(argv: string[] = process.argv.slice(2)): void {
   }
 
   // --- Dispatch to implemented commands ---
-  if (args.command === "init") {
-    runInit(args).catch((err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`sqlever init: ${msg}\n`);
-      process.exit(1);
-    });
-    return;
-  }
-
-  if (args.command === "add") {
-    // Check if --expand flag is present
-    if (args.rest.includes("--expand")) {
-      const expandOpts = parseExpandArgs(args.rest);
-      expandOpts.topDir = args.topDir;
-      runExpandAdd(expandOpts).catch((err: unknown) => {
-        process.stderr.write(`sqlever add --expand: ${err instanceof Error ? err.message : String(err)}\n`);
-        process.exit(1);
-      });
-      return;
-    }
-    const addOpts = parseAddArgs(args.rest);
-    addOpts.topDir = args.topDir;
-    runAdd(addOpts).catch((err: unknown) => {
-      process.stderr.write(`sqlever add: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
-    });
-    return;
-  }
-
-  if (args.command === "deploy") {
-    runDeploy(args).then((exitCode) => {
-      if (exitCode !== 0) {
-        process.exit(exitCode);
-      }
-    }).catch((err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`sqlever deploy: ${msg}\n`);
-      process.exit(1);
-    });
-    return;
-  }
-
-  if (args.command === "log") {
-    runLogCommand(args).catch((err: unknown) => {
-      process.stderr.write(`sqlever log: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
-    });
-    return;
-  }
-
-  if (args.command === "revert") {
-    runRevert(args)
-      .then((exitCode) => {
-        if (exitCode !== 0) process.exit(exitCode);
-      })
-      .catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(`sqlever revert: ${msg}\n`);
-        process.exit(1);
-      });
-    return;
-  }
-
-  if (args.command === "tag") {
-    const tagOpts = parseTagArgs(args.rest);
-    tagOpts.topDir = args.topDir;
-    runTag(tagOpts).catch((err: unknown) => {
-      process.stderr.write(`sqlever tag: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
-    });
-    return;
-  }
-
-  if (args.command === "rework") {
-    const reworkOpts = parseReworkArgs(args.rest);
-    reworkOpts.topDir = args.topDir;
-    runRework(reworkOpts).catch((err: unknown) => {
-      process.stderr.write(`sqlever rework: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
-    });
-    return;
-  }
-
-  if (args.command === "show") {
-    const showOpts = parseShowArgs(args.rest);
-    if (args.topDir !== undefined) showOpts.topDir = args.topDir;
-    if (args.planFile !== undefined) showOpts.planFile = args.planFile;
-    try {
-      runShow(showOpts);
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`sqlever show: ${msg}\n`);
-      process.exit(1);
-    }
-    return;
-  }
-
-  if (args.command === "verify") {
-    runVerify(args).catch((err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`sqlever verify: ${msg}\n`);
-      process.exit(1);
-    });
-    return;
-  }
-
-  if (args.command === "status") {
-    runStatus(args).catch((err: unknown) => {
-      process.stderr.write(`sqlever status: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
-    });
-    return;
-  }
-
-  if (args.command === "plan") {
-    runPlan(args);
-    return;
-  }
-
-  if (args.command === "analyze") {
-    const analyzeOpts = parseAnalyzeArgs(args.rest);
-    if (args.topDir !== undefined) analyzeOpts.topDir = args.topDir;
-    if (args.planFile !== undefined) analyzeOpts.planFile = args.planFile;
-    runAnalyze(analyzeOpts)
-      .then((result) => { if (result.exitCode !== 0) process.exit(result.exitCode); })
-      .catch((err: unknown) => { process.stderr.write(`sqlever analyze: ${err instanceof Error ? err.message : String(err)}\n`); process.exit(1); });
-    return;
-  }
-
-  if (args.command === "explain") {
-    const explainOpts = parseExplainArgs(args.rest);
-    runExplain(explainOpts)
-      .then((exitCode) => { if (exitCode !== 0) process.exit(exitCode); })
-      .catch((err: unknown) => { process.stderr.write(`sqlever explain: ${err instanceof Error ? err.message : String(err)}\n`); process.exit(1); });
-    return;
-  }
-
-  if (args.command === "doctor") {
-    const exitCode = runDoctor(args);
+  // All commands are dispatched via a single try/catch with consistent
+  // error formatting: "sqlever <command>: <message>".
+  const command = args.command;
+  try {
+    const exitCode = await dispatchCommand(command, args);
     if (exitCode !== 0) process.exit(exitCode);
-    return;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`sqlever ${command}: ${msg}\n`);
+    process.exit(1);
   }
+}
 
-  if (args.command === "diff") {
-    runDiff(args).catch((err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`sqlever diff: ${msg}\n`);
-      process.exit(1);
-    });
-    return;
+/**
+ * Dispatch a command and return its exit code (0 = success).
+ *
+ * Commands that don't return an exit code return 0 on success.
+ * Errors are propagated as exceptions to the caller.
+ */
+async function dispatchCommand(command: string, args: ParsedArgs): Promise<number> {
+  switch (command) {
+    case "init":
+      await runInit(args);
+      return 0;
+
+    case "add": {
+      if (args.rest.includes("--expand")) {
+        const expandOpts = parseExpandArgs(args.rest);
+        expandOpts.topDir = args.topDir;
+        await runExpandAdd(expandOpts);
+      } else {
+        const addOpts = parseAddArgs(args.rest);
+        addOpts.topDir = args.topDir;
+        await runAdd(addOpts);
+      }
+      return 0;
+    }
+
+    case "deploy":
+      return await runDeploy(args);
+
+    case "log":
+      await runLogCommand(args);
+      return 0;
+
+    case "revert":
+      return await runRevert(args);
+
+    case "tag": {
+      const tagOpts = parseTagArgs(args.rest);
+      tagOpts.topDir = args.topDir;
+      await runTag(tagOpts);
+      return 0;
+    }
+
+    case "rework": {
+      const reworkOpts = parseReworkArgs(args.rest);
+      reworkOpts.topDir = args.topDir;
+      await runRework(reworkOpts);
+      return 0;
+    }
+
+    case "show": {
+      const showOpts = parseShowArgs(args.rest);
+      if (args.topDir !== undefined) showOpts.topDir = args.topDir;
+      if (args.planFile !== undefined) showOpts.planFile = args.planFile;
+      runShow(showOpts);
+      return 0;
+    }
+
+    case "verify":
+      return await runVerify(args);
+
+    case "status":
+      await runStatus(args);
+      return 0;
+
+    case "plan":
+      runPlan(args);
+      return 0;
+
+    case "analyze": {
+      const analyzeOpts = parseAnalyzeArgs(args.rest);
+      if (args.topDir !== undefined) analyzeOpts.topDir = args.topDir;
+      if (args.planFile !== undefined) analyzeOpts.planFile = args.planFile;
+      const result = await runAnalyze(analyzeOpts);
+      return result.exitCode;
+    }
+
+    case "explain": {
+      const explainOpts = parseExplainArgs(args.rest);
+      return await runExplain(explainOpts);
+    }
+
+    case "doctor":
+      return runDoctor(args);
+
+    case "diff":
+      await runDiff(args);
+      return 0;
+
+    case "review": {
+      const reviewOpts = parseReviewArgs(args.rest);
+      if (args.topDir !== undefined) reviewOpts.topDir = args.topDir;
+      if (args.planFile !== undefined) reviewOpts.planFile = args.planFile;
+      const reviewResult = await runReviewCommand(reviewOpts);
+      return reviewResult.exitCode;
+    }
+
+    case "batch":
+      await runBatch(args);
+      return 0;
+
+    default:
+      stubHandler(command);
   }
-
-  if (args.command === "review") {
-    const reviewOpts = parseReviewArgs(args.rest);
-    if (args.topDir !== undefined) reviewOpts.topDir = args.topDir;
-    if (args.planFile !== undefined) reviewOpts.planFile = args.planFile;
-    runReviewCommand(reviewOpts)
-      .then((result) => { if (result.exitCode !== 0) process.exit(result.exitCode); })
-      .catch((err: unknown) => { process.stderr.write(`sqlever review: ${err instanceof Error ? err.message : String(err)}\n`); process.exit(1); });
-    return;
-  }
-
-  if (args.command === "batch") {
-    runBatch(args).catch((err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`sqlever batch: ${msg}\n`);
-      process.exit(1);
-    });
-    return;
-  }
-
-  // Known command — stub handler
-  stubHandler(args.command);
 }
 
 // Run when executed directly (not when imported by tests)

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -10,7 +10,7 @@ import { loadConfig, type MergedConfig } from "../config/index";
 import { computeChangeId, type ChangeIdInput } from "../plan/types";
 import { appendChange } from "../plan/writer";
 import type { Change } from "../plan/types";
-import { info, error, verbose } from "../output";
+import { info, verbose } from "../output";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -312,18 +312,16 @@ export async function runAdd(
 
   // Validate change name
   if (!opts.name) {
-    error("Error: change name is required. Usage: sqlever add <name>");
-    process.exit(1);
+    throw new Error("change name is required. Usage: sqlever add <name>");
   }
 
   // Validate change name format (alphanumeric, underscores, hyphens)
   if (!/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(opts.name)) {
-    error(
-      `Error: invalid change name '${opts.name}'. ` +
+    throw new Error(
+      `invalid change name '${opts.name}'. ` +
       "Names must start with a letter or underscore and contain only " +
       "letters, digits, underscores, and hyphens.",
     );
-    process.exit(1);
   }
 
   // Load config if not provided
@@ -338,19 +336,17 @@ export async function runAdd(
 
   // Ensure plan file exists
   if (!existsSync(planPath)) {
-    error(`Error: plan file not found at ${planPath}. Run 'sqlever init' first.`);
-    process.exit(1);
+    throw new Error(`plan file not found at ${planPath}. Run 'sqlever init' first.`);
   }
 
   // Read existing plan to check for duplicates and get last change ID
   const planInfo = readPlanInfo(planPath);
 
   if (planInfo.existingNames.has(opts.name)) {
-    error(
-      `Error: change '${opts.name}' already exists in the plan. ` +
+    throw new Error(
+      `change '${opts.name}' already exists in the plan. ` +
       "Use 'sqlever rework' to create a new version of an existing change.",
     );
-    process.exit(1);
   }
 
   // Get planner identity
@@ -402,16 +398,13 @@ export async function runAdd(
   const verifyPath = join(verifyDir, `${opts.name}.sql`);
 
   if (existsSync(deployPath)) {
-    error(`Error: deploy script already exists at ${deployPath}`);
-    process.exit(1);
+    throw new Error(`deploy script already exists at ${deployPath}`);
   }
   if (existsSync(revertPath)) {
-    error(`Error: revert script already exists at ${revertPath}`);
-    process.exit(1);
+    throw new Error(`revert script already exists at ${revertPath}`);
   }
   if (!opts.noVerify && existsSync(verifyPath)) {
-    error(`Error: verify script already exists at ${verifyPath}`);
-    process.exit(1);
+    throw new Error(`verify script already exists at ${verifyPath}`);
   }
 
   writeFileSync(deployPath, deployTemplate(opts.name, opts.requires), "utf-8");

--- a/src/commands/batch.ts
+++ b/src/commands/batch.ts
@@ -13,7 +13,7 @@
 
 import type { ParsedArgs } from "../cli";
 import type { BatchJob } from "../batch/queue";
-import { info, error as logError, json as jsonOut, table } from "../output";
+import { info, json as jsonOut, table } from "../output";
 
 // ---------------------------------------------------------------------------
 // Subcommand argument types
@@ -347,9 +347,8 @@ export async function runBatch(args: ParsedArgs): Promise<void> {
   }
 
   if (!BATCH_SUBCOMMANDS.includes(subcommand as BatchSubcommand)) {
-    logError(`sqlever batch: unknown subcommand '${subcommand}'`);
     process.stdout.write(BATCH_HELP);
-    process.exit(1);
+    throw new Error(`unknown subcommand '${subcommand}'`);
   }
 
   const format = args.format;

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -13,7 +13,7 @@ import { join, resolve } from "node:path";
 import { loadConfig } from "../config/index";
 import { parsePlan } from "../plan/parser";
 import type { Change, Plan, Tag } from "../plan/types";
-import { info, error, json as jsonOut } from "../output";
+import { info, json as jsonOut } from "../output";
 import type { ParsedArgs } from "../cli";
 import { resolveTargetUri, withDatabase } from "./shared";
 
@@ -304,9 +304,7 @@ export async function runDiff(args: ParsedArgs): Promise<void> {
     : join(topDir, config.core.plan_file);
 
   if (!existsSync(planFilePath)) {
-    error(`Plan file not found: ${planFilePath}`);
-    error("Run 'sqlever init' to initialize a project.");
-    process.exit(1);
+    throw new Error(`plan file not found: ${planFilePath}. Run 'sqlever init' to initialize a project.`);
   }
 
   const planContent = readFileSync(planFilePath, "utf-8");
@@ -314,12 +312,10 @@ export async function runDiff(args: ParsedArgs): Promise<void> {
 
   // Validate tag arguments
   if (diffOpts.fromTag && !diffOpts.toTag) {
-    error("--from requires --to");
-    process.exit(1);
+    throw new Error("--from requires --to");
   }
   if (diffOpts.toTag && !diffOpts.fromTag) {
-    error("--to requires --from");
-    process.exit(1);
+    throw new Error("--to requires --from");
   }
 
   // Resolve target URI for DB connection

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,7 +15,7 @@ import {
   confSet,
   type SqitchConf,
 } from "../config/sqitch-conf";
-import { info, error } from "../output";
+import { info } from "../output";
 import { serializePlan } from "../plan/writer";
 import type { Plan } from "../plan/types";
 
@@ -177,14 +177,13 @@ export async function runInit(args: ParsedArgs): Promise<void> {
     try {
       const planStat = await stat(planPath);
       if (planStat.isFile()) {
-        error(
-          `Plan file already exists: ${planPath}\n` +
-            `Use --force to reinitialize.`,
+        throw new Error(
+          `plan file already exists: ${planPath}. Use --force to reinitialize.`,
         );
-        process.exit(1);
       }
-    } catch {
-      // File doesn't exist — proceed
+    } catch (err) {
+      // Rethrow our own errors; ignore ENOENT (file doesn't exist)
+      if (err instanceof Error && !("code" in err)) throw err;
     }
   }
 

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -4,7 +4,7 @@
 // event type, pagination (limit/offset), ordering, and JSON output.
 
 import { Registry, type Event } from "../db/registry";
-import { info, error, json, table, verbose, getConfig } from "../output";
+import { info, json, table, verbose, getConfig } from "../output";
 import type { ParsedArgs } from "../cli";
 import { loadConfig } from "../config/index";
 import { resolveTargetUri, withDatabase } from "./shared";
@@ -208,8 +208,7 @@ export async function runLogCommand(args: ParsedArgs): Promise<void> {
     ?? undefined;
 
   if (!dbUri) {
-    error("Error: no database URI specified. Use --db-uri or configure a target.");
-    process.exit(1);
+    throw new Error("no database URI specified. Use --db-uri or configure a target.");
   }
 
   // Resolve project name from config

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -11,7 +11,7 @@ import { resolve } from "node:path";
 import type { ParsedArgs } from "../cli";
 import { parsePlan } from "../plan/parser";
 import type { Plan, Change, Tag } from "../plan/types";
-import { info, error, json, table, getConfig } from "../output";
+import { info, json, table, getConfig } from "../output";
 
 // ---------------------------------------------------------------------------
 // Plan-specific argument parsing
@@ -256,20 +256,16 @@ export function runPlan(args: ParsedArgs): void {
   try {
     content = readFileSync(opts.planFile, "utf-8");
   } catch {
-    error(`Error: cannot read plan file: ${opts.planFile}`);
-    process.exit(1);
-    return; // unreachable, for TypeScript
+    throw new Error(`cannot read plan file: ${opts.planFile}`);
   }
 
   let plan: Plan;
   try {
     plan = parsePlan(content);
   } catch (e) {
-    error(
-      `Error: failed to parse plan file: ${e instanceof Error ? e.message : String(e)}`,
+    throw new Error(
+      `failed to parse plan file: ${e instanceof Error ? e.message : String(e)}`,
     );
-    process.exit(1);
-    return;
   }
 
   // Apply filters

--- a/src/commands/rework.ts
+++ b/src/commands/rework.ts
@@ -21,7 +21,7 @@ import {
   revertTemplate,
   verifyTemplate,
 } from "./add";
-import { info, error, verbose } from "../output";
+import { info, verbose } from "../output";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -194,8 +194,7 @@ export async function runRework(
 
   // Validate change name
   if (!opts.name) {
-    error("Error: change name is required. Usage: sqlever rework <name> [-n note]");
-    process.exit(1);
+    throw new Error("change name is required. Usage: sqlever rework <name> [-n note]");
   }
 
   // Validate change name format (same rules as `add` — prevents path traversal)
@@ -220,22 +219,12 @@ export async function runRework(
 
   // Ensure plan file exists
   if (!existsSync(planPath)) {
-    error(`Error: plan file not found at ${planPath}. Run 'sqlever init' first.`);
-    process.exit(1);
+    throw new Error(`plan file not found at ${planPath}. Run 'sqlever init' first.`);
   }
 
   // Read and analyze the plan
   const planContent = readFileSync(planPath, "utf-8");
-  let ctx: ReworkContext;
-  try {
-    ctx = findReworkContext(planContent, opts.name);
-  } catch (err) {
-    if (err instanceof ReworkError) {
-      error(`Error: ${err.message}`);
-      process.exit(1);
-    }
-    throw err;
-  }
+  const ctx = findReworkContext(planContent, opts.name);
 
   const tagName = ctx.tagAfterChange.name;
 

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -14,7 +14,7 @@ import { join, resolve } from "node:path";
 import { loadConfig, type MergedConfig } from "../config/index";
 import { parsePlan } from "../plan/parser";
 import type { Change, Tag } from "../plan/types";
-import { info, error, json, getConfig } from "../output";
+import { info, json, getConfig } from "../output";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -207,19 +207,17 @@ export function runShow(
 ): void {
   // Validate type
   if (!opts.type || !VALID_TYPES.has(opts.type)) {
-    error(
-      `Error: invalid show type '${opts.type || ""}'. ` +
+    throw new Error(
+      `invalid show type '${opts.type || ""}'. ` +
       "Expected one of: deploy, revert, verify, change, tag.",
     );
-    process.exit(1);
   }
 
   // Validate name
   if (!opts.name) {
-    error(
-      "Error: name is required. Usage: sqlever show <type> <name>",
+    throw new Error(
+      "name is required. Usage: sqlever show <type> <name>",
     );
-    process.exit(1);
   }
 
   // Validate name format for script types to prevent path traversal.
@@ -258,8 +256,7 @@ export function runShow(
     const content = readScript(scriptPath);
 
     if (content === null) {
-      error(`Error: ${opts.type} script not found at ${scriptPath}`);
-      process.exit(1);
+      throw new Error(`${opts.type} script not found at ${scriptPath}`);
     }
 
     if (outputCfg.format === "json") {
@@ -279,14 +276,12 @@ export function runShow(
   // Metadata types: change, tag
   if (opts.type === "change") {
     if (!existsSync(planPath)) {
-      error(`Error: plan file not found at ${planPath}`);
-      process.exit(1);
+      throw new Error(`plan file not found at ${planPath}`);
     }
 
     const change = findChange(planPath, opts.name);
     if (!change) {
-      error(`Error: change '${opts.name}' not found in plan`);
-      process.exit(1);
+      throw new Error(`change '${opts.name}' not found in plan`);
     }
 
     if (outputCfg.format === "json") {
@@ -299,14 +294,12 @@ export function runShow(
 
   if (opts.type === "tag") {
     if (!existsSync(planPath)) {
-      error(`Error: plan file not found at ${planPath}`);
-      process.exit(1);
+      throw new Error(`plan file not found at ${planPath}`);
     }
 
     const tag = findTag(planPath, opts.name);
     if (!tag) {
-      error(`Error: tag '${opts.name}' not found in plan`);
-      process.exit(1);
+      throw new Error(`tag '${opts.name}' not found in plan`);
     }
 
     if (outputCfg.format === "json") {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -13,7 +13,7 @@ import { loadConfig } from "../config/index";
 import { parsePlan } from "../plan/parser";
 import { computeScriptHash, type Plan } from "../plan/types";
 import type { Change as RegistryChange } from "../db/registry";
-import { info, error, json as jsonOut } from "../output";
+import { info, json as jsonOut } from "../output";
 import type { ParsedArgs } from "../cli";
 import { resolveTargetUri, withDatabase } from "./shared";
 // Re-exported from shared for backward compatibility (tests import from status).
@@ -273,9 +273,7 @@ export async function runStatus(args: ParsedArgs): Promise<void> {
     : join(topDir, config.core.plan_file);
 
   if (!existsSync(planFilePath)) {
-    error(`Plan file not found: ${planFilePath}`);
-    error("Run 'sqlever init' to initialize a project.");
-    process.exit(1);
+    throw new Error(`plan file not found: ${planFilePath}. Run 'sqlever init' to initialize a project.`);
   }
 
   const planContent = readFileSync(planFilePath, "utf-8");

--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -13,7 +13,7 @@ import { loadConfig, type MergedConfig } from "../config/index";
 import { computeTagId, type TagIdInput, type Tag } from "../plan/types";
 import { appendTag } from "../plan/writer";
 import { parsePlan } from "../plan/parser";
-import { info, error, verbose } from "../output";
+import { info, verbose } from "../output";
 import { getPlannerIdentity, nowTimestamp } from "./add";
 
 // ---------------------------------------------------------------------------
@@ -105,20 +105,18 @@ export async function runTag(
 
   // Validate tag name
   if (!opts.name) {
-    error("Error: tag name is required. Usage: sqlever tag <name> [-n note]");
-    process.exit(1);
+    throw new Error("tag name is required. Usage: sqlever tag <name> [-n note]");
   }
 
   // Strip leading @ if the user included it
   const tagName = opts.name.startsWith("@") ? opts.name.slice(1) : opts.name;
 
   if (!isValidTagName(tagName)) {
-    error(
-      `Error: invalid tag name '${tagName}'. ` +
+    throw new Error(
+      `invalid tag name '${tagName}'. ` +
       "Names must start with a letter or underscore and contain only " +
       "letters, digits, underscores, hyphens, and dots.",
     );
-    process.exit(1);
   }
 
   // Load config if not provided
@@ -130,8 +128,7 @@ export async function runTag(
 
   // Ensure plan file exists
   if (!existsSync(planPath)) {
-    error(`Error: plan file not found at ${planPath}. Run 'sqlever init' first.`);
-    process.exit(1);
+    throw new Error(`plan file not found at ${planPath}. Run 'sqlever init' first.`);
   }
 
   // Parse the plan file to get project info and the last change
@@ -140,18 +137,16 @@ export async function runTag(
 
   // Must have at least one change to tag
   if (plan.changes.length === 0) {
-    error("Error: no changes in plan. Add a change before tagging.");
-    process.exit(1);
+    throw new Error("no changes in plan. Add a change before tagging.");
   }
 
   // Check for duplicate tag name
   const existingTagNames = new Set(plan.tags.map((t) => t.name));
   if (existingTagNames.has(tagName)) {
-    error(
-      `Error: tag '@${tagName}' already exists in the plan. ` +
+    throw new Error(
+      `tag '@${tagName}' already exists in the plan. ` +
       "Tag names must be unique.",
     );
-    process.exit(1);
   }
 
   // The tag attaches to the last change

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -21,7 +21,7 @@ import {
   type Change as RegistryChange,
 } from "../db/registry";
 import { PsqlRunner, type PsqlRunResult } from "../psql";
-import { info, error as logError, verbose } from "../output";
+import { info, verbose } from "../output";
 import { resolveTargetUri, withDatabase } from "./shared";
 
 // ---------------------------------------------------------------------------
@@ -296,7 +296,7 @@ export async function runVerify(
   opts?: {
     psqlRunner?: PsqlRunner;
   },
-): Promise<void> {
+): Promise<number> {
   const options = parseVerifyOptions(args);
   const topDir = resolve(options.topDir);
 
@@ -308,27 +308,19 @@ export async function runVerify(
     ? resolve(options.planFile)
     : join(topDir, config.core.plan_file);
 
-  let plan: Plan;
-  try {
-    const planContent = readFileSync(planFilePath, "utf-8");
-    plan = parsePlan(planContent);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    logError(`Failed to read plan file: ${msg}`);
-    process.exit(1);
-  }
+  const planContent = readFileSync(planFilePath, "utf-8");
+  const plan = parsePlan(planContent);
 
   // Resolve target URI
   const targetUri = resolveTargetUri(config, options.dbUri, options.target);
   if (!targetUri) {
-    logError(
-      "No database target specified. Use --db-uri or configure a target in sqitch.conf.",
+    throw new Error(
+      "no database target specified. Use --db-uri or configure a target in sqitch.conf.",
     );
-    process.exit(1);
   }
 
   // 2. Connect to database, run verification, disconnect
-  await withDatabase(
+  return await withDatabase(
     targetUri,
     { command: "verify", project: plan.project.name },
     async (db) => {
@@ -339,26 +331,19 @@ export async function runVerify(
 
       if (deployedChanges.length === 0) {
         info("Nothing to verify. No changes are deployed.");
-        return;
+        return 0;
       }
 
       // 4. Filter to --from/--to range
-      let changesToVerify: RegistryChange[];
-      try {
-        changesToVerify = filterChangesForRange(
-          deployedChanges,
-          options.fromChange,
-          options.toChange,
-        );
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        logError(msg);
-        process.exit(1);
-      }
+      const changesToVerify = filterChangesForRange(
+        deployedChanges,
+        options.fromChange,
+        options.toChange,
+      );
 
       if (changesToVerify.length === 0) {
         info("Nothing to verify in the specified range.");
-        return;
+        return 0;
       }
 
       // 5. Execute verify scripts
@@ -396,9 +381,7 @@ export async function runVerify(
       info(formatVerifyResult(verifyResult));
 
       // 7. Exit code 3 if any failures (SPEC R6)
-      if (verifyResult.failed > 0) {
-        process.exit(EXIT_CODE_VERIFY_FAILED);
-      }
+      return verifyResult.failed > 0 ? EXIT_CODE_VERIFY_FAILED : 0;
     },
   );
 }

--- a/tests/unit/add.test.ts
+++ b/tests/unit/add.test.ts
@@ -564,129 +564,52 @@ describe("runAdd", () => {
     );
     const cfg = testConfig(tmpDir);
 
-    // Mock process.exit to capture exit
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runAdd(
-        {
-          name: "create_users",
-          note: "duplicate",
-          requires: [],
-          conflicts: [],
-          noVerify: false,
-        },
+    await expect(
+      runAdd(
+        { name: "create_users", note: "duplicate", requires: [], conflicts: [], noVerify: false },
         cfg,
         TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+      ),
+    ).rejects.toThrow("already exists");
   });
 
   it("errors when plan file does not exist", async () => {
     // Don't create sqitch.plan
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runAdd(
-        {
-          name: "create_users",
-          note: "",
-          requires: [],
-          conflicts: [],
-          noVerify: false,
-        },
+    await expect(
+      runAdd(
+        { name: "create_users", note: "", requires: [], conflicts: [], noVerify: false },
         cfg,
         TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+      ),
+    ).rejects.toThrow("plan file not found");
   });
 
   it("errors on invalid change name", async () => {
     setupProject(tmpDir);
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runAdd(
-        {
-          name: "123-invalid",
-          note: "",
-          requires: [],
-          conflicts: [],
-          noVerify: false,
-        },
+    await expect(
+      runAdd(
+        { name: "123-invalid", note: "", requires: [], conflicts: [], noVerify: false },
         cfg,
         TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+      ),
+    ).rejects.toThrow("invalid change name");
   });
 
   it("errors when no change name provided", async () => {
     setupProject(tmpDir);
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runAdd(
-        {
-          name: "",
-          note: "",
-          requires: [],
-          conflicts: [],
-          noVerify: false,
-        },
+    await expect(
+      runAdd(
+        { name: "", note: "", requires: [], conflicts: [], noVerify: false },
         cfg,
         TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+      ),
+    ).rejects.toThrow("change name is required");
   });
 
   it("skips verify file when --no-verify is set", async () => {
@@ -858,32 +781,13 @@ describe("runAdd", () => {
     writeFileSync(join(tmpDir, "deploy", "create_users.sql"), "existing", "utf-8");
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runAdd(
-        {
-          name: "create_users",
-          note: "",
-          requires: [],
-          conflicts: [],
-          noVerify: false,
-        },
+    await expect(
+      runAdd(
+        { name: "create_users", note: "", requires: [], conflicts: [], noVerify: false },
         cfg,
         TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+      ),
+    ).rejects.toThrow("deploy script already exists");
   });
 
   it("correctly formats plan entry with multiple deps", async () => {

--- a/tests/unit/diff.test.ts
+++ b/tests/unit/diff.test.ts
@@ -497,7 +497,7 @@ describe("diff CLI integration", () => {
       tempDir,
     );
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain("Plan file not found");
+    expect(stderr).toContain("plan file not found");
   });
 
   test("shows pending changes in plan-only mode (no DB)", async () => {

--- a/tests/unit/rework.test.ts
+++ b/tests/unit/rework.test.ts
@@ -364,92 +364,36 @@ describe("runRework", () => {
     setupReworkProject(tmpDir, PLAN_WITH_TAG);
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runRework({ name: "", note: "" }, cfg, TEST_ENV);
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    await expect(
+      runRework({ name: "", note: "" }, cfg, TEST_ENV),
+    ).rejects.toThrow("change name is required");
   });
 
   it("errors when change does not exist in plan", async () => {
     setupReworkProject(tmpDir, PLAN_WITH_TAG);
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runRework(
-        { name: "nonexistent_change", note: "" },
-        cfg,
-        TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    await expect(
+      runRework({ name: "nonexistent_change", note: "" }, cfg, TEST_ENV),
+    ).rejects.toThrow("Unknown change");
   });
 
   it("errors when no tag exists after the change", async () => {
     setupReworkProject(tmpDir, PLAN_NO_TAG);
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runRework({ name: "add_users", note: "" }, cfg, TEST_ENV);
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    await expect(
+      runRework({ name: "add_users", note: "" }, cfg, TEST_ENV),
+    ).rejects.toThrow("no tag exists");
   });
 
   it("errors when plan file does not exist", async () => {
     // Don't create plan file
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runRework({ name: "add_users", note: "" }, cfg, TEST_ENV);
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    await expect(
+      runRework({ name: "add_users", note: "" }, cfg, TEST_ENV),
+    ).rejects.toThrow("plan file not found");
   });
 
   it("handles rework when change is not the last change in plan", async () => {

--- a/tests/unit/show.test.ts
+++ b/tests/unit/show.test.ts
@@ -375,107 +375,29 @@ describe("runShow", () => {
   });
 
   it("errors on invalid show type", () => {
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      runShow({ type: "invalid" as any, name: "foo" });
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    expect(() => runShow({ type: "invalid" as any, name: "foo" })).toThrow("invalid show type");
   });
 
   it("errors when no name is provided", () => {
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      runShow({ type: "deploy", name: "" });
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    expect(() => runShow({ type: "deploy", name: "" })).toThrow("name is required");
   });
 
   it("errors when deploy script not found", () => {
     setupProject(tmpDir);
     const cfg = testConfig(tmpDir);
-
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      runShow({ type: "deploy", name: "nonexistent", topDir: tmpDir }, cfg);
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    expect(() => runShow({ type: "deploy", name: "nonexistent", topDir: tmpDir }, cfg)).toThrow("script not found");
   });
 
   it("errors when change not found in plan", () => {
     setupProject(tmpDir);
     const cfg = testConfig(tmpDir);
-
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      runShow({ type: "change", name: "nonexistent", topDir: tmpDir }, cfg);
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    expect(() => runShow({ type: "change", name: "nonexistent", topDir: tmpDir }, cfg)).toThrow("not found in plan");
   });
 
   it("errors when tag not found in plan", () => {
     setupProject(tmpDir);
     const cfg = testConfig(tmpDir);
-
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      runShow({ type: "tag", name: "nonexistent", topDir: tmpDir }, cfg);
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    expect(() => runShow({ type: "tag", name: "nonexistent", topDir: tmpDir }, cfg)).toThrow("not found in plan");
   });
 
   it("prints deploy script to stdout", () => {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -667,7 +667,7 @@ describe("status CLI integration", () => {
       tempDir,
     );
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain("Plan file not found");
+    expect(stderr).toContain("plan file not found");
   });
 
   test("shows plan-only status (no DB) when plan exists but no target", async () => {

--- a/tests/unit/tag.test.ts
+++ b/tests/unit/tag.test.ts
@@ -286,26 +286,9 @@ describe("runTag", () => {
     );
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runTag(
-        { name: "v1.0", note: "duplicate" },
-        cfg,
-        TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    await expect(
+      runTag({ name: "v1.0", note: "duplicate" }, cfg, TEST_ENV),
+    ).rejects.toThrow("already exists");
   });
 
   it("errors when plan has no changes", async () => {
@@ -318,104 +301,36 @@ describe("runTag", () => {
     );
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runTag(
-        { name: "v1.0", note: "" },
-        cfg,
-        TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    await expect(
+      runTag({ name: "v1.0", note: "" }, cfg, TEST_ENV),
+    ).rejects.toThrow("no changes in plan");
   });
 
   it("errors when plan file does not exist", async () => {
     // Don't create a plan file
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runTag(
-        { name: "v1.0", note: "" },
-        cfg,
-        TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    await expect(
+      runTag({ name: "v1.0", note: "" }, cfg, TEST_ENV),
+    ).rejects.toThrow("plan file not found");
   });
 
   it("errors when no tag name provided", async () => {
     setupProject(tmpDir);
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runTag(
-        { name: "", note: "" },
-        cfg,
-        TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    await expect(
+      runTag({ name: "", note: "" }, cfg, TEST_ENV),
+    ).rejects.toThrow("tag name is required");
   });
 
   it("errors on invalid tag name", async () => {
     setupProject(tmpDir);
     const cfg = testConfig(tmpDir);
 
-    const origExit = process.exit;
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => {
-      exitCode = code;
-      throw new Error(`process.exit(${code})`);
-    }) as never;
-
-    try {
-      await runTag(
-        { name: "123-invalid", note: "" },
-        cfg,
-        TEST_ENV,
-      );
-    } catch {
-      // Expected
-    } finally {
-      process.exit = origExit;
-    }
-
-    expect(exitCode).toBe(1);
+    await expect(
+      runTag({ name: "123-invalid", note: "" }, cfg, TEST_ENV),
+    ).rejects.toThrow("invalid tag name");
   });
 
   it("tags the last change in a multi-change plan", async () => {


### PR DESCRIPTION
## Summary

- **Exit code handling**: Commands no longer call `process.exit()` directly — they throw errors or return exit codes, letting `cli.ts` handle all exits in one place with consistent `"sqlever <cmd>: <message>"` formatting
- **Async dispatch**: Replace 15 separate `.then().catch()` chains in `cli.ts` with a single `async dispatchCommand()` switch/case and one `try/catch` — removes ~200 lines of duplicated error-handling boilerplate
- **Error messages**: Remove redundant `"Error:"` prefix from command messages (cli.ts already adds `"sqlever <cmd>:"` prefix); lowercase message starts to follow Unix conventions
- **Help text**: Standardize all 24 command descriptions to consistent imperative verb phrases

Files changed: `cli.ts`, 11 command files (`add`, `batch`, `diff`, `init`, `log`, `plan`, `rework`, `show`, `status`, `tag`, `verify`), 6 test files. Net -432 lines.

## Test plan

- [x] All 2626 tests pass (0 failures)
- [x] Tests updated to use `rejects.toThrow()` / `toThrow()` instead of mocking `process.exit()`
- [x] No new TypeScript errors introduced (all pre-existing)
- [x] CLI subprocess integration tests still verify exit codes and stderr messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)