### PR TITLE
refactor: remove process.exit from library code, clean dead code

### DIFF
--- a/src/analysis/rules/SA002.ts
+++ b/src/analysis/rules/SA002.ts
@@ -40,13 +40,13 @@ const VOLATILE_FUNCTIONS: ReadonlySet<string> = new Set([
 /**
  * Recursively check if an AST expression node contains a volatile function call.
  */
-function containsVolatileFunction(n: unknown): string | null {
-  if (!n || typeof n !== "object") return null;
-  const nd = node(n);
+function containsVolatileFunction(astNode: unknown): string | null {
+  if (!astNode || typeof astNode !== "object") return null;
+  const exprNode = node(astNode);
 
   // Direct function call
-  if (nd.FuncCall) {
-    const funcNode = node(nd.FuncCall);
+  if (exprNode.FuncCall) {
+    const funcNode = node(exprNode.FuncCall);
     const funcNames = nodes(funcNode.funcname);
     for (const fn of funcNames) {
       const name = (node(fn).String as Record<string, unknown> | undefined);
@@ -64,21 +64,21 @@ function containsVolatileFunction(n: unknown): string | null {
   }
 
   // TypeCast wrapping a volatile function (e.g. random()::int)
-  if (nd.TypeCast) {
-    return containsVolatileFunction(node(nd.TypeCast).arg);
+  if (exprNode.TypeCast) {
+    return containsVolatileFunction(node(exprNode.TypeCast).arg);
   }
 
   // Check nested expressions
-  if (nd.A_Expr) {
-    const expr = node(nd.A_Expr);
+  if (exprNode.A_Expr) {
+    const expr = node(exprNode.A_Expr);
     const left = containsVolatileFunction(expr.lexpr);
     if (left) return left;
     return containsVolatileFunction(expr.rexpr);
   }
 
   // CoalesceExpr
-  if (nd.CoalesceExpr) {
-    for (const arg of nodes(node(nd.CoalesceExpr).args)) {
+  if (exprNode.CoalesceExpr) {
+    for (const arg of nodes(node(exprNode.CoalesceExpr).args)) {
       const result = containsVolatileFunction(arg);
       if (result) return result;
     }

--- a/src/analysis/rules/SA002b.ts
+++ b/src/analysis/rules/SA002b.ts
@@ -36,12 +36,12 @@ const VOLATILE_FUNCTIONS: ReadonlySet<string> = new Set([
  * Check if an expression contains a volatile function call.
  * Returns true if ANY function in the expression is volatile.
  */
-function containsVolatileFunction(n: unknown): boolean {
-  if (!n || typeof n !== "object") return false;
-  const nd = node(n);
+function containsVolatileFunction(astNode: unknown): boolean {
+  if (!astNode || typeof astNode !== "object") return false;
+  const exprNode = node(astNode);
 
-  if (nd.FuncCall) {
-    const funcNode = node(nd.FuncCall);
+  if (exprNode.FuncCall) {
+    const funcNode = node(exprNode.FuncCall);
     for (const fn of nodes(funcNode.funcname)) {
       const name = (node(fn).String as Record<string, unknown> | undefined);
       const sval = name ? String(node(name).sval ?? "").toLowerCase() : "";
@@ -56,20 +56,20 @@ function containsVolatileFunction(n: unknown): boolean {
     return false;
   }
 
-  if (nd.TypeCast) {
-    return containsVolatileFunction(node(nd.TypeCast).arg);
+  if (exprNode.TypeCast) {
+    return containsVolatileFunction(node(exprNode.TypeCast).arg);
   }
 
-  if (nd.A_Expr) {
-    const expr = node(nd.A_Expr);
+  if (exprNode.A_Expr) {
+    const expr = node(exprNode.A_Expr);
     return (
       containsVolatileFunction(expr.lexpr) ||
       containsVolatileFunction(expr.rexpr)
     );
   }
 
-  if (nd.CoalesceExpr) {
-    for (const arg of nodes(node(nd.CoalesceExpr).args)) {
+  if (exprNode.CoalesceExpr) {
+    for (const arg of nodes(node(exprNode.CoalesceExpr).args)) {
       if (containsVolatileFunction(arg)) return true;
     }
   }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -320,12 +320,6 @@ export function isAutoCommit(scriptContent: string): boolean {
 }
 
 /**
- * @deprecated Use isAutoCommit() instead.
- * Kept as an alias for backward compatibility.
- */
-export const isNonTransactional = isAutoCommit;
-
-/**
  * Resolve the path to a deploy/verify script.
  */
 function scriptPath(

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -12,7 +12,7 @@
 //   - Release advisory lock, print summary
 
 import { resolve, join } from "node:path";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import type { ParsedArgs } from "../cli";
 import { loadConfig } from "../config/index";
 import { parsePlan } from "../plan/parser";
@@ -394,12 +394,9 @@ export async function runRevert(
 
       verbose(`Reverting: ${change.name}`);
 
-      // Read revert script to verify it exists
-      try {
-        readFileSync(change.revertScriptPath, "utf-8");
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        logError(`Failed to read revert script for '${change.name}': ${msg}`);
+      // Verify revert script exists before executing
+      if (!existsSync(change.revertScriptPath)) {
+        logError(`Revert script not found for '${change.name}': ${change.revertScriptPath}`);
         const failInput = buildRevertInput(change.deployed, change.planChange);
         await safeRecordFail(registry, failInput, change.name);
         failCount++;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -16,8 +16,6 @@ import type { Change as RegistryChange } from "../db/registry";
 import { info, json as jsonOut } from "../output";
 import type { ParsedArgs } from "../cli";
 import { resolveTargetUri, withDatabase } from "./shared";
-// Re-exported from shared for backward compatibility (tests import from status).
-export { resolveTargetUri };
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,7 +10,7 @@
 //
 // The merged config is the single source of truth for all commands.
 
-import { existsSync, readFileSync } from "fs";
+import { readFileSync } from "fs";
 import { join, resolve } from "path";
 import { homedir } from "os";
 import {
@@ -291,7 +291,6 @@ function loadSqleverToml(projectDir: string): SqleverToml | null {
  */
 function readFileSafe(path: string): string | null {
   try {
-    if (!existsSync(path)) return null;
     return readFileSync(path, "utf-8");
   } catch {
     return null;

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -12,7 +12,7 @@
 
 import Client from "pg/lib/client";
 import { parseUri, sqitchToStandard } from "./uri";
-import { error as logError, verbose as logVerbose, maskUri } from "../output";
+import { verbose as logVerbose, maskUri } from "../output";
 
 /** Exit code for database-unreachable errors (SPEC R6). */
 export const EXIT_CODE_DB_UNREACHABLE = 10;
@@ -84,7 +84,7 @@ export class DatabaseClient {
   /**
    * Connect to the database. Applies session settings after connecting.
    *
-   * On connection failure, logs a clear error and exits with code 10.
+   * @throws Error on connection failure (caller should handle exit codes)
    */
   async connect(): Promise<void> {
     const maskedUri = maskUri(this.uri);
@@ -95,9 +95,7 @@ export class DatabaseClient {
       this.connected = true;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      logError(`Database unreachable: ${message}`);
-      logError(`Connection URI: ${maskedUri}`);
-      process.exit(EXIT_CODE_DB_UNREACHABLE);
+      throw new Error(`Database unreachable: ${message} (URI: ${maskedUri})`);
     }
 
     await this.setSessionSettings();

--- a/src/expand-contract/generator.ts
+++ b/src/expand-contract/generator.ts
@@ -26,7 +26,7 @@ import {
   type AddOptions,
 } from "../commands/add";
 import type { MergedConfig } from "../config/index";
-import { info, error, verbose } from "../output";
+import { info, verbose } from "../output";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -767,10 +767,5 @@ export async function runExpandAdd(
   const { loadConfig } = await import("../config/index");
   const cfg = config ?? loadConfig(opts.topDir, undefined, environment);
 
-  try {
-    await generateExpandContract(opts, cfg, environment);
-  } catch (err) {
-    error(`Error: ${err instanceof Error ? err.message : String(err)}`);
-    process.exit(1);
-  }
+  await generateExpandContract(opts, cfg, environment);
 }

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -201,50 +201,29 @@ describe("DatabaseClient", () => {
       expect(unsafeSetQuery).toBeUndefined();
     });
 
-    it("exits with code 10 on connection failure", async () => {
-      const exitSpy = spyOn(process, "exit").mockImplementation(
-        (_code?: number) => {
-          throw new Error(`process.exit(${_code})`);
-        },
-      );
-      const stderr = captureStderr();
+    it("throws on connection failure with descriptive message", async () => {
+      const client = new DatabaseClient("postgresql://user:pass@host/db");
+      const pgClient = mockInstances[0]!;
+      pgClient.connectShouldFail = true;
+      pgClient.connectError = new Error("ECONNREFUSED");
 
-      try {
-        const client = new DatabaseClient("postgresql://user:pass@host/db");
-        const pgClient = mockInstances[0]!;
-        pgClient.connectShouldFail = true;
-        pgClient.connectError = new Error("ECONNREFUSED");
-
-        await expect(client.connect()).rejects.toThrow("process.exit(10)");
-        expect(exitSpy).toHaveBeenCalledWith(EXIT_CODE_DB_UNREACHABLE);
-      } finally {
-        exitSpy.mockRestore();
-        stderr.restore();
-      }
+      await expect(client.connect()).rejects.toThrow("Database unreachable: ECONNREFUSED");
     });
 
     it("does not log password on connection failure", async () => {
-      const exitSpy = spyOn(process, "exit").mockImplementation(
-        (_code?: number) => {
-          throw new Error(`process.exit(${_code})`);
-        },
+      const client = new DatabaseClient(
+        "postgresql://admin:supersecret@host/db",
       );
-      setConfig({ verbose: true });
-      const stderr = captureStderr();
+      const pgClient = mockInstances[0]!;
+      pgClient.connectShouldFail = true;
 
       try {
-        const client = new DatabaseClient(
-          "postgresql://admin:supersecret@host/db",
-        );
-        const pgClient = mockInstances[0]!;
-        pgClient.connectShouldFail = true;
-
-        await expect(client.connect()).rejects.toThrow("process.exit");
-        expect(stderr.output).not.toContain("supersecret");
-        expect(stderr.output).toContain("***");
-      } finally {
-        exitSpy.mockRestore();
-        stderr.restore();
+        await client.connect();
+        throw new Error("should have thrown");
+      } catch (err) {
+        const message = (err as Error).message;
+        expect(message).not.toContain("supersecret");
+        expect(message).toContain("***");
       }
     });
   });

--- a/tests/unit/deploy-failures.test.ts
+++ b/tests/unit/deploy-failures.test.ts
@@ -84,7 +84,6 @@ const {
   parseDeployOptions,
   projectLockKey,
   isAutoCommit,
-  isNonTransactional,
   ADVISORY_LOCK_NAMESPACE,
   EXIT_CONCURRENT_DEPLOY,
   EXIT_DEPLOY_FAILED,
@@ -451,13 +450,9 @@ describe("deploy failure recovery", () => {
       expect(EXIT_DB_UNREACHABLE).toBe(10);
     });
 
-    it("connect() calls process.exit(10) when DB is unreachable", async () => {
-      // The DatabaseClient.connect() method calls process.exit(10) directly.
-      // We verify the constant is correct and that runDeploy uses
-      // the DatabaseClient which has this behavior.
-      // Direct integration test of the exit path requires mocking process.exit,
-      // which the existing test infrastructure doesn't do. Instead, we verify
-      // the contract: EXIT_DB_UNREACHABLE = 10 and DatabaseClient uses it.
+    it("connect() throws when DB is unreachable", async () => {
+      // DatabaseClient.connect() throws an error on connection failure.
+      // The caller is responsible for handling the exit code.
       const { EXIT_CODE_DB_UNREACHABLE } = await import("../../src/db/client");
       expect(EXIT_CODE_DB_UNREACHABLE).toBe(10);
     });

--- a/tests/unit/deploy-revert-robustness.test.ts
+++ b/tests/unit/deploy-revert-robustness.test.ts
@@ -83,7 +83,6 @@ const {
   runDeploy,
   projectLockKey,
   isAutoCommit,
-  isNonTransactional,
   parseDeployOptions,
   ADVISORY_LOCK_NAMESPACE,
   EXIT_CONCURRENT_DEPLOY,

--- a/tests/unit/deploy.test.ts
+++ b/tests/unit/deploy.test.ts
@@ -77,7 +77,6 @@ const {
   runDeploy,
   projectLockKey,
   isAutoCommit,
-  isNonTransactional,
   parseDeployOptions,
   buildScriptNameMap,
   ADVISORY_LOCK_NAMESPACE,
@@ -299,11 +298,6 @@ describe("deploy", () => {
 
     it("supports legacy no-transaction directive for backward compat", () => {
       expect(isAutoCommit("-- sqlever:no-transaction\nCREATE INDEX CONCURRENTLY ...")).toBe(true);
-    });
-
-    it("isNonTransactional alias works (backward compat)", () => {
-      expect(isNonTransactional("-- sqlever:auto-commit\nSELECT 1")).toBe(true);
-      expect(isNonTransactional("-- sqlever:no-transaction\nSELECT 1")).toBe(true);
     });
   });
 

--- a/tests/unit/e2e-deep.test.ts
+++ b/tests/unit/e2e-deep.test.ts
@@ -158,7 +158,6 @@ const {
   executeDeploy,
   projectLockKey,
   isAutoCommit,
-  isNonTransactional,
   ADVISORY_LOCK_NAMESPACE,
   EXIT_CONCURRENT_DEPLOY,
   EXIT_DEPLOY_FAILED,

--- a/tests/unit/revert.test.ts
+++ b/tests/unit/revert.test.ts
@@ -51,7 +51,7 @@ const {
 } = await import("../../src/commands/revert");
 const { resolveTargetUri } = await import("../../src/commands/shared");
 const { parseArgs } = await import("../../src/cli");
-const { isAutoCommit, isNonTransactional } = await import("../../src/commands/deploy");
+const { isAutoCommit } = await import("../../src/commands/deploy");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -571,7 +571,6 @@ describe("revert command", () => {
     it("a revert script with legacy -- sqlever:no-transaction should NOT use --single-transaction", () => {
       const scriptContent = "-- sqlever:no-transaction\nDROP INDEX CONCURRENTLY IF EXISTS idx_foo;\n";
       expect(isAutoCommit(scriptContent)).toBe(true);
-      expect(isNonTransactional(scriptContent)).toBe(true);
     });
 
     it("a normal revert script should NOT use --single-transaction (matching Sqitch)", () => {

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -6,10 +6,10 @@ import { createHash } from "node:crypto";
 import {
   computeStatus,
   formatStatusText,
-  resolveTargetUri,
   parseStatusOptions,
   type StatusResult,
 } from "../../src/commands/status";
+import { resolveTargetUri } from "../../src/commands/shared";
 import type { Plan } from "../../src/plan/types";
 import type { Change as RegistryChange } from "../../src/db/registry";
 import type { MergedConfig } from "../../src/config/index";


### PR DESCRIPTION
## Summary

- Replace `process.exit(10)` in `DatabaseClient.connect()` with `throw` -- the caller (`main()`'s global try/catch) handles exit codes
- Replace `process.exit(1)` in `runExpandAdd()` with propagated throw
- Replace throwaway `readFileSync` in `revert.ts` with `existsSync` check
- Remove deprecated `isNonTransactional` alias from `deploy.ts` and update all tests
- Remove re-export of `resolveTargetUri` from `status.ts` -- tests now import from `shared.ts`
- Remove TOCTOU `existsSync` + `readFileSync` in `config/index.ts` `readFileSafe()` -- just try/catch
- Rename `n`/`nd` to `astNode`/`exprNode` in SA002/SA002b for clarity

Closes #158

## Test plan

- [x] All 2636 unit tests pass (`bun test tests/unit/`)
- [x] No new type errors in `src/` (`bun x tsc --noEmit`)
- [ ] CI green on all PG versions

Generated with [Claude Code](https://claude.com/claude-code)