### PR TITLE
fix: resolve TypeScript strict mode errors

### DIFF
--- a/tests/compile-test.ts
+++ b/tests/compile-test.ts
@@ -5,8 +5,6 @@
  * the WASM parser works in the compiled output.
  */
 import { parse, parseSync, loadModule } from "libpg-query";
-import { readFileSync } from "fs";
-import { join, dirname } from "path";
 
 async function main() {
   console.log("=== bun build --compile parser test ===\n");
@@ -87,11 +85,11 @@ async function main() {
   const times: number[] = [];
   for (let i = 0; i < 5; i++) {
     const start = performance.now();
-    const r = await parse(largeSql);
+    await parse(largeSql);
     times.push(performance.now() - start);
   }
   times.sort((a, b) => a - b);
-  const median = times[Math.floor(times.length / 2)];
+  const median = times[Math.floor(times.length / 2)]!;
   console.log(`   SQL length: ${largeSql.length} chars, ${largeSql.split("\n").length} lines`);
   console.log(`   Median parse time: ${median.toFixed(2)}ms`);
   console.log(`   ${median < 200 ? "PASS" : "FAIL"}: ${median < 200 ? "< 200ms target met" : "> 200ms target exceeded"}`);

--- a/tests/integration/customer-zero.test.ts
+++ b/tests/integration/customer-zero.test.ts
@@ -36,7 +36,7 @@ import {
   hasPg,
 } from "./helpers";
 import { parsePlan } from "../../src/plan/parser";
-import type { Plan, Change } from "../../src/plan/types";
+import type { Plan } from "../../src/plan/types";
 
 // ---------------------------------------------------------------------------
 // Paths

--- a/tests/unit/ai-dblab-deep.test.ts
+++ b/tests/unit/ai-dblab-deep.test.ts
@@ -19,7 +19,6 @@ import {
   callLLM,
   DEFAULT_MODELS,
   type ExplainConfig,
-  type LLMProvider as ExplainLLMProvider,
 } from "../../src/ai/explain";
 import { parseExplainArgs } from "../../src/commands/explain";
 import {
@@ -178,7 +177,7 @@ describe("LLM explain — deep tests", () => {
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const config: ExplainConfig = {
       provider: "openai",
@@ -223,7 +222,7 @@ describe("LLM explain — deep tests", () => {
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const config: ExplainConfig = {
       provider: "anthropic",
@@ -264,7 +263,7 @@ describe("LLM explain — deep tests", () => {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const config: ExplainConfig = {
       provider: "ollama",
@@ -291,7 +290,7 @@ describe("LLM explain — deep tests", () => {
         JSON.stringify({ error: { message: "Invalid API key" } }),
         { status: 401 },
       );
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const config: ExplainConfig = {
       provider: "openai",
@@ -310,7 +309,7 @@ describe("LLM explain — deep tests", () => {
   test("API 429: throws with rate limit status code", async () => {
     const mockFn = (async () => {
       return new Response("Rate limit exceeded", { status: 429 });
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const config: ExplainConfig = {
       provider: "openai",
@@ -329,7 +328,7 @@ describe("LLM explain — deep tests", () => {
   test("API 500: throws with server error status", async () => {
     const mockFn = (async () => {
       return new Response("Internal Server Error", { status: 500 });
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const config: ExplainConfig = {
       provider: "anthropic",
@@ -348,7 +347,7 @@ describe("LLM explain — deep tests", () => {
   test("Network error: fetch itself throws (e.g. DNS failure)", async () => {
     const mockFn = (async () => {
       throw new TypeError("fetch failed: getaddrinfo ENOTFOUND api.openai.com");
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const config: ExplainConfig = {
       provider: "openai",
@@ -444,7 +443,7 @@ describe("LLM explain — deep tests", () => {
     // Ollama without key does NOT throw (it makes a network call, so we mock it)
     const mockFn = (async () => {
       return new Response(JSON.stringify({ response: "ok" }), { status: 200 });
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const result = await callLLM(
       "test",

--- a/tests/unit/analysis-deep.test.ts
+++ b/tests/unit/analysis-deep.test.ts
@@ -90,22 +90,6 @@ function silenceStdout(): () => void {
   };
 }
 
-// Capture stdout during test runs
-function captureStdout(): { getOutput: () => string; restore: () => void } {
-  let output = "";
-  const original = process.stdout.write.bind(process.stdout);
-  process.stdout.write = ((chunk: unknown) => {
-    output += typeof chunk === "string" ? chunk : String(chunk);
-    return true;
-  }) as typeof process.stdout.write;
-  return {
-    getOutput: () => output,
-    restore: () => {
-      process.stdout.write = original;
-    },
-  };
-}
-
 // Load WASM module and register rules before all tests
 beforeAll(async () => {
   await loadModule();

--- a/tests/unit/batch-deep.test.ts
+++ b/tests/unit/batch-deep.test.ts
@@ -21,7 +21,7 @@ class MockPgClient {
     this.connected = true;
   }
 
-  async query(text: string, values?: unknown[]) {
+  async query(text: string, values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number; command: string }> {
     this.queries.push({ text, values });
     return { rows: [], rowCount: 0, command: "SELECT" };
   }
@@ -44,7 +44,6 @@ const {
   splitStatements,
   isValidTransition,
   VALID_TRANSITIONS,
-  PARTITION_COUNT,
   DEFAULT_HEARTBEAT_STALENESS_MS,
   DEFAULT_BATCH_SIZE,
   DEFAULT_SLEEP_MS,
@@ -53,29 +52,19 @@ const {
 
 const {
   BatchWorker,
-  DEFAULT_LOCK_TIMEOUT_MS,
-  DEFAULT_STATEMENT_TIMEOUT_MS,
-  DEFAULT_SEARCH_PATH,
 } = await import("../../src/batch/worker");
 
 const {
   calculateProgress,
-  parseIntervalToSeconds,
   computeDeadTupleRatio,
-  checkHeartbeatStaleness,
   ProgressMonitor,
-  DEFAULT_REPLICATION_LAG_THRESHOLD_SECONDS,
-  DEFAULT_MAX_DEAD_TUPLE_RATIO,
 } = await import("../../src/batch/progress");
 
 const {
   parseBatchAddArgs,
-  parseBatchNameArgs,
-  parseSleepValue,
   formatJobText,
   formatJobListText,
   formatJobJson,
-  BATCH_SUBCOMMANDS,
 } = await import("../../src/commands/batch");
 
 import type {
@@ -87,7 +76,6 @@ import type {
 import type {
   DmlExecutor,
   SignalCheckFn,
-  WorkerResult,
 } from "../../src/batch/worker";
 
 // ---------------------------------------------------------------------------
@@ -398,10 +386,6 @@ describe("batch-deep", () => {
     });
 
     it("all invalid transitions rejected — disallowed pairs return false", () => {
-      const allStatuses: JobStatus[] = [
-        "pending", "running", "paused", "done", "failed", "dead", "cancelled",
-      ];
-
       const invalid: [JobStatus, JobStatus][] = [
         ["pending", "done"],
         ["pending", "failed"],
@@ -778,7 +762,6 @@ describe("batch-deep", () => {
       const client = await makeClient();
       const pgClient = latestPgClient();
 
-      const pausedJob = mockJob({ status: "paused" });
       const resumedJob = mockJob({ status: "running" });
 
       setupQueryResponses(pgClient, [

--- a/tests/unit/batch-progress.test.ts
+++ b/tests/unit/batch-progress.test.ts
@@ -21,7 +21,7 @@ class MockPgClient {
     this.connected = true;
   }
 
-  async query(text: string, values?: unknown[]) {
+  async query(text: string, values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number; command: string }> {
     this.queries.push({ text, values });
     return { rows: [], rowCount: 0, command: "SELECT" };
   }

--- a/tests/unit/batch-worker.test.ts
+++ b/tests/unit/batch-worker.test.ts
@@ -46,7 +46,6 @@ mock.module("pg/lib/client", () => ({
 
 const { DatabaseClient } = await import("../../src/db/client");
 const {
-  BatchQueue,
   DEFAULT_BATCH_SIZE,
   DEFAULT_SLEEP_MS,
   DEFAULT_MAX_RETRIES,
@@ -63,7 +62,6 @@ import type { BatchJob, PartitionId } from "../../src/batch/queue";
 import type {
   DmlExecutor,
   SignalCheckFn,
-  WorkerResult,
   BatchWorkerConfig,
 } from "../../src/batch/worker";
 
@@ -356,7 +354,7 @@ describe("batch/worker", () => {
       await worker.run();
 
       // The DML executor should have received "500" as the starting PK
-      expect(receivedLastPk).toBe("500");
+      expect(receivedLastPk as string | null).toBe("500");
     });
 
     it("passes updated lastPk to successive batch calls", async () => {
@@ -969,7 +967,7 @@ describe("batch/worker", () => {
 
       const signalCheck: SignalCheckFn = async () => {
         // Simulate async check (e.g., reading a file or querying DB)
-        return "cancel";
+        return "cancel" as const;
       };
 
       const dml = fixedDml([]);

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, spyOn, mock } from "bun:test";
-import { resetConfig, setConfig } from "../../src/output";
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { resetConfig } from "../../src/output";
 
 // ---------------------------------------------------------------------------
 // Mock pg/lib/client — we never want a real database connection in unit tests.
@@ -71,24 +71,6 @@ const { DatabaseClient, EXIT_CODE_DB_UNREACHABLE } = await import(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function captureStderr() {
-  let output = "";
-  const spy = spyOn(process.stderr, "write").mockImplementation(
-    (chunk: string | Uint8Array) => {
-      output += String(chunk);
-      return true;
-    },
-  );
-  return {
-    get output() {
-      return output;
-    },
-    restore() {
-      spy.mockRestore();
-    },
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/tests/unit/deploy-failures.test.ts
+++ b/tests/unit/deploy-failures.test.ts
@@ -73,7 +73,7 @@ mock.module("pg/lib/client", () => ({
 
 // Type imports (these work statically)
 import type { DeployOptions, DeployDeps } from "../../src/commands/deploy";
-import type { SpawnFn, PsqlRunResult } from "../../src/psql";
+import type { SpawnFn } from "../../src/psql";
 
 // Import after mocking
 const { DatabaseClient } = await import("../../src/db/client");
@@ -82,9 +82,7 @@ const {
   executeDeploy,
   runDeploy,
   parseDeployOptions,
-  projectLockKey,
   isAutoCommit,
-  ADVISORY_LOCK_NAMESPACE,
   EXIT_CONCURRENT_DEPLOY,
   EXIT_DEPLOY_FAILED,
   EXIT_LOCK_TIMEOUT,
@@ -163,7 +161,7 @@ add_index 2025-01-02T00:00:00Z Test User <test@example.com> # Concurrent index
 /**
  * Create a mock PsqlRunner that succeeds (exit code 0) for all scripts.
  */
-function createMockPsqlRunner(exitCode = 0, stderr = ""): PsqlRunner {
+function createMockPsqlRunner(exitCode = 0, stderr = ""): InstanceType<typeof PsqlRunner> {
   const mockSpawn: SpawnFn = (_cmd, _args, _opts) => {
     const child = Object.assign(new EventEmitter(), {
       stdout: new EventEmitter(),
@@ -181,7 +179,7 @@ function createMockPsqlRunner(exitCode = 0, stderr = ""): PsqlRunner {
 /**
  * Create a mock PsqlRunner that fails on a specific deploy script name.
  */
-function createFailingPsqlRunner(failOnScript: string, errorMsg = "ERROR: relation does not exist"): PsqlRunner {
+function createFailingPsqlRunner(failOnScript: string, errorMsg = "ERROR: relation does not exist"): InstanceType<typeof PsqlRunner> {
   const mockSpawn: SpawnFn = (_cmd, args, _opts) => {
     const child = Object.assign(new EventEmitter(), {
       stdout: new EventEmitter(),
@@ -204,7 +202,7 @@ function createFailingPsqlRunner(failOnScript: string, errorMsg = "ERROR: relati
  * Create a PsqlRunner that tracks invocations and fails on specific scripts.
  */
 function createTrackingPsqlRunner(failOnScripts: string[] = []): {
-  runner: PsqlRunner;
+  runner: InstanceType<typeof PsqlRunner>;
   calls: Array<{ scriptFile: string; args: string[] }>;
 } {
   const calls: Array<{ scriptFile: string; args: string[] }> = [];
@@ -249,7 +247,7 @@ async function createDeps(opts?: Partial<{
 }>): Promise<DeployDeps> {
   const db = new DatabaseClient("postgresql://localhost/testdb");
   const registry = new Registry(db);
-  let psqlRunner: PsqlRunner;
+  let psqlRunner: InstanceType<typeof PsqlRunner>;
   if (opts?.failOnScript) {
     psqlRunner = createFailingPsqlRunner(opts.failOnScript);
   } else {

--- a/tests/unit/deploy-phase.test.ts
+++ b/tests/unit/deploy-phase.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { EventEmitter } from "events";
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { resetConfig, setConfig } from "../../src/output";
@@ -40,7 +40,7 @@ class MockPgClient {
     this.connected = true;
   }
 
-  async query(text: string, values?: unknown[]) {
+  async query(text: string, values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number; command: string }> {
     this.queries.push({ text, values });
     // Advisory lock
     if (text.includes("pg_try_advisory_lock")) {
@@ -125,7 +125,6 @@ mock.module("pg/lib/client", () => ({
 }));
 
 // Type imports
-import type { DeployOptions, DeployDeps, DeployPhase } from "../../src/commands/deploy";
 import type { SpawnFn } from "../../src/psql";
 
 // Import after mocking
@@ -602,7 +601,7 @@ describe("executeDeploy --phase contract", () => {
     setupProject(tmpDir);
 
     // Mock: expand change is already deployed
-    const mockQuery = async (text: string, values?: unknown[]) => {
+    const mockQuery = async (text: string, _values?: unknown[]) => {
       if (text.includes("pg_try_advisory_lock")) {
         return { rows: [{ pg_try_advisory_lock: true }], rowCount: 1, command: "SELECT" };
       }

--- a/tests/unit/deploy-revert-robustness.test.ts
+++ b/tests/unit/deploy-revert-robustness.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach, mock, afterEach, spyOn } from "bun:test";
 import { EventEmitter } from "events";
-import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { resetConfig, setConfig } from "../../src/output";
@@ -32,7 +32,7 @@ class MockPgClient {
     this.connected = true;
   }
 
-  async query(text: string, values?: unknown[]) {
+  async query(text: string, values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number; command: string }> {
     this.queries.push({ text, values });
     // Default: advisory lock returns true
     if (text.includes("pg_try_advisory_lock")) {
@@ -80,14 +80,10 @@ const { DatabaseClient, EXIT_CODE_DB_UNREACHABLE } = await import("../../src/db/
 const { Registry } = await import("../../src/db/registry");
 const {
   executeDeploy,
-  runDeploy,
+  parseDeployOptions,
   projectLockKey,
   isAutoCommit,
-  parseDeployOptions,
   ADVISORY_LOCK_NAMESPACE,
-  EXIT_CONCURRENT_DEPLOY,
-  EXIT_DEPLOY_FAILED,
-  EXIT_LOCK_TIMEOUT,
   EXIT_DB_UNREACHABLE,
 } = await import("../../src/commands/deploy");
 const {
@@ -96,14 +92,12 @@ const {
   buildRevertInput,
   confirmRevert,
   runRevert,
-  EXIT_CODE_CONCURRENT,
 } = await import("../../src/commands/revert");
 const { loadConfig } = await import("../../src/config/index");
 const { PsqlRunner } = await import("../../src/psql");
 const { ShutdownManager } = await import("../../src/signals");
 const { parseArgs } = await import("../../src/cli");
 const {
-  shouldSetLockTimeout,
   isLockTimeoutError,
   retryWithBackoff,
 } = await import("../../src/lock-guard");
@@ -133,14 +127,6 @@ function writeDeployScript(dir: string, name: string, content: string): void {
   writeFileSync(join(dir, "deploy", `${name}.sql`), content, "utf-8");
 }
 
-function writeRevertScript(dir: string, name: string, content: string): void {
-  writeFileSync(join(dir, "revert", `${name}.sql`), content, "utf-8");
-}
-
-function writeVerifyScript(dir: string, name: string, content: string): void {
-  writeFileSync(join(dir, "verify", `${name}.sql`), content, "utf-8");
-}
-
 function writeSqitchConf(dir: string, content: string): void {
   writeFileSync(join(dir, "sqitch.conf"), content, "utf-8");
 }
@@ -162,16 +148,6 @@ add_users [create_schema] 2025-01-02T00:00:00Z Test User <test@example.com> # Ad
 add_posts [add_users] 2025-01-03T00:00:00Z Test User <test@example.com> # Add posts table
 `;
 
-/** Tagged plan */
-const TAGGED_PLAN = `%syntax-version=1.0.0
-%project=myproject
-
-create_schema 2025-01-01T00:00:00Z Test User <test@example.com> # Create schema
-add_users [create_schema] 2025-01-02T00:00:00Z Test User <test@example.com> # Add users table
-@v1.0 2025-01-03T00:00:00Z Test User <test@example.com> # Release v1.0
-add_posts [add_users] 2025-01-04T00:00:00Z Test User <test@example.com> # Add posts table
-`;
-
 /** Non-transactional plan */
 const NON_TXN_PLAN = `%syntax-version=1.0.0
 %project=myproject
@@ -180,7 +156,7 @@ create_schema 2025-01-01T00:00:00Z Test User <test@example.com> # Schema
 add_index 2025-01-02T00:00:00Z Test User <test@example.com> # Concurrent index
 `;
 
-function createMockPsqlRunner(exitCode = 0, stderr = ""): PsqlRunner {
+function createMockPsqlRunner(exitCode = 0, stderr = ""): InstanceType<typeof PsqlRunner> {
   const mockSpawn: SpawnFn = (_cmd, _args, _opts) => {
     const child = Object.assign(new EventEmitter(), {
       stdout: new EventEmitter(),
@@ -195,7 +171,7 @@ function createMockPsqlRunner(exitCode = 0, stderr = ""): PsqlRunner {
   return new PsqlRunner("psql", mockSpawn);
 }
 
-function createFailingPsqlRunner(failOnScript: string, errorMsg = "ERROR: relation does not exist"): PsqlRunner {
+function createFailingPsqlRunner(failOnScript: string, errorMsg = "ERROR: relation does not exist"): InstanceType<typeof PsqlRunner> {
   const mockSpawn: SpawnFn = (_cmd, args, _opts) => {
     const child = Object.assign(new EventEmitter(), {
       stdout: new EventEmitter(),
@@ -215,7 +191,7 @@ function createFailingPsqlRunner(failOnScript: string, errorMsg = "ERROR: relati
 }
 
 function createTrackingPsqlRunner(failOnScripts: string[] = []): {
-  runner: PsqlRunner;
+  runner: InstanceType<typeof PsqlRunner>;
   calls: Array<{ scriptFile: string; args: string[] }>;
 } {
   const calls: Array<{ scriptFile: string; args: string[] }> = [];
@@ -260,7 +236,7 @@ async function createDeps(opts?: Partial<{
 }>): Promise<DeployDeps> {
   const db = new DatabaseClient("postgresql://localhost/testdb");
   const registry = new Registry(db);
-  let psqlRunner: PsqlRunner;
+  let psqlRunner: InstanceType<typeof PsqlRunner>;
   if (opts?.failOnScript) {
     psqlRunner = createFailingPsqlRunner(opts.failOnScript);
   } else {
@@ -1003,11 +979,7 @@ create_schema 2025-01-01T00:00:00Z Test User <test@example.com> # Schema
     });
 
     it("runRevert returns exit code (no process.exit)", async () => {
-      // Verify revert.ts source does not call process.exit()
-      const srcPath = join(
-        testDir, "..", "..", "..", "src", "commands", "revert.ts",
-      );
-      // Use a more reliable approach: check the actual module behavior
+      // Verify revert.ts does not call process.exit() — check the actual module behavior
       const args = parseArgs(["revert", "-y", "--top-dir", "/tmp/__nonexistent_sqlever_dir_robustness__"]);
 
       const exitSpy = spyOn(process, "exit").mockImplementation(

--- a/tests/unit/deploy.test.ts
+++ b/tests/unit/deploy.test.ts
@@ -26,7 +26,7 @@ class MockPgClient {
     this.connected = true;
   }
 
-  async query(text: string, values?: unknown[]) {
+  async query(text: string, values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number; command: string }> {
     this.queries.push({ text, values });
     // Default: advisory lock returns true
     if (text.includes("pg_try_advisory_lock")) {
@@ -66,8 +66,8 @@ mock.module("pg/lib/client", () => ({
 }));
 
 // Type imports (these work statically)
-import type { DeployOptions, DeployDeps, buildScriptNameMap as BuildScriptNameMapType } from "../../src/commands/deploy";
-import type { SpawnFn, PsqlRunResult } from "../../src/psql";
+import type { DeployOptions, DeployDeps } from "../../src/commands/deploy";
+import type { SpawnFn } from "../../src/psql";
 
 // Import after mocking
 const { DatabaseClient } = await import("../../src/db/client");
@@ -144,7 +144,7 @@ add_posts [add_users] 2025-01-04T00:00:00Z Test User <test@example.com> # Add po
 /**
  * Create a mock PsqlRunner that succeeds (exit code 0).
  */
-function createMockPsqlRunner(exitCode = 0, stderr = ""): PsqlRunner {
+function createMockPsqlRunner(exitCode = 0, stderr = ""): InstanceType<typeof PsqlRunner> {
   const mockSpawn: SpawnFn = (_cmd, _args, _opts) => {
     const child = Object.assign(new EventEmitter(), {
       stdout: new EventEmitter(),
@@ -162,7 +162,7 @@ function createMockPsqlRunner(exitCode = 0, stderr = ""): PsqlRunner {
 /**
  * Create a mock PsqlRunner that fails on a specific script.
  */
-function createFailingPsqlRunner(failOnScript: string, errorMsg = "ERROR: relation does not exist"): PsqlRunner {
+function createFailingPsqlRunner(failOnScript: string, errorMsg = "ERROR: relation does not exist"): InstanceType<typeof PsqlRunner> {
   const mockSpawn: SpawnFn = (_cmd, args, _opts) => {
     const child = Object.assign(new EventEmitter(), {
       stdout: new EventEmitter(),
@@ -199,7 +199,7 @@ function defaultOptions(dir: string): DeployOptions {
 async function createDeps(opts?: Partial<{ psqlExitCode: number; psqlStderr: string; failOnScript: string }>): Promise<DeployDeps> {
   const db = new DatabaseClient("postgresql://localhost/testdb");
   const registry = new Registry(db);
-  let psqlRunner: PsqlRunner;
+  let psqlRunner: InstanceType<typeof PsqlRunner>;
   if (opts?.failOnScript) {
     psqlRunner = createFailingPsqlRunner(opts.failOnScript);
   } else {
@@ -213,10 +213,6 @@ async function createDeps(opts?: Partial<{ psqlExitCode: number; psqlStderr: str
 
 function getPgClient(): MockPgClient {
   return mockInstances[mockInstances.length - 1]!;
-}
-
-function queryTexts(pgClient: MockPgClient): string[] {
-  return pgClient.queries.map((q) => q.text);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/diff.test.ts
+++ b/tests/unit/diff.test.ts
@@ -9,7 +9,6 @@ import {
   findTagChangeIndex,
   formatDiffText,
   type DiffResult,
-  type DiffEntry,
 } from "../../src/commands/diff";
 import type { Plan, Change, Tag } from "../../src/plan/types";
 import { resetConfig } from "../../src/output";

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -7,7 +7,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { runDoctorChecks, type DoctorReport } from "../../src/commands/doctor";
+import { runDoctorChecks } from "../../src/commands/doctor";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,10 +20,6 @@ function createTempProject(): string {
 
 function writePlan(dir: string, content: string): void {
   writeFileSync(join(dir, "sqitch.plan"), content);
-}
-
-function writeConf(dir: string, content: string): void {
-  writeFileSync(join(dir, "sqitch.conf"), content);
 }
 
 function writeScript(dir: string, subdir: string, name: string, content: string): void {

--- a/tests/unit/e2e-deep.test.ts
+++ b/tests/unit/e2e-deep.test.ts
@@ -12,7 +12,6 @@ import {
   writeFileSync,
   readFileSync,
   rmSync,
-  existsSync,
   mkdtempSync,
 } from "fs";
 import { join } from "path";
@@ -150,15 +149,12 @@ mock.module("pg/lib/client", () => ({
 // ---------------------------------------------------------------------------
 
 import type { DeployOptions, DeployDeps } from "../../src/commands/deploy";
-import type { SpawnFn, PsqlRunResult } from "../../src/psql";
+import type { SpawnFn } from "../../src/psql";
 
 const { DatabaseClient } = await import("../../src/db/client");
 const { Registry } = await import("../../src/db/registry");
 const {
   executeDeploy,
-  projectLockKey,
-  isAutoCommit,
-  ADVISORY_LOCK_NAMESPACE,
   EXIT_CONCURRENT_DEPLOY,
   EXIT_DEPLOY_FAILED,
   EXIT_LOCK_TIMEOUT,
@@ -168,7 +164,7 @@ const { loadConfig } = await import("../../src/config/index");
 const { PsqlRunner } = await import("../../src/psql");
 const { ShutdownManager } = await import("../../src/signals");
 const { parsePlan } = await import("../../src/plan/parser");
-const { computeChangeId, computeTagId } = await import("../../src/plan/types");
+const { computeChangeId } = await import("../../src/plan/types");
 const {
   topologicalSort,
   validateDependencies,
@@ -180,24 +176,16 @@ const {
 const {
   shouldUseTUI,
   DeployProgress,
-  formatDuration,
 } = await import("../../src/tui/deploy");
 const {
-  parseIncludeDirective,
-  findIncludes,
-  resolveIncludePath,
   resolveIncludes,
-  getFileAtCommit,
-  getFileContent,
-  isGitRepo,
-  getGitRoot,
   resolveDeployIncludes,
 } = await import("../../src/includes/snapshot");
-const { runTag, isValidTagName, parseTagArgs } = await import("../../src/commands/tag");
+const { runTag } = await import("../../src/commands/tag");
 const { findReworkContext, ReworkError } = await import("../../src/commands/rework");
-const { computeChangesToRevert, buildRevertInput } = await import("../../src/commands/revert");
+const { computeChangesToRevert } = await import("../../src/commands/revert");
 const { computeStatus, formatStatusText } = await import("../../src/commands/status");
-const { runAnalyze, parseAnalyzeArgs } = await import("../../src/commands/analyze");
+const { runAnalyze } = await import("../../src/commands/analyze");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -235,7 +223,7 @@ function writeSqitchConf(dir: string, content: string): void {
   writeFileSync(join(dir, "sqitch.conf"), content, "utf-8");
 }
 
-function createMockPsqlRunner(exitCode = 0, stderr = ""): PsqlRunner {
+function createMockPsqlRunner(exitCode = 0, stderr = ""): InstanceType<typeof PsqlRunner> {
   const mockSpawn: SpawnFn = (_cmd, _args, _opts) => {
     const child = Object.assign(new EventEmitter(), {
       stdout: new EventEmitter(),
@@ -253,7 +241,7 @@ function createMockPsqlRunner(exitCode = 0, stderr = ""): PsqlRunner {
 function createFailingPsqlRunner(
   failOnScript: string,
   errorMsg = "ERROR: relation does not exist",
-): PsqlRunner {
+): InstanceType<typeof PsqlRunner> {
   const mockSpawn: SpawnFn = (_cmd, args, _opts) => {
     const child = Object.assign(new EventEmitter(), {
       stdout: new EventEmitter(),
@@ -294,7 +282,7 @@ async function createDeps(opts?: Partial<{
 }>): Promise<DeployDeps> {
   const db = new DatabaseClient("postgresql://localhost/testdb");
   const registry = new Registry(db);
-  let psqlRunner: PsqlRunner;
+  let psqlRunner: InstanceType<typeof PsqlRunner>;
   if (opts?.failOnScript) {
     psqlRunner = createFailingPsqlRunner(opts.failOnScript);
   } else {

--- a/tests/unit/expand-contract-deep.test.ts
+++ b/tests/unit/expand-contract-deep.test.ts
@@ -11,7 +11,6 @@ import {
   writeFileSync,
   readFileSync,
   existsSync,
-  mkdirSync,
   rmSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -23,9 +22,7 @@ import { resetConfig } from "../../src/output";
 // ---------------------------------------------------------------------------
 
 import {
-  deriveChangeNames,
   syncTriggerName,
-  syncTriggerFunctionName,
   expandDeployTemplate,
   expandRevertTemplate,
   expandVerifyTemplate,
@@ -33,7 +30,6 @@ import {
   contractRevertTemplate,
   contractVerifyTemplate,
   parseExpandArgs,
-  validateExpandOptions,
   inferOperation,
   generateExpandContract,
   type ExpandContractConfig,
@@ -43,22 +39,12 @@ import {
   forwardSyncExpression,
   reverseSyncExpression,
   generateTriggerFunctionBody,
-  generateCreateFunction,
   generateCreateTrigger,
-  generateCreateSQL,
-  generateDropTrigger,
-  generateDropFunction,
-  generateDropSQL,
   generateSyncTrigger,
-  configToTriggerOptions,
-  validateTriggerOptions,
-  generateSyncTriggerSafe,
   type SyncTriggerOptions,
 } from "../../src/expand-contract/triggers";
 
 import {
-  isExpandChange,
-  isContractChange,
   isExpandContractChange,
   extractBaseName,
   expandChangeName,

--- a/tests/unit/log.test.ts
+++ b/tests/unit/log.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, spyOn, mock } from "bun:test";
-import { resetConfig, setConfig } from "../../src/output";
+import { resetConfig } from "../../src/output";
+import type { Event } from "../../src/db/registry";
 
 // ---------------------------------------------------------------------------
 // Mock pg/lib/client — same approach as registry.test.ts
@@ -100,7 +101,7 @@ function captureWrites() {
 }
 
 // Sample event data
-function makeSampleEvent(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+function makeSampleEvent(overrides: Partial<Event> = {}): Event {
   return {
     event: "deploy",
     change_id: "abc123",

--- a/tests/unit/no-snapshot.test.ts
+++ b/tests/unit/no-snapshot.test.ts
@@ -178,18 +178,11 @@ const SINGLE_CHANGE_PLAN = `%syntax-version=1.0.0
 create_schema 2025-01-01T00:00:00Z Test User <test@example.com> # Create schema
 `;
 
-const TWO_CHANGE_PLAN = `%syntax-version=1.0.0
-%project=myproject
-
-create_schema 2025-01-01T00:00:00Z Test User <test@example.com> # Create schema
-add_users [create_schema] 2025-01-02T00:00:00Z Test User <test@example.com> # Add users table
-`;
-
 /**
  * Create a tracking PsqlRunner that records calls and their arguments/content.
  */
 function createTrackingPsqlRunner(failOnScripts: string[] = []): {
-  runner: PsqlRunner;
+  runner: InstanceType<typeof PsqlRunner>;
   calls: Array<{ scriptFile: string; args: string[]; content?: string }>;
 } {
   const calls: Array<{ scriptFile: string; args: string[]; content?: string }> = [];

--- a/tests/unit/output.test.ts
+++ b/tests/unit/output.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { describe, it, expect, beforeEach, spyOn } from "bun:test";
 import {
   setConfig,
   getConfig,

--- a/tests/unit/parser-spike.test.ts
+++ b/tests/unit/parser-spike.test.ts
@@ -439,9 +439,9 @@ describe("libpg-query WASM parser spike", () => {
       }
 
       times.sort((a, b) => a - b);
-      const median = times[Math.floor(times.length / 2)];
-      const min = times[0];
-      const max = times[times.length - 1];
+      const median = times[Math.floor(times.length / 2)]!;
+      const min = times[0]!;
+      const max = times[times.length - 1]!;
 
       console.log(
         `\n  Parse benchmark (1000-line SQL, ${iterations} runs):`,
@@ -478,9 +478,9 @@ describe("libpg-query WASM parser spike", () => {
       }
 
       times.sort((a, b) => a - b);
-      const median = times[Math.floor(times.length / 2)];
-      const min = times[0];
-      const max = times[times.length - 1];
+      const median = times[Math.floor(times.length / 2)]!;
+      const min = times[0]!;
+      const max = times[times.length - 1]!;
 
       console.log(
         `\n  parseSync benchmark (1000-line SQL, ${iterations} runs):`,

--- a/tests/unit/plan-cmd.test.ts
+++ b/tests/unit/plan-cmd.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../../src/commands/plan";
 import type { PlanOptions } from "../../src/commands/plan";
 import { parsePlan } from "../../src/plan/parser";
-import type { Plan, Change, Tag } from "../../src/plan/types";
+import type { Plan } from "../../src/plan/types";
 import { resetConfig, setConfig } from "../../src/output";
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/plan-roundtrip.test.ts
+++ b/tests/unit/plan-roundtrip.test.ts
@@ -13,7 +13,6 @@ import { tmpdir } from "node:os";
 import { parsePlan } from "../../src/plan/parser";
 import {
   serializePlan,
-  serializeChange,
   appendChange,
 } from "../../src/plan/writer";
 import { computeChangeId } from "../../src/plan/types";

--- a/tests/unit/revert.test.ts
+++ b/tests/unit/revert.test.ts
@@ -22,7 +22,7 @@ class MockPgClient {
     this.connected = true;
   }
 
-  async query(text: string, values?: unknown[]) {
+  async query(text: string, values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number; command: string }> {
     this.queries.push({ text, values });
     return { rows: [], rowCount: 0, command: "SELECT" };
   }
@@ -47,7 +47,6 @@ const {
   buildRevertInput,
   confirmRevert,
   runRevert,
-  EXIT_CODE_CONCURRENT,
 } = await import("../../src/commands/revert");
 const { resolveTargetUri } = await import("../../src/commands/shared");
 const { parseArgs } = await import("../../src/cli");

--- a/tests/unit/security-edge-cases.test.ts
+++ b/tests/unit/security-edge-cases.test.ts
@@ -5,13 +5,9 @@
 //
 // Issue: NikolayS/sqlever#130
 
-import { describe, it, expect, beforeAll, beforeEach, afterEach, spyOn } from "bun:test";
-import { EventEmitter } from "events";
+import { describe, it, expect, beforeEach, spyOn } from "bun:test";
 import {
   mkdtempSync,
-  writeFileSync,
-  readFileSync,
-  mkdirSync,
   rmSync,
   symlinkSync,
 } from "node:fs";

--- a/tests/unit/shared.test.ts
+++ b/tests/unit/shared.test.ts
@@ -42,7 +42,6 @@ mock.module("pg/lib/client", () => ({
 const { resolveTargetUri, withDatabase } = await import(
   "../../src/commands/shared"
 );
-const { DatabaseClient } = await import("../../src/db/client");
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/tests/unit/sqitch-compat-deep.test.ts
+++ b/tests/unit/sqitch-compat-deep.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { parsePlan, parseDependencies, PlanParseError } from "../../src/plan/parser";
+import { parsePlan, PlanParseError } from "../../src/plan/parser";
 import {
   computeChangeId,
   computeTagId,
@@ -17,13 +17,10 @@ import {
 } from "../../src/plan/types";
 import {
   parseSqitchConf,
-  confGet,
   confGetString,
   confGetBool,
   confGetAll,
   confListSubsections,
-  confGetSection,
-  serializeSqitchConf,
 } from "../../src/config/sqitch-conf";
 import { parseArgs } from "../../src/cli";
 
@@ -38,16 +35,6 @@ function minimalPlan(lines: string[] = []): string {
   return [
     "%syntax-version=1.0.0",
     "%project=testproject",
-    "",
-    ...lines,
-  ].join("\n");
-}
-
-function planWithUri(lines: string[] = []): string {
-  return [
-    "%syntax-version=1.0.0",
-    "%project=testproject",
-    "%uri=https://example.com/testproject",
     "",
     ...lines,
   ].join("\n");
@@ -651,10 +638,11 @@ describe("command flag parsing — parseArgs", () => {
     expect(args.help).toBe(true);
     expect(args.command).toBeUndefined();
 
-    const args2 = parseArgs(["deploy", "--help"]);
+    const helpArgs = parseArgs(["deploy", "--help"]);
     // --help is a global flag consumed by parseArgs, not passed to rest
     // Actually, looking at cli.ts, --help is handled BEFORE command dispatch
     // The parseArgs function sets args.help = true
+    expect(helpArgs.help).toBe(true);
   });
 
   it("15: --version / -V flag", () => {


### PR DESCRIPTION
## Summary

- Remove all unused imports, variables, and function declarations (TS6133/TS6192/TS6196) across 26 test files
- Fix fetch mock type casts by routing through `unknown` (TS2352) in ai-dblab-deep tests
- Add non-null assertions for array index accesses flagged by `noUncheckedIndexedAccess` (TS18048)
- Fix MockPgClient `query()` return types from inferred `never[]` to explicit `unknown[]` (TS2322) in 5 test files
- Replace `PsqlRunner` value used as type with `InstanceType<typeof PsqlRunner>` (TS2749) in 5 test files
- Fix `Event` type in log tests by importing the proper interface (TS2769)
- Narrow `SignalCheckFn` return literal with `as const` (TS2322)

No production code was changed -- all fixes are in test files. No `any` casts or `@ts-ignore`/`@ts-expect-error` suppressions were used.

**Before:** 137 errors from `bun x tsc --noEmit`
**After:** 0 errors

Closes #182

## Test plan

- [x] `bun x tsc --noEmit` exits with 0 errors
- [x] `bun test tests/unit/` -- all 3034 tests pass (0 failures)


Generated with [Claude Code](https://claude.com/claude-code)