### PR TITLE
refactor(analysis): deduplicate rules -- shared AST helpers

### DIFF
--- a/src/analysis/ast-helpers.ts
+++ b/src/analysis/ast-helpers.ts
@@ -1,0 +1,154 @@
+// src/analysis/ast-helpers.ts — Shared AST helpers for analysis rules
+//
+// Centralizes repeated patterns: volatile function detection,
+// ALTER TABLE command iteration, and DropStmt name extraction.
+
+import type { StringNode } from "./types.js";
+import { node, nodes } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Volatile functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Known volatile functions that cause table rewrites on all PG versions.
+ * Checked case-insensitively via lowercase lookup.
+ */
+export const VOLATILE_FUNCTIONS: ReadonlySet<string> = new Set([
+  "random",
+  "gen_random_uuid",
+  "clock_timestamp",
+  "txid_current",
+  "timeofday",
+  "uuid_generate_v1",
+  "uuid_generate_v1mc",
+  "uuid_generate_v4",
+  "statement_timestamp",
+  "setseed",
+  "nextval",
+  "currval",
+  "lastval",
+]);
+
+/**
+ * Recursively check if an AST expression node contains a volatile function call.
+ * Returns the volatile function name (lowercase) if found, or null.
+ */
+export function containsVolatileFunction(n: unknown): string | null {
+  if (!n || typeof n !== "object") return null;
+  const nd = node(n);
+
+  // Direct function call
+  if (nd.FuncCall) {
+    const funcNode = node(nd.FuncCall);
+    const funcNames = nodes(funcNode.funcname);
+    for (const fn of funcNames) {
+      const name = node(fn).String as Record<string, unknown> | undefined;
+      const sval = name ? String(node(name).sval ?? "").toLowerCase() : "";
+      if (sval && VOLATILE_FUNCTIONS.has(sval)) {
+        return sval;
+      }
+    }
+    // Check function arguments recursively
+    for (const arg of nodes(funcNode.args)) {
+      const result = containsVolatileFunction(arg);
+      if (result) return result;
+    }
+    return null;
+  }
+
+  // TypeCast wrapping a volatile function (e.g. random()::int)
+  if (nd.TypeCast) {
+    return containsVolatileFunction(node(nd.TypeCast).arg);
+  }
+
+  // Check nested expressions
+  if (nd.A_Expr) {
+    const expr = node(nd.A_Expr);
+    const left = containsVolatileFunction(expr.lexpr);
+    if (left) return left;
+    return containsVolatileFunction(expr.rexpr);
+  }
+
+  // CoalesceExpr
+  if (nd.CoalesceExpr) {
+    for (const arg of nodes(node(nd.CoalesceExpr).args)) {
+      const result = containsVolatileFunction(arg);
+      if (result) return result;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// ALTER TABLE iteration
+// ---------------------------------------------------------------------------
+
+/** Callback signature for forEachAlterTableCmd. */
+export interface AlterTableCmdContext {
+  /** The AlterTableCmd node (already unwrapped via node()). */
+  cmd: Record<string, unknown>;
+  /** The AlterTableStmt node (already unwrapped via node()). */
+  alterStmt: Record<string, unknown>;
+  /** The parent StmtEntry for location extraction. */
+  stmtLocation: number;
+}
+
+/**
+ * Iterate over ALTER TABLE ... commands in a parsed AST.
+ *
+ * Handles the boilerplate of: checking for AlterTableStmt, filtering
+ * OBJECT_TABLE, iterating cmds, and guarding the AlterTableCmd null check.
+ */
+export function forEachAlterTableCmd(
+  ast: { stmts?: { stmt: Record<string, unknown>; stmt_location?: number }[] },
+  callback: (ctx: AlterTableCmdContext) => void,
+): void {
+  if (!ast?.stmts) return;
+
+  for (const stmtEntry of ast.stmts) {
+    const stmt = stmtEntry.stmt;
+    if (!stmt?.AlterTableStmt) continue;
+
+    const alterStmt = node(stmt.AlterTableStmt);
+    if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+
+    for (const cmdEntry of nodes(alterStmt.cmds)) {
+      if (!cmdEntry.AlterTableCmd) continue;
+      const cmd = node(cmdEntry.AlterTableCmd);
+
+      callback({
+        cmd,
+        alterStmt,
+        stmtLocation: stmtEntry.stmt_location ?? 0,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DropStmt name extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract qualified object names from a DropStmt's objects list.
+ *
+ * DropStmt stores names as List nodes containing String nodes.
+ * Returns an array of dot-joined qualified names (e.g. ["public.my_index"]).
+ */
+export function extractDropObjectNames(
+  dropStmt: Record<string, unknown>,
+): string[] {
+  const names: string[] = [];
+  for (const obj of nodes(dropStmt.objects)) {
+    const list = node(obj).List;
+    if (list) {
+      const parts = nodes<StringNode>(node(list).items)
+        .map((item) => item?.String?.sval)
+        .filter(Boolean);
+      names.push(parts.join("."));
+    }
+  }
+  return names;
+}

--- a/src/analysis/rules/SA001.ts
+++ b/src/analysis/rules/SA001.ts
@@ -8,11 +8,12 @@
  * This fails outright on populated tables because existing rows would have NULL
  * for the new column, violating the NOT NULL constraint.
  *
- * Does NOT fire when a DEFAULT is present — that case is covered by SA002/SA002b.
+ * Does NOT fire when a DEFAULT is present -- that case is covered by SA002/SA002b.
  */
 
 import type { Rule, Finding, AnalysisContext } from "../types.js";
 import { offsetToLocation, node, nodes } from "../types.js";
+import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA001: Rule = {
   id: "SA001",
@@ -23,54 +24,39 @@ export const SA001: Rule = {
     const findings: Finding[] = [];
     const { ast, rawSql, filePath } = context;
 
-    if (!ast?.stmts) return findings;
+    forEachAlterTableCmd(ast, ({ cmd, alterStmt, stmtLocation }) => {
+      if (cmd.subtype !== "AT_AddColumn") return;
 
-    for (const stmtEntry of ast.stmts) {
-      const stmt = stmtEntry.stmt;
-      if (!stmt?.AlterTableStmt) continue;
+      const colDef = node(cmd.def).ColumnDef;
+      if (!colDef) return;
+      const colDefNode = node(colDef);
 
-      const alterStmt = node(stmt.AlterTableStmt);
-      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+      const constraints = nodes(colDefNode.constraints);
+      let hasNotNull = false;
+      let hasDefault = false;
 
-      for (const cmdEntry of nodes(alterStmt.cmds)) {
-        const cmd = node(cmdEntry.AlterTableCmd);
-        if (!cmdEntry.AlterTableCmd || cmd.subtype !== "AT_AddColumn") continue;
-
-        const colDef = node(cmd.def).ColumnDef;
-        if (!colDef) continue;
-        const colDefNode = node(colDef);
-
-        const constraints = nodes(colDefNode.constraints);
-        let hasNotNull = false;
-        let hasDefault = false;
-
-        for (const c of constraints) {
-          const constraint = node(c.Constraint);
-          if (!c.Constraint) continue;
-          if (constraint.contype === "CONSTR_NOTNULL") hasNotNull = true;
-          if (constraint.contype === "CONSTR_DEFAULT") hasDefault = true;
-        }
-
-        if (hasNotNull && !hasDefault) {
-          const location = offsetToLocation(
-            rawSql,
-            stmtEntry.stmt_location ?? 0,
-            filePath,
-          );
-          const tableName = node(alterStmt.relation).relname ?? "unknown";
-          const colName = colDefNode.colname ?? "unknown";
-
-          findings.push({
-            ruleId: "SA001",
-            severity: "error",
-            message: `Adding NOT NULL column "${colName}" to table "${tableName}" without a DEFAULT will fail on populated tables.`,
-            location,
-            suggestion:
-              "Add a DEFAULT value, or add the column as nullable first, backfill, then set NOT NULL.",
-          });
-        }
+      for (const c of constraints) {
+        if (!c.Constraint) continue;
+        const constraint = node(c.Constraint);
+        if (constraint.contype === "CONSTR_NOTNULL") hasNotNull = true;
+        if (constraint.contype === "CONSTR_DEFAULT") hasDefault = true;
       }
-    }
+
+      if (hasNotNull && !hasDefault) {
+        const location = offsetToLocation(rawSql, stmtLocation, filePath);
+        const tableName = node(alterStmt.relation).relname ?? "unknown";
+        const colName = colDefNode.colname ?? "unknown";
+
+        findings.push({
+          ruleId: "SA001",
+          severity: "error",
+          message: `Adding NOT NULL column "${colName}" to table "${tableName}" without a DEFAULT will fail on populated tables.`,
+          location,
+          suggestion:
+            "Add a DEFAULT value, or add the column as nullable first, backfill, then set NOT NULL.",
+        });
+      }
+    });
 
     return findings;
   },

--- a/src/analysis/rules/SA002.ts
+++ b/src/analysis/rules/SA002.ts
@@ -16,76 +16,7 @@
 
 import type { Rule, Finding, AnalysisContext } from "../types.js";
 import { offsetToLocation, node, nodes } from "../types.js";
-
-/**
- * Known volatile functions that cause table rewrites on all PG versions.
- * These are checked case-insensitively.
- */
-const VOLATILE_FUNCTIONS: ReadonlySet<string> = new Set([
-  "random",
-  "gen_random_uuid",
-  "clock_timestamp",
-  "txid_current",
-  "timeofday",
-  "uuid_generate_v1",
-  "uuid_generate_v1mc",
-  "uuid_generate_v4",
-  "statement_timestamp",
-  "setseed",
-  "nextval",
-  "currval",
-  "lastval",
-]);
-
-/**
- * Recursively check if an AST expression node contains a volatile function call.
- */
-function containsVolatileFunction(astNode: unknown): string | null {
-  if (!astNode || typeof astNode !== "object") return null;
-  const exprNode = node(astNode);
-
-  // Direct function call
-  if (exprNode.FuncCall) {
-    const funcNode = node(exprNode.FuncCall);
-    const funcNames = nodes(funcNode.funcname);
-    for (const fn of funcNames) {
-      const name = (node(fn).String as Record<string, unknown> | undefined);
-      const sval = name ? String(node(name).sval ?? "").toLowerCase() : "";
-      if (sval && VOLATILE_FUNCTIONS.has(sval)) {
-        return sval;
-      }
-    }
-    // Check function arguments recursively
-    for (const arg of nodes(funcNode.args)) {
-      const result = containsVolatileFunction(arg);
-      if (result) return result;
-    }
-    return null;
-  }
-
-  // TypeCast wrapping a volatile function (e.g. random()::int)
-  if (exprNode.TypeCast) {
-    return containsVolatileFunction(node(exprNode.TypeCast).arg);
-  }
-
-  // Check nested expressions
-  if (exprNode.A_Expr) {
-    const expr = node(exprNode.A_Expr);
-    const left = containsVolatileFunction(expr.lexpr);
-    if (left) return left;
-    return containsVolatileFunction(expr.rexpr);
-  }
-
-  // CoalesceExpr
-  if (exprNode.CoalesceExpr) {
-    for (const arg of nodes(node(exprNode.CoalesceExpr).args)) {
-      const result = containsVolatileFunction(arg);
-      if (result) return result;
-    }
-  }
-
-  return null;
-}
+import { containsVolatileFunction, forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA002: Rule = {
   id: "SA002",
@@ -96,52 +27,38 @@ export const SA002: Rule = {
     const findings: Finding[] = [];
     const { ast, rawSql, filePath } = context;
 
-    if (!ast?.stmts) return findings;
+    forEachAlterTableCmd(ast, ({ cmd, alterStmt, stmtLocation }) => {
+      if (cmd.subtype !== "AT_AddColumn") return;
 
-    for (const stmtEntry of ast.stmts) {
-      const stmt = stmtEntry.stmt;
-      if (!stmt?.AlterTableStmt) continue;
+      const colDef = node(cmd.def).ColumnDef;
+      if (!colDef) return;
+      const colDefNode = node(colDef);
 
-      const alterStmt = node(stmt.AlterTableStmt);
-      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+      for (const c of nodes(colDefNode.constraints)) {
+        if (!c.Constraint) continue;
+        const constraint = node(c.Constraint);
+        if (constraint.contype !== "CONSTR_DEFAULT") continue;
 
-      for (const cmdEntry of nodes(alterStmt.cmds)) {
-        const cmd = node(cmdEntry.AlterTableCmd);
-        if (!cmdEntry.AlterTableCmd || cmd.subtype !== "AT_AddColumn") continue;
+        const rawExpr = constraint.raw_expr;
+        if (!rawExpr) continue;
 
-        const colDef = node(cmd.def).ColumnDef;
-        if (!colDef) continue;
-        const colDefNode = node(colDef);
+        const volatileFunc = containsVolatileFunction(rawExpr);
+        if (volatileFunc) {
+          const location = offsetToLocation(rawSql, stmtLocation, filePath);
+          const tableName = node(alterStmt.relation).relname ?? "unknown";
+          const colName = colDefNode.colname ?? "unknown";
 
-        for (const c of nodes(colDefNode.constraints)) {
-          const constraint = node(c.Constraint);
-          if (!c.Constraint || constraint.contype !== "CONSTR_DEFAULT") continue;
-
-          const rawExpr = constraint.raw_expr;
-          if (!rawExpr) continue;
-
-          const volatileFunc = containsVolatileFunction(rawExpr);
-          if (volatileFunc) {
-            const location = offsetToLocation(
-              rawSql,
-              stmtEntry.stmt_location ?? 0,
-              filePath,
-            );
-            const tableName = node(alterStmt.relation).relname ?? "unknown";
-            const colName = colDefNode.colname ?? "unknown";
-
-            findings.push({
-              ruleId: "SA002",
-              severity: "error",
-              message: `Adding column "${colName}" to table "${tableName}" with volatile default ${volatileFunc}() causes a full table rewrite on all PostgreSQL versions.`,
-              location,
-              suggestion:
-                "Add the column without a default, then backfill in batches using UPDATE.",
-            });
-          }
+          findings.push({
+            ruleId: "SA002",
+            severity: "error",
+            message: `Adding column "${colName}" to table "${tableName}" with volatile default ${volatileFunc}() causes a full table rewrite on all PostgreSQL versions.`,
+            location,
+            suggestion:
+              "Add the column without a default, then backfill in batches using UPDATE.",
+          });
         }
       }
-    }
+    });
 
     return findings;
   },

--- a/src/analysis/rules/SA002b.ts
+++ b/src/analysis/rules/SA002b.ts
@@ -14,68 +14,7 @@
 
 import type { Rule, Finding, AnalysisContext } from "../types.js";
 import { offsetToLocation, node, nodes } from "../types.js";
-
-// Import volatile function set from SA002 to reuse the detection logic
-const VOLATILE_FUNCTIONS: ReadonlySet<string> = new Set([
-  "random",
-  "gen_random_uuid",
-  "clock_timestamp",
-  "txid_current",
-  "timeofday",
-  "uuid_generate_v1",
-  "uuid_generate_v1mc",
-  "uuid_generate_v4",
-  "statement_timestamp",
-  "setseed",
-  "nextval",
-  "currval",
-  "lastval",
-]);
-
-/**
- * Check if an expression contains a volatile function call.
- * Returns true if ANY function in the expression is volatile.
- */
-function containsVolatileFunction(astNode: unknown): boolean {
-  if (!astNode || typeof astNode !== "object") return false;
-  const exprNode = node(astNode);
-
-  if (exprNode.FuncCall) {
-    const funcNode = node(exprNode.FuncCall);
-    for (const fn of nodes(funcNode.funcname)) {
-      const name = (node(fn).String as Record<string, unknown> | undefined);
-      const sval = name ? String(node(name).sval ?? "").toLowerCase() : "";
-      if (sval && VOLATILE_FUNCTIONS.has(sval)) {
-        return true;
-      }
-    }
-    // Check function arguments
-    for (const arg of nodes(funcNode.args)) {
-      if (containsVolatileFunction(arg)) return true;
-    }
-    return false;
-  }
-
-  if (exprNode.TypeCast) {
-    return containsVolatileFunction(node(exprNode.TypeCast).arg);
-  }
-
-  if (exprNode.A_Expr) {
-    const expr = node(exprNode.A_Expr);
-    return (
-      containsVolatileFunction(expr.lexpr) ||
-      containsVolatileFunction(expr.rexpr)
-    );
-  }
-
-  if (exprNode.CoalesceExpr) {
-    for (const arg of nodes(node(exprNode.CoalesceExpr).args)) {
-      if (containsVolatileFunction(arg)) return true;
-    }
-  }
-
-  return false;
-}
+import { containsVolatileFunction, forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA002b: Rule = {
   id: "SA002b",
@@ -89,52 +28,38 @@ export const SA002b: Rule = {
     // Only fires when targeting PG < 11
     if (pgVersion >= 11) return findings;
 
-    if (!ast?.stmts) return findings;
+    forEachAlterTableCmd(ast, ({ cmd, alterStmt, stmtLocation }) => {
+      if (cmd.subtype !== "AT_AddColumn") return;
 
-    for (const stmtEntry of ast.stmts) {
-      const stmt = stmtEntry.stmt;
-      if (!stmt?.AlterTableStmt) continue;
+      const colDef = node(cmd.def).ColumnDef;
+      if (!colDef) return;
+      const colDefNode = node(colDef);
 
-      const alterStmt = node(stmt.AlterTableStmt);
-      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+      for (const c of nodes(colDefNode.constraints)) {
+        if (!c.Constraint) continue;
+        const constraint = node(c.Constraint);
+        if (constraint.contype !== "CONSTR_DEFAULT") continue;
 
-      for (const cmdEntry of nodes(alterStmt.cmds)) {
-        const cmd = node(cmdEntry.AlterTableCmd);
-        if (!cmdEntry.AlterTableCmd || cmd.subtype !== "AT_AddColumn") continue;
+        const rawExpr = constraint.raw_expr;
 
-        const colDef = node(cmd.def).ColumnDef;
-        if (!colDef) continue;
-        const colDefNode = node(colDef);
+        // Skip volatile defaults -- those are handled by SA002
+        if (rawExpr && containsVolatileFunction(rawExpr)) continue;
 
-        for (const c of nodes(colDefNode.constraints)) {
-          const constraint = node(c.Constraint);
-          if (!c.Constraint || constraint.contype !== "CONSTR_DEFAULT") continue;
+        // This is a non-volatile default on PG < 11
+        const location = offsetToLocation(rawSql, stmtLocation, filePath);
+        const tableName = node(alterStmt.relation).relname ?? "unknown";
+        const colName = colDefNode.colname ?? "unknown";
 
-          const rawExpr = constraint.raw_expr;
-
-          // Skip volatile defaults — those are handled by SA002
-          if (rawExpr && containsVolatileFunction(rawExpr)) continue;
-
-          // This is a non-volatile default on PG < 11
-          const location = offsetToLocation(
-            rawSql,
-            stmtEntry.stmt_location ?? 0,
-            filePath,
-          );
-          const tableName = node(alterStmt.relation).relname ?? "unknown";
-          const colName = colDefNode.colname ?? "unknown";
-
-          findings.push({
-            ruleId: "SA002b",
-            severity: "warn",
-            message: `Adding column "${colName}" to table "${tableName}" with a default causes a full table rewrite on PostgreSQL < 11 (target version: ${pgVersion}).`,
-            location,
-            suggestion:
-              "Upgrade to PostgreSQL 11+ where non-volatile defaults are metadata-only, or add the column without a default and backfill.",
-          });
-        }
+        findings.push({
+          ruleId: "SA002b",
+          severity: "warn",
+          message: `Adding column "${colName}" to table "${tableName}" with a default causes a full table rewrite on PostgreSQL < 11 (target version: ${pgVersion}).`,
+          location,
+          suggestion:
+            "Upgrade to PostgreSQL 11+ where non-volatile defaults are metadata-only, or add the column without a default and backfill.",
+        });
       }
-    }
+    });
 
     return findings;
   },

--- a/src/analysis/rules/SA003.ts
+++ b/src/analysis/rules/SA003.ts
@@ -9,7 +9,7 @@
  * known to be binary-compatible (no rewrite needed).
  *
  * When a USING clause is present, SA003 ALWAYS fires regardless of the safe
- * cast allowlist — PostgreSQL rewrites the table to evaluate the expression.
+ * cast allowlist -- PostgreSQL rewrites the table to evaluate the expression.
  *
  * Safe cast allowlist:
  * - varchar(N) to varchar(M) where M > N (widening)
@@ -21,13 +21,14 @@
  */
 
 import type { Rule, Finding, AnalysisContext, TypeName } from "../types.js";
-import { offsetToLocation, displayTypeName, node, nodes } from "../types.js";
+import { offsetToLocation, displayTypeName, node } from "../types.js";
+import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 /**
  * Check if a type change is in the safe cast allowlist.
  * Returns true if the cast is safe (no table rewrite).
  *
- * Note: This function does NOT know the source type from the AST alone —
+ * Note: This function does NOT know the source type from the AST alone --
  * ALTER COLUMN TYPE only specifies the target type. We check if the target
  * type is in a family known to have safe widening casts. Without a DB
  * connection, we can only check the target type; the actual safety depends
@@ -54,65 +55,46 @@ export const SA003: Rule = {
     const findings: Finding[] = [];
     const { ast, rawSql, filePath } = context;
 
-    if (!ast?.stmts) return findings;
+    forEachAlterTableCmd(ast, ({ cmd, alterStmt, stmtLocation }) => {
+      if (cmd.subtype !== "AT_AlterColumnType") return;
 
-    for (const stmtEntry of ast.stmts) {
-      const stmt = stmtEntry.stmt;
-      if (!stmt?.AlterTableStmt) continue;
+      const colDef = node(cmd.def).ColumnDef;
+      if (!colDef) return;
+      const colDefNode = node(colDef);
 
-      const alterStmt = node(stmt.AlterTableStmt);
-      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+      const hasUsing = !!colDefNode.raw_default;
+      const targetType = colDefNode.typeName;
+      const targetTypeDisplay = displayTypeName(targetType as TypeName | undefined);
+      const colName = cmd.name ?? "unknown";
+      const tableName = node(alterStmt.relation).relname ?? "unknown";
 
-      for (const cmdEntry of nodes(alterStmt.cmds)) {
-        const cmd = node(cmdEntry.AlterTableCmd);
-        if (!cmdEntry.AlterTableCmd || cmd.subtype !== "AT_AlterColumnType") continue;
-
-        const colDef = node(cmd.def).ColumnDef;
-        if (!colDef) continue;
-        const colDefNode = node(colDef);
-
-        const hasUsing = !!colDefNode.raw_default;
-        const targetType = colDefNode.typeName;
-        const targetTypeDisplay = displayTypeName(targetType as TypeName | undefined);
-        const colName = cmd.name ?? "unknown";
-        const tableName = node(alterStmt.relation).relname ?? "unknown";
-
-        // USING clause always triggers — PG rewrites to evaluate the expression
-        if (hasUsing) {
-          const location = offsetToLocation(
-            rawSql,
-            stmtEntry.stmt_location ?? 0,
-            filePath,
-          );
-          findings.push({
-            ruleId: "SA003",
-            severity: "error",
-            message: `Changing type of column "${colName}" on table "${tableName}" to ${targetTypeDisplay} with USING clause causes a full table rewrite with AccessExclusiveLock.`,
-            location,
-            suggestion:
-              "Consider the expand/contract pattern: add a new column, backfill in batches, then swap.",
-          });
-          continue;
-        }
-
-        // Check safe cast allowlist (static mode: conservative)
-        if (!isSafeCast(targetType as TypeName | undefined)) {
-          const location = offsetToLocation(
-            rawSql,
-            stmtEntry.stmt_location ?? 0,
-            filePath,
-          );
-          findings.push({
-            ruleId: "SA003",
-            severity: "error",
-            message: `Changing type of column "${colName}" on table "${tableName}" to ${targetTypeDisplay} may cause a full table rewrite with AccessExclusiveLock.`,
-            location,
-            suggestion:
-              "Consider the expand/contract pattern: add a new column with the new type, backfill in batches, then swap. Safe casts (varchar widening, numeric precision widening) can be suppressed with -- sqlever:disable SA003.",
-          });
-        }
+      // USING clause always triggers -- PG rewrites to evaluate the expression
+      if (hasUsing) {
+        const location = offsetToLocation(rawSql, stmtLocation, filePath);
+        findings.push({
+          ruleId: "SA003",
+          severity: "error",
+          message: `Changing type of column "${colName}" on table "${tableName}" to ${targetTypeDisplay} with USING clause causes a full table rewrite with AccessExclusiveLock.`,
+          location,
+          suggestion:
+            "Consider the expand/contract pattern: add a new column, backfill in batches, then swap.",
+        });
+        return;
       }
-    }
+
+      // Check safe cast allowlist (static mode: conservative)
+      if (!isSafeCast(targetType as TypeName | undefined)) {
+        const location = offsetToLocation(rawSql, stmtLocation, filePath);
+        findings.push({
+          ruleId: "SA003",
+          severity: "error",
+          message: `Changing type of column "${colName}" on table "${tableName}" to ${targetTypeDisplay} may cause a full table rewrite with AccessExclusiveLock.`,
+          location,
+          suggestion:
+            "Consider the expand/contract pattern: add a new column with the new type, backfill in batches, then swap. Safe casts (varchar widening, numeric precision widening) can be suppressed with -- sqlever:disable SA003.",
+        });
+      }
+    });
 
     return findings;
   },

--- a/src/analysis/rules/SA005.ts
+++ b/src/analysis/rules/SA005.ts
@@ -8,8 +8,9 @@
  * Without CONCURRENTLY, DROP INDEX takes an AccessExclusiveLock on the table.
  */
 
-import type { Rule, Finding, AnalysisContext, StringNode } from "../types.js";
-import { offsetToLocation, node, nodes } from "../types.js";
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation, node } from "../types.js";
+import { extractDropObjectNames } from "../ast-helpers.js";
 
 export const SA005: Rule = {
   id: "SA005",
@@ -40,18 +41,7 @@ export const SA005: Rule = {
         filePath,
       );
 
-      // Extract index name(s) from the objects list
-      const indexNames: string[] = [];
-      for (const obj of nodes(dropStmt.objects)) {
-        const list = node(obj).List;
-        if (list) {
-          const names = nodes(node(list).items)
-            .map((item) => (item as unknown as StringNode)?.String?.sval)
-            .filter(Boolean);
-          indexNames.push(names.join("."));
-        }
-      }
-
+      const indexNames = extractDropObjectNames(dropStmt);
       const nameStr = indexNames.length > 0 ? indexNames.join(", ") : "unnamed";
 
       findings.push({

--- a/src/analysis/rules/SA006.ts
+++ b/src/analysis/rules/SA006.ts
@@ -11,7 +11,8 @@
  */
 
 import type { Rule, Finding, AnalysisContext } from "../types.js";
-import { offsetToLocation, node, nodes } from "../types.js";
+import { offsetToLocation, node } from "../types.js";
+import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA006: Rule = {
   id: "SA006",
@@ -22,38 +23,22 @@ export const SA006: Rule = {
     const findings: Finding[] = [];
     const { ast, rawSql, filePath } = context;
 
-    if (!ast?.stmts) return findings;
+    forEachAlterTableCmd(ast, ({ cmd, alterStmt, stmtLocation }) => {
+      if (cmd.subtype !== "AT_DropColumn") return;
 
-    for (const stmtEntry of ast.stmts) {
-      const stmt = stmtEntry.stmt;
-      if (!stmt?.AlterTableStmt) continue;
+      const location = offsetToLocation(rawSql, stmtLocation, filePath);
+      const tableName = node(alterStmt.relation).relname ?? "unknown";
+      const colName = cmd.name ?? "unknown";
 
-      const alterStmt = node(stmt.AlterTableStmt);
-      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
-
-      for (const cmdEntry of nodes(alterStmt.cmds)) {
-        const cmd = node(cmdEntry.AlterTableCmd);
-        if (!cmdEntry.AlterTableCmd || cmd.subtype !== "AT_DropColumn") continue;
-
-        const location = offsetToLocation(
-          rawSql,
-          stmtEntry.stmt_location ?? 0,
-          filePath,
-        );
-
-        const tableName = node(alterStmt.relation).relname ?? "unknown";
-        const colName = cmd.name ?? "unknown";
-
-        findings.push({
-          ruleId: "SA006",
-          severity: "warn",
-          message: `Dropping column "${colName}" from table "${tableName}" causes irreversible data loss.`,
-          location,
-          suggestion:
-            "Ensure a backup exists and that no application code depends on this column. Consider a deprecation period before dropping.",
-        });
-      }
-    }
+      findings.push({
+        ruleId: "SA006",
+        severity: "warn",
+        message: `Dropping column "${colName}" from table "${tableName}" causes irreversible data loss.`,
+        location,
+        suggestion:
+          "Ensure a backup exists and that no application code depends on this column. Consider a deprecation period before dropping.",
+      });
+    });
 
     return findings;
   },

--- a/src/analysis/rules/SA007.ts
+++ b/src/analysis/rules/SA007.ts
@@ -10,8 +10,9 @@
  * mode, always fires.
  */
 
-import type { Rule, Finding, AnalysisContext, StringNode } from "../types.js";
-import { offsetToLocation, node, nodes } from "../types.js";
+import type { Rule, Finding, AnalysisContext } from "../types.js";
+import { offsetToLocation, node } from "../types.js";
+import { extractDropObjectNames } from "../ast-helpers.js";
 
 export const SA007: Rule = {
   id: "SA007",
@@ -42,18 +43,7 @@ export const SA007: Rule = {
         filePath,
       );
 
-      // Extract table name(s) from the objects list
-      const tableNames: string[] = [];
-      for (const obj of nodes(dropStmt.objects)) {
-        const list = node(obj).List;
-        if (list) {
-          const names = nodes(node(list).items)
-            .map((item) => (item as unknown as StringNode)?.String?.sval)
-            .filter(Boolean);
-          tableNames.push(names.join("."));
-        }
-      }
-
+      const tableNames = extractDropObjectNames(dropStmt);
       const nameStr =
         tableNames.length > 0 ? tableNames.join(", ") : "unknown";
 

--- a/src/analysis/rules/SA009.ts
+++ b/src/analysis/rules/SA009.ts
@@ -20,6 +20,7 @@
 
 import type { Rule, Finding, AnalysisContext, StringNode } from "../types.js";
 import { offsetToLocation, node, nodes } from "../types.js";
+import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA009: Rule = {
   id: "SA009",
@@ -30,57 +31,42 @@ export const SA009: Rule = {
     const findings: Finding[] = [];
     const { ast, rawSql, filePath } = context;
 
-    if (!ast?.stmts) return findings;
+    forEachAlterTableCmd(ast, ({ cmd, alterStmt, stmtLocation }) => {
+      if (cmd.subtype !== "AT_AddConstraint") return;
 
-    for (const stmtEntry of ast.stmts) {
-      const stmt = stmtEntry.stmt;
-      if (!stmt?.AlterTableStmt) continue;
+      if (!node(cmd.def).Constraint) return;
+      const constraint = node(node(cmd.def).Constraint);
+      if (constraint.contype !== "CONSTR_FOREIGN") return;
 
-      const alterStmt = node(stmt.AlterTableStmt);
-      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+      // Check for NOT VALID: in the AST, skip_validation = true means NOT VALID was used
+      const hasNotValid = constraint.skip_validation === true;
 
-      for (const cmdEntry of nodes(alterStmt.cmds)) {
-        const cmd = node(cmdEntry.AlterTableCmd);
-        if (!cmdEntry.AlterTableCmd || cmd.subtype !== "AT_AddConstraint") continue;
+      if (!hasNotValid) {
+        const location = offsetToLocation(rawSql, stmtLocation, filePath);
+        const tableName = node(alterStmt.relation).relname ?? "unknown";
+        const constraintName = constraint.conname ?? "unnamed";
+        const refTable = node(constraint.pktable).relname ?? "unknown";
 
-        const constraint = node(node(cmd.def).Constraint);
-        if (!node(cmd.def).Constraint || constraint.contype !== "CONSTR_FOREIGN") continue;
+        // Extract FK column names
+        const fkCols = nodes<StringNode>(constraint.fk_attrs)
+          .map((attr) => attr?.String?.sval)
+          .filter(Boolean)
+          .join(", ");
 
-        // Check for NOT VALID: in the AST, skip_validation = true means NOT VALID was used
-        const hasNotValid = constraint.skip_validation === true;
-
-        if (!hasNotValid) {
-          const location = offsetToLocation(
-            rawSql,
-            stmtEntry.stmt_location ?? 0,
-            filePath,
-          );
-
-          const tableName = node(alterStmt.relation).relname ?? "unknown";
-          const constraintName = constraint.conname ?? "unnamed";
-          const refTable = node(constraint.pktable).relname ?? "unknown";
-
-          // Extract FK column names
-          const fkCols = nodes(constraint.fk_attrs)
-            .map((attr) => (attr as unknown as StringNode)?.String?.sval)
-            .filter(Boolean)
-            .join(", ");
-
-          findings.push({
-            ruleId: "SA009",
-            severity: "warn",
-            message: `Adding foreign key "${constraintName}" on ${tableName}(${fkCols}) referencing ${refTable} without NOT VALID takes a ShareRowExclusiveLock and validates all existing rows.`,
-            location,
-            suggestion:
-              "Use ADD CONSTRAINT ... NOT VALID, then VALIDATE CONSTRAINT in a separate statement (takes only ShareUpdateExclusiveLock, does not block writes).",
-          });
-        }
-
-        // Connected check: index on referencing columns
-        // This would run when context.db is available
-        // Left as a stub for the analysis engine integration
+        findings.push({
+          ruleId: "SA009",
+          severity: "warn",
+          message: `Adding foreign key "${constraintName}" on ${tableName}(${fkCols}) referencing ${refTable} without NOT VALID takes a ShareRowExclusiveLock and validates all existing rows.`,
+          location,
+          suggestion:
+            "Use ADD CONSTRAINT ... NOT VALID, then VALIDATE CONSTRAINT in a separate statement (takes only ShareUpdateExclusiveLock, does not block writes).",
+        });
       }
-    }
+
+      // Connected check: index on referencing columns
+      // This would run when context.db is available
+      // Left as a stub for the analysis engine integration
+    });
 
     return findings;
   },

--- a/src/analysis/rules/SA012.ts
+++ b/src/analysis/rules/SA012.ts
@@ -29,7 +29,7 @@ export const SA012: Rule = {
       if (!stmt?.AlterSeqStmt) continue;
 
       const alterSeq = node(stmt.AlterSeqStmt);
-      const options = nodes(alterSeq.options) as unknown as DefElem[];
+      const options = nodes<DefElem>(alterSeq.options);
 
       // Check if any option is "restart"
       const hasRestart = options.some(

--- a/src/analysis/rules/SA013.ts
+++ b/src/analysis/rules/SA013.ts
@@ -74,7 +74,7 @@ function isRiskyDDL(stmt: Record<string, unknown>): { risky: boolean; descriptio
 
   // VACUUM FULL (AccessExclusiveLock)
   if (stmt?.VacuumStmt) {
-    const options = nodes(node(stmt.VacuumStmt).options) as unknown as DefElem[];
+    const options = nodes<DefElem>(node(stmt.VacuumStmt).options);
     const hasFull = options.some(
       (opt) => opt?.DefElem?.defname === "full",
     );
@@ -85,7 +85,7 @@ function isRiskyDDL(stmt: Record<string, unknown>): { risky: boolean; descriptio
 
   // REINDEX without CONCURRENTLY (AccessExclusiveLock)
   if (stmt?.ReindexStmt) {
-    const params = nodes(node(stmt.ReindexStmt).params) as unknown as DefElem[];
+    const params = nodes<DefElem>(node(stmt.ReindexStmt).params);
     const hasConcurrently = params.some(
       (p) => p?.DefElem?.defname === "concurrently",
     );

--- a/src/analysis/rules/SA014.ts
+++ b/src/analysis/rules/SA014.ts
@@ -31,7 +31,7 @@ export const SA014: Rule = {
       // Check VACUUM FULL
       if (stmt?.VacuumStmt) {
         const vacuumStmt = node(stmt.VacuumStmt);
-        const options = nodes(vacuumStmt.options) as unknown as DefElem[];
+        const options = nodes<DefElem>(vacuumStmt.options);
         const hasFull = options.some(
           (opt) => opt?.DefElem?.defname === "full",
         );

--- a/src/analysis/rules/SA016.ts
+++ b/src/analysis/rules/SA016.ts
@@ -14,7 +14,8 @@
  */
 
 import type { Rule, Finding, AnalysisContext } from "../types.js";
-import { offsetToLocation, node, nodes } from "../types.js";
+import { offsetToLocation, node } from "../types.js";
+import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA016: Rule = {
   id: "SA016",
@@ -25,46 +26,31 @@ export const SA016: Rule = {
     const findings: Finding[] = [];
     const { ast, rawSql, filePath } = context;
 
-    if (!ast?.stmts) return findings;
+    forEachAlterTableCmd(ast, ({ cmd, alterStmt, stmtLocation }) => {
+      if (cmd.subtype !== "AT_AddConstraint") return;
 
-    for (const stmtEntry of ast.stmts) {
-      const stmt = stmtEntry.stmt;
-      if (!stmt?.AlterTableStmt) continue;
+      if (!node(cmd.def).Constraint) return;
+      const constraint = node(node(cmd.def).Constraint);
+      if (constraint.contype !== "CONSTR_CHECK") return;
 
-      const alterStmt = node(stmt.AlterTableStmt);
-      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+      // Check for NOT VALID: skip_validation = true means NOT VALID was used
+      const hasNotValid = constraint.skip_validation === true;
 
-      for (const cmdEntry of nodes(alterStmt.cmds)) {
-        const cmd = node(cmdEntry.AlterTableCmd);
-        if (!cmdEntry.AlterTableCmd || cmd.subtype !== "AT_AddConstraint") continue;
+      if (!hasNotValid) {
+        const location = offsetToLocation(rawSql, stmtLocation, filePath);
+        const tableName = node(alterStmt.relation).relname ?? "unknown";
+        const constraintName = constraint.conname ?? "unnamed";
 
-        const constraint = node(node(cmd.def).Constraint);
-        if (!node(cmd.def).Constraint || constraint.contype !== "CONSTR_CHECK") continue;
-
-        // Check for NOT VALID: skip_validation = true means NOT VALID was used
-        const hasNotValid = constraint.skip_validation === true;
-
-        if (!hasNotValid) {
-          const location = offsetToLocation(
-            rawSql,
-            stmtEntry.stmt_location ?? 0,
-            filePath,
-          );
-
-          const tableName = node(alterStmt.relation).relname ?? "unknown";
-          const constraintName = constraint.conname ?? "unnamed";
-
-          findings.push({
-            ruleId: "SA016",
-            severity: "error",
-            message: `Adding CHECK constraint "${constraintName}" on table "${tableName}" without NOT VALID performs a full table scan under a heavy lock.`,
-            location,
-            suggestion:
-              "Use ADD CONSTRAINT ... NOT VALID, then VALIDATE CONSTRAINT in a separate statement (takes a weaker lock and does not block writes).",
-          });
-        }
+        findings.push({
+          ruleId: "SA016",
+          severity: "error",
+          message: `Adding CHECK constraint "${constraintName}" on table "${tableName}" without NOT VALID performs a full table scan under a heavy lock.`,
+          location,
+          suggestion:
+            "Use ADD CONSTRAINT ... NOT VALID, then VALIDATE CONSTRAINT in a separate statement (takes a weaker lock and does not block writes).",
+        });
       }
-    }
+    });
 
     return findings;
   },

--- a/src/analysis/rules/SA017.ts
+++ b/src/analysis/rules/SA017.ts
@@ -20,7 +20,8 @@
  */
 
 import type { Rule, Finding, AnalysisContext } from "../types.js";
-import { offsetToLocation, node, nodes } from "../types.js";
+import { offsetToLocation, node } from "../types.js";
+import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA017: Rule = {
   id: "SA017",
@@ -31,42 +32,27 @@ export const SA017: Rule = {
     const findings: Finding[] = [];
     const { ast, rawSql, filePath } = context;
 
-    if (!ast?.stmts) return findings;
+    forEachAlterTableCmd(ast, ({ cmd, alterStmt, stmtLocation }) => {
+      if (cmd.subtype !== "AT_SetNotNull") return;
 
-    for (const stmtEntry of ast.stmts) {
-      const stmt = stmtEntry.stmt;
-      if (!stmt?.AlterTableStmt) continue;
+      const colName = cmd.name ?? "unknown";
+      const tableName = node(alterStmt.relation).relname ?? "unknown";
 
-      const alterStmt = node(stmt.AlterTableStmt);
-      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+      // Connected check: if DB is available, check for existing
+      // CHECK (col IS NOT NULL) constraint and suppress if found
+      // This is left as a stub for the analysis engine integration
 
-      for (const cmdEntry of nodes(alterStmt.cmds)) {
-        const cmd = node(cmdEntry.AlterTableCmd);
-        if (!cmdEntry.AlterTableCmd || cmd.subtype !== "AT_SetNotNull") continue;
+      const location = offsetToLocation(rawSql, stmtLocation, filePath);
 
-        const colName = cmd.name ?? "unknown";
-        const tableName = node(alterStmt.relation).relname ?? "unknown";
-
-        // Connected check: if DB is available, check for existing
-        // CHECK (col IS NOT NULL) constraint and suppress if found
-        // This is left as a stub for the analysis engine integration
-
-        const location = offsetToLocation(
-          rawSql,
-          stmtEntry.stmt_location ?? 0,
-          filePath,
-        );
-
-        findings.push({
-          ruleId: "SA017",
-          severity: "warn",
-          message: `SET NOT NULL on column "${colName}" of table "${tableName}" requires a full table scan on PG < 12, or a valid CHECK (${colName} IS NOT NULL) constraint on PG 12+.`,
-          location,
-          suggestion:
-            "Use the three-step pattern: (1) ADD CONSTRAINT ... CHECK (col IS NOT NULL) NOT VALID, (2) VALIDATE CONSTRAINT, (3) SET NOT NULL.",
-        });
-      }
-    }
+      findings.push({
+        ruleId: "SA017",
+        severity: "warn",
+        message: `SET NOT NULL on column "${colName}" of table "${tableName}" requires a full table scan on PG < 12, or a valid CHECK (${colName} IS NOT NULL) constraint on PG 12+.`,
+        location,
+        suggestion:
+          "Use the three-step pattern: (1) ADD CONSTRAINT ... CHECK (col IS NOT NULL) NOT VALID, (2) VALIDATE CONSTRAINT, (3) SET NOT NULL.",
+      });
+    });
 
     return findings;
   },

--- a/src/analysis/rules/SA018.ts
+++ b/src/analysis/rules/SA018.ts
@@ -18,6 +18,7 @@
 
 import type { Rule, Finding, AnalysisContext, StringNode } from "../types.js";
 import { offsetToLocation, node, nodes } from "../types.js";
+import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA018: Rule = {
   id: "SA018",
@@ -28,53 +29,38 @@ export const SA018: Rule = {
     const findings: Finding[] = [];
     const { ast, rawSql, filePath } = context;
 
-    if (!ast?.stmts) return findings;
+    forEachAlterTableCmd(ast, ({ cmd, alterStmt, stmtLocation }) => {
+      if (cmd.subtype !== "AT_AddConstraint") return;
 
-    for (const stmtEntry of ast.stmts) {
-      const stmt = stmtEntry.stmt;
-      if (!stmt?.AlterTableStmt) continue;
+      if (!node(cmd.def).Constraint) return;
+      const constraint = node(node(cmd.def).Constraint);
+      if (constraint.contype !== "CONSTR_PRIMARY") return;
 
-      const alterStmt = node(stmt.AlterTableStmt);
-      if (alterStmt.objtype !== "OBJECT_TABLE") continue;
+      // If USING INDEX is specified, indexname will be set
+      if (constraint.indexname) return;
 
-      for (const cmdEntry of nodes(alterStmt.cmds)) {
-        const cmd = node(cmdEntry.AlterTableCmd);
-        if (!cmdEntry.AlterTableCmd || cmd.subtype !== "AT_AddConstraint") continue;
+      const location = offsetToLocation(rawSql, stmtLocation, filePath);
+      const tableName = node(alterStmt.relation).relname ?? "unknown";
 
-        const constraint = node(node(cmd.def).Constraint);
-        if (!node(cmd.def).Constraint || constraint.contype !== "CONSTR_PRIMARY") continue;
+      // Extract PK column names
+      const pkCols = nodes<StringNode>(constraint.keys)
+        .map((key) => key?.String?.sval)
+        .filter(Boolean)
+        .join(", ");
 
-        // If USING INDEX is specified, indexname will be set
-        if (constraint.indexname) continue;
+      // Connected check: if DB is available, check for pre-existing
+      // unique index on PK columns and suppress if found
+      // This is left as a stub for the analysis engine integration
 
-        const location = offsetToLocation(
-          rawSql,
-          stmtEntry.stmt_location ?? 0,
-          filePath,
-        );
-
-        const tableName = node(alterStmt.relation).relname ?? "unknown";
-
-        // Extract PK column names
-        const pkCols = nodes(constraint.keys)
-          .map((key) => (key as unknown as StringNode)?.String?.sval)
-          .filter(Boolean)
-          .join(", ");
-
-        // Connected check: if DB is available, check for pre-existing
-        // unique index on PK columns and suppress if found
-        // This is left as a stub for the analysis engine integration
-
-        findings.push({
-          ruleId: "SA018",
-          severity: "warn",
-          message: `ADD PRIMARY KEY on "${tableName}" (${pkCols}) without USING INDEX holds AccessExclusiveLock while creating the index.`,
-          location,
-          suggestion:
-            "Create the unique index concurrently first, then use ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY USING INDEX.",
-        });
-      }
-    }
+      findings.push({
+        ruleId: "SA018",
+        severity: "warn",
+        message: `ADD PRIMARY KEY on "${tableName}" (${pkCols}) without USING INDEX holds AccessExclusiveLock while creating the index.`,
+        location,
+        suggestion:
+          "Create the unique index concurrently first, then use ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY USING INDEX.",
+      });
+    });
 
     return findings;
   },

--- a/src/analysis/rules/SA019.ts
+++ b/src/analysis/rules/SA019.ts
@@ -30,7 +30,7 @@ export const SA019: Rule = {
       const reindexStmt = node(stmt.ReindexStmt);
 
       // Check if CONCURRENTLY is used
-      const params = nodes(reindexStmt.params) as unknown as DefElem[];
+      const params = nodes<DefElem>(reindexStmt.params);
       const hasConcurrently = params.some(
         (p) => p?.DefElem?.defname === "concurrently",
       );

--- a/src/analysis/rules/SA020.ts
+++ b/src/analysis/rules/SA020.ts
@@ -18,8 +18,9 @@
  * to suppress the warning.
  */
 
-import type { Rule, Finding, AnalysisContext, StringNode, DefElem } from "../types.js";
+import type { Rule, Finding, AnalysisContext, DefElem } from "../types.js";
 import { offsetToLocation, node, nodes } from "../types.js";
+import { extractDropObjectNames } from "../ast-helpers.js";
 
 /**
  * Check if the SQL contains a -- sqlever:auto-commit or
@@ -81,17 +82,7 @@ export const SA020: Rule = {
             filePath,
           );
 
-          // Extract index name(s)
-          const indexNames: string[] = [];
-          for (const obj of nodes(dropStmt.objects)) {
-            const list = node(obj).List;
-            if (list) {
-              const names = nodes(node(list).items)
-                .map((item) => (item as unknown as StringNode)?.String?.sval)
-                .filter(Boolean);
-              indexNames.push(names.join("."));
-            }
-          }
+          const indexNames = extractDropObjectNames(dropStmt);
           const nameStr =
             indexNames.length > 0 ? indexNames.join(", ") : "unnamed";
 
@@ -109,7 +100,7 @@ export const SA020: Rule = {
       // REINDEX CONCURRENTLY
       if (stmt?.ReindexStmt) {
         const reindexStmt = node(stmt.ReindexStmt);
-        const params = nodes(reindexStmt.params) as unknown as DefElem[];
+        const params = nodes<DefElem>(reindexStmt.params);
         const hasConcurrently = params.some(
           (p) => p?.DefElem?.defname === "concurrently",
         );

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -17,32 +17,32 @@
  */
 export type PgNode = Record<string, unknown>;
 
+/** Shared empty object returned by node() for nullish inputs. */
+const EMPTY: Record<string, unknown> = Object.freeze({}) as Record<string, unknown>;
+
 /**
  * Narrow an unknown AST value to a record for property access.
  *
  * Usage in rules: `const alterStmt = node(stmt.AlterTableStmt)`
  * then access `alterStmt.objtype`, `alterStmt.cmds`, etc.
+ *
+ * Returns a frozen EMPTY sentinel for nullish inputs, avoiding
+ * a fresh allocation per call.
  */
 export function node(value: unknown): Record<string, unknown> {
-  return (value ?? {}) as Record<string, unknown>;
+  return (value ?? EMPTY) as Record<string, unknown>;
 }
 
 /**
  * Narrow an unknown AST value to an array of records.
  *
  * Usage in rules: `for (const cmd of nodes(alterStmt.cmds))`
- */
-export function nodes(value: unknown): Record<string, unknown>[] {
-  return (value ?? []) as Record<string, unknown>[];
-}
-
-/**
- * Extract a string leaf value from an AST node.
  *
- * Usage: `str(alterStmt.objtype)` returns the string value or "".
+ * Accepts a generic parameter to avoid double-casts in callers:
+ *   `nodes<StringNode>(items)` instead of `nodes(items) as unknown as StringNode[]`
  */
-export function str(value: unknown): string {
-  return typeof value === "string" ? value : "";
+export function nodes<T = Record<string, unknown>>(value: unknown): T[] {
+  return (value ?? []) as T[];
 }
 
 /**
@@ -53,20 +53,6 @@ export interface DefElem {
     defname?: string;
     arg?: PgNode;
     defaction?: number;
-    location?: number;
-  };
-}
-
-/**
- * A RangeVar node from the libpg-query AST.
- */
-export interface RangeVar {
-  RangeVar?: {
-    relname?: string;
-    schemaname?: string;
-    inh?: boolean;
-    relpersistence?: string;
-    alias?: PgNode;
     location?: number;
   };
 }


### PR DESCRIPTION
## Summary

- Extract shared AST patterns into `src/analysis/ast-helpers.ts`: `VOLATILE_FUNCTIONS` set, `containsVolatileFunction()`, `forEachAlterTableCmd()`, and `extractDropObjectNames()`
- Update SA001, SA002, SA002b, SA003, SA006, SA009, SA016, SA017, SA018 to use `forEachAlterTableCmd()`, eliminating duplicated 5-line ALTER TABLE iteration boilerplate and fixing the node-before-null-guard pattern
- Update SA005, SA007, SA020 to use `extractDropObjectNames()`, removing duplicated DropStmt name extraction
- Make `nodes()` generic (`nodes<DefElem>(...)`) to eliminate `as unknown as T[]` double-casts across SA012, SA013, SA014, SA019, SA020, SA009, SA018
- Add frozen `EMPTY` sentinel for `node()` to avoid per-call object allocations
- Remove dead `str()` export and unused `RangeVar` interface from `types.ts`

Net result: -150 lines, zero behavior change. All 2637 unit tests pass.

Closes #155

## Test plan

- [x] `bun test tests/unit/` -- all 2637 tests pass (0 fail)
- [x] `bun x tsc --noEmit` -- no new type errors in `src/`
- [x] Verified no remaining `as unknown as DefElem[]` or `as unknown as StringNode` double-casts in rules

Generated with [Claude Code](https://claude.com/claude-code)