### PR TITLE
ci: add Sqitch oracle compatibility tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: test
           POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
         ports:
           - 5417:5432
         options: >-


### PR DESCRIPTION
## Summary
- Add `POSTGRES_DB: postgres` to the compat job's Postgres service container for consistency with the integration job
- The compat job runs `tests/compat/` (oracle + handoff tests) using the `sqitch/sqitch` Docker image against a PG 17 service container
- Oracle tests deploy the same project with both Sqitch and sqlever, then compare every row in `sqitch.changes`, `sqitch.events`, and `sqitch.tags` -- any divergence is a compatibility bug
- Handoff tests verify mid-deploy handoff between Sqitch and sqlever in both directions

Closes #186

## Test plan
- [x] Unit tests pass locally (3034 pass, 0 fail)
- [ ] CI compat job runs all 26 compatibility tests without skips
- [ ] CI pipeline passes on push

Generated with [Claude Code](https://claude.com/claude-code)