### PR TITLE
perf(deploy): eliminate redundant reads and quadratic rebuilds

### DIFF
--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -224,24 +224,55 @@ export interface AnalyzeOptions {
 // ---------------------------------------------------------------------------
 
 /**
+ * Precomputed line-start offsets for offsetToLocation. Cached for the
+ * last-seen rawSql string so that repeated calls within the same file
+ * (typical during analysis) use an O(log N) binary search instead of
+ * an O(N) linear scan per call.
+ */
+let cachedLineStartsSql: string | undefined;
+let cachedLineStarts: number[] = [];
+
+function getLineStarts(rawSql: string): number[] {
+  if (rawSql === cachedLineStartsSql) return cachedLineStarts;
+  const starts = [0]; // line 1 starts at offset 0
+  for (let i = 0; i < rawSql.length; i++) {
+    if (rawSql[i] === "\n") {
+      starts.push(i + 1);
+    }
+  }
+  cachedLineStartsSql = rawSql;
+  cachedLineStarts = starts;
+  return starts;
+}
+
+/**
  * Convert a byte offset in the source SQL to a 1-based line and column.
+ *
+ * Uses a precomputed line-start index with binary search for O(log N)
+ * per call instead of O(N).
  */
 export function offsetToLocation(
   rawSql: string,
   byteOffset: number,
   filePath: string,
 ): Location {
-  let line = 1;
-  let col = 1;
-  const len = Math.min(byteOffset, rawSql.length);
-  for (let i = 0; i < len; i++) {
-    if (rawSql[i] === "\n") {
-      line++;
-      col = 1;
+  const starts = getLineStarts(rawSql);
+  const offset = Math.min(byteOffset, rawSql.length);
+
+  // Binary search for the line containing this offset
+  let lo = 0;
+  let hi = starts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (starts[mid]! <= offset) {
+      lo = mid;
     } else {
-      col++;
+      hi = mid - 1;
     }
   }
+
+  const line = lo + 1; // 1-based
+  const col = offset - starts[lo]! + 1; // 1-based
   return { file: filePath, line, column: col };
 }
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -13,8 +13,8 @@ import { DatabaseClient } from "../db/client";
 import { Registry, type RecordDeployInput } from "../db/registry";
 import { parsePlan } from "../plan/parser";
 import { topologicalSort, filterPending, filterToTarget, validateDependencies } from "../plan/sort";
-import { computeScriptHash } from "../plan/types";
-import type { Change, Plan } from "../plan/types";
+import { computeScriptHashFromBytes } from "../plan/types";
+import type { Change, Plan, Tag } from "../plan/types";
 import { PsqlRunner, type PsqlRunResult } from "../psql";
 import { shouldSetLockTimeout } from "../lock-guard";
 import { resolveDeployIncludes } from "../includes/snapshot";
@@ -368,6 +368,8 @@ export interface DeployDeps {
 export async function executeDeploy(
   options: DeployOptions,
   deps: DeployDeps,
+  /** Pre-parsed plan — avoids re-reading and re-parsing the plan file when the caller already has it. */
+  preloadedPlan?: Plan,
 ): Promise<DeployResult> {
   const { db, registry, psqlRunner, config, shutdownMgr } = deps;
   const topDir = resolve(options.projectDir);
@@ -375,12 +377,17 @@ export async function executeDeploy(
   const verifyDir = config.core.verify_dir;
   const planFilePath = join(topDir, config.core.plan_file);
 
-  // 1. Parse plan file
-  if (!existsSync(planFilePath)) {
-    return { deployed: 0, skipped: 0, dryRun: options.dryRun, error: `Plan file not found: ${planFilePath}` };
+  // 1. Parse plan file (use preloaded plan when available)
+  let plan: Plan;
+  if (preloadedPlan) {
+    plan = preloadedPlan;
+  } else {
+    if (!existsSync(planFilePath)) {
+      return { deployed: 0, skipped: 0, dryRun: options.dryRun, error: `Plan file not found: ${planFilePath}` };
+    }
+    const planContent = readFileSync(planFilePath, "utf-8");
+    plan = parsePlan(planContent);
   }
-  const planContent = readFileSync(planFilePath, "utf-8");
-  const plan = parsePlan(planContent);
   const projectName = plan.project.name;
 
   // 2. Resolve DB URI
@@ -570,11 +577,17 @@ export async function executeDeploy(
     // Topological sort
     const sortedChanges = topologicalSort(pendingChanges);
 
-    // Build tag lookup: change_id -> tags attached to it
+    // Build tag lookup: change_id -> tag name strings (for registry events)
     const changeTagMap = buildChangeTagMap(plan);
+
+    // Build tag object lookup: change_id -> Tag[] (for recordTag calls)
+    const changeTagObjectMap = buildChangeTagObjectMap(plan);
 
     // Build script name lookup: change_id -> script filename (handles reworks)
     const scriptNameMap = buildScriptNameMap(plan);
+
+    // Build dependency name -> change_id map once (avoids O(C*N) rebuild per change)
+    const dependencyMap = buildDependencyMap(allChanges);
 
     // 9. Set up TUI progress dashboard
     const outputCfg = getConfig();
@@ -626,9 +639,11 @@ export async function executeDeploy(
         };
       }
 
-      const scriptContent = readFileSync(deployScript, "utf-8");
+      // Read deploy script once — reuse for auto-commit check, hash, and include resolution
+      const scriptBytes = readFileSync(deployScript);
+      const scriptContent = scriptBytes.toString("utf-8");
       const autoCommit = isAutoCommit(scriptContent);
-      const scriptHash = computeScriptHash(deployScript);
+      const scriptHash = computeScriptHashFromBytes(scriptBytes);
 
       // Resolve lock_timeout for this script
       let effectiveLockTimeout: number | undefined = options.lockTimeout;
@@ -649,13 +664,14 @@ export async function executeDeploy(
         info(`Deploying change: ${change.name}`);
       }
 
-      // Resolve snapshot includes (if any) before executing
+      // Resolve snapshot includes (if any) before executing — pass pre-read content
       const resolved = resolveDeployIncludes(
         deployScript,
         change.planned_at,
         topDir,
         undefined, // commitHash — let resolveDeployIncludes look it up from planned_at
         options.noSnapshot,
+        scriptContent,
       );
 
       // Execute via psql — use assembled content when includes were resolved,
@@ -707,7 +723,7 @@ export async function executeDeploy(
             requires: change.requires,
             conflicts: change.conflicts,
             tags: changeTagMap.get(change.change_id) ?? [],
-            dependencies: buildDependencies(change, allChanges),
+            dependencies: buildDependencies(change, dependencyMap),
           });
         } catch {
           // Best effort — don't mask the original error
@@ -747,7 +763,7 @@ export async function executeDeploy(
         requires: change.requires,
         conflicts: change.conflicts,
         tags: changeTagMap.get(change.change_id) ?? [],
-        dependencies: buildDependencies(change, allChanges),
+        dependencies: buildDependencies(change, dependencyMap),
       };
 
       // Record tracking update in its own transaction (psql runs in a
@@ -757,8 +773,8 @@ export async function executeDeploy(
         await registry.recordDeploy(recordInput);
       });
 
-      // Record any tags attached to this change
-      const changeTags = plan.tags.filter((t) => t.change_id === change.change_id);
+      // Record any tags attached to this change (O(1) lookup instead of linear scan)
+      const changeTags = changeTagObjectMap.get(change.change_id) ?? [];
       for (const tag of changeTags) {
         await registry.recordTag({
           tag_id: tag.tag_id,
@@ -961,21 +977,41 @@ function buildChangeTagMap(plan: Plan): Map<string, string[]> {
 }
 
 /**
+ * Build a mapping from change_id to full Tag objects (for recordTag calls).
+ * O(1) lookup per change replaces O(T) linear scan via plan.tags.filter.
+ */
+function buildChangeTagObjectMap(plan: Plan): Map<string, Tag[]> {
+  const map = new Map<string, Tag[]>();
+  for (const tag of plan.tags) {
+    const existing = map.get(tag.change_id) ?? [];
+    existing.push(tag);
+    map.set(tag.change_id, existing);
+  }
+  return map;
+}
+
+/**
+ * Build a name -> change_id lookup map (first occurrence wins for reworked changes).
+ * Constructed once before the deploy loop and passed to buildDependencies.
+ */
+export function buildDependencyMap(allChanges: Change[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const c of allChanges) {
+    if (!map.has(c.name)) {
+      map.set(c.name, c.change_id);
+    }
+  }
+  return map;
+}
+
+/**
  * Build dependency records for a change, resolving dependency IDs from
- * the full change set.
+ * a pre-built name-to-ID map.
  */
 function buildDependencies(
   change: Change,
-  allChanges: Change[],
+  dependencyMap: Map<string, string>,
 ): RecordDeployInput["dependencies"] {
-  // Build name -> change_id map (first occurrence wins for reworked changes)
-  const changeMap = new Map<string, string>();
-  for (const c of allChanges) {
-    if (!changeMap.has(c.name)) {
-      changeMap.set(c.name, c.change_id);
-    }
-  }
-
   const deps: RecordDeployInput["dependencies"] = [];
 
   for (const req of change.requires) {
@@ -984,7 +1020,7 @@ function buildDependencies(
     deps.push({
       type: "require",
       dependency: req,
-      dependency_id: changeMap.get(baseName) ?? null,
+      dependency_id: dependencyMap.get(baseName) ?? null,
     });
   }
 
@@ -993,7 +1029,7 @@ function buildDependencies(
     deps.push({
       type: "conflict",
       dependency: conflict,
-      dependency_id: changeMap.get(baseName) ?? null,
+      dependency_id: dependencyMap.get(baseName) ?? null,
     });
   }
 
@@ -1027,14 +1063,15 @@ export async function runDeploy(args: ParsedArgs): Promise<number> {
   // Set up signal handling
   shutdownManager.register({ quiet: false });
 
-  // Read project name from plan file for session settings
+  // Parse plan file once — reuse for DB session settings and executeDeploy
   const projectDir = resolve(options.projectDir);
   const config = loadConfig(options.projectDir);
   const planFilePath = join(projectDir, config.core.plan_file);
+  let plan: Plan | undefined;
   let projectName = "unknown";
   if (existsSync(planFilePath)) {
     const planContent = readFileSync(planFilePath, "utf-8");
-    const plan = parsePlan(planContent);
+    plan = parsePlan(planContent);
     projectName = plan.project.name;
   }
 
@@ -1053,7 +1090,7 @@ export async function runDeploy(args: ParsedArgs): Promise<number> {
     psqlRunner,
     config,
     shutdownMgr: shutdownManager,
-  });
+  }, plan);
 
   if (result.error && !result.dryRun) {
     if (result.error === "Concurrent deploy detected") {

--- a/src/includes/snapshot.ts
+++ b/src/includes/snapshot.ts
@@ -54,8 +54,15 @@ export interface IncludeDirective {
 }
 
 // ---------------------------------------------------------------------------
-// Constants
+// Constants and caches
 // ---------------------------------------------------------------------------
+
+/**
+ * Cache for findCommitByTimestamp results. Maps "timestamp\0repoRoot" to
+ * the resolved commit hash. Avoids spawning a git subprocess for every
+ * change when many share the same planned_at timestamp.
+ */
+const commitByTimestampCache = new Map<string, string | undefined>();
 
 /** Default maximum include nesting depth. */
 const DEFAULT_MAX_DEPTH = 64;
@@ -238,12 +245,19 @@ export function findCommitByTimestamp(
   timestamp: string,
   repoRoot: string,
 ): string | undefined {
+  const cacheKey = `${timestamp}\0${repoRoot}`;
+  if (commitByTimestampCache.has(cacheKey)) {
+    return commitByTimestampCache.get(cacheKey);
+  }
+
   // --before accepts ISO 8601; -1 limits to one result; %H = full hash
   const result = gitExec(
     ["log", "--format=%H", "-1", `--before=${timestamp}`],
     repoRoot,
   );
-  return result?.trim() || undefined;
+  const commit = result?.trim() || undefined;
+  commitByTimestampCache.set(cacheKey, commit);
+  return commit;
 }
 
 /**
@@ -453,12 +467,14 @@ export function resolveDeployIncludes(
   repoRoot: string,
   commitHash?: string,
   noSnapshot?: boolean,
+  /** Pre-read script content — avoids a redundant readFileSync when the caller already has it. */
+  scriptContent?: string,
 ): ResolvedScript | undefined {
   const absoluteRoot = resolve(repoRoot);
 
-  // Read the script content to check for includes first
-  const scriptContent = readFileSync(deployScriptPath, "utf-8");
-  const directives = findIncludes(scriptContent);
+  // Use pre-read content when available, otherwise read from disk
+  const content = scriptContent ?? readFileSync(deployScriptPath, "utf-8");
+  const directives = findIncludes(content);
 
   if (directives.length === 0) {
     return undefined; // No includes — execute the original script


### PR DESCRIPTION
## Summary

- **Read deploy script once per change** -- was read 3 times (auto-commit check, script hash via `computeScriptHash`, include resolution in `resolveDeployIncludes`). Now reads as a Buffer once, derives string content, and passes pre-read content to all consumers.
- **Build dependency name-to-ID map once before deploy loop** -- `buildDependencies()` was rebuilding the map from scratch on every change (O(C*N) total). Now `buildDependencyMap()` runs once and the map is passed to each call.
- **Replace `plan.tags.filter` with pre-built map lookup** -- line 767 was doing a linear scan of all tags per change despite `changeTagMap` already existing. Added `buildChangeTagObjectMap` for the `recordTag` call that needs full Tag objects.
- **Parse plan file once in `runDeploy`** -- was parsed in both `runDeploy` (for project name) and again in `executeDeploy`. Now the parsed Plan is passed through.
- **Cache git commits by timestamp** in `findCommitByTimestamp` -- avoids spawning a git subprocess when multiple changes share the same `planned_at` timestamp.
- **Use static frozen `EMPTY_NODE`** for `node()` null case -- avoids allocating a new `{}` on every null AST node access.
- **Precompute line-start index** for `offsetToLocation` -- O(log N) binary search per call instead of O(N) linear scan, with caching for repeated calls on the same SQL string.

## Test plan

- [x] All 2637 unit tests pass (`bun test tests/unit/`)
- [x] Type-check passes for all source files (`bun x tsc --noEmit`)
- [x] Deploy-specific tests pass (64 tests in `tests/unit/deploy.test.ts`)
- [x] Snapshot include tests pass
- [ ] Integration tests (CI)

Closes #157

Generated with [Claude Code](https://claude.com/claude-code)