### PR TITLE
feat(analysis): add human-readable rule names for inline suppression

### DIFF
--- a/src/analysis/index.ts
+++ b/src/analysis/index.ts
@@ -180,6 +180,9 @@ export class Analyzer {
 
       try {
         const findings = rule.check(context);
+        for (const finding of findings) {
+          finding.ruleName = rule.name;
+        }
         allFindings.push(...findings);
       } catch (err: unknown) {
         // Rule threw an error — report it as an internal finding
@@ -220,6 +223,7 @@ export class Analyzer {
     const directives = parseSuppressions(originalSql);
     const sqlLines = originalSql.split("\n");
     const knownRuleIds = new Set(this.registry.ids());
+    const nameToId = this.registry.nameToIdMap();
     const { ranges, warnings: directiveWarnings } =
       resolveSuppressionRanges(
         directives,
@@ -227,6 +231,7 @@ export class Analyzer {
         sqlLines.length,
         knownRuleIds,
         filePath,
+        nameToId,
       );
 
     // 8. Filter findings through suppressions

--- a/src/analysis/registry.ts
+++ b/src/analysis/registry.ts
@@ -64,6 +64,17 @@ export class RuleRegistry {
   }
 
   /**
+   * Return a map from human-readable rule name to rule ID.
+   */
+  nameToIdMap(): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const rule of this.rules.values()) {
+      map.set(rule.name, rule.id);
+    }
+    return map;
+  }
+
+  /**
    * Number of registered rules.
    */
   get size(): number {

--- a/src/analysis/reporter.ts
+++ b/src/analysis/reporter.ts
@@ -20,6 +20,8 @@ export interface Location {
 
 export interface Finding {
   ruleId: string;
+  /** Human-readable rule name, e.g., "add-column-not-null". */
+  ruleName?: string;
   severity: Severity;
   message: string;
   location: Location;
@@ -43,6 +45,7 @@ export interface JsonReport {
   metadata: ReportMetadata;
   findings: Array<{
     ruleId: string;
+    ruleName?: string;
     severity: Severity;
     message: string;
     location: Location;
@@ -143,9 +146,10 @@ export function formatText(
 
   for (const f of findings) {
     const sevLabel = severityLabel(f.severity, useColors);
+    const ruleLabel = f.ruleName ? `${f.ruleId}/${f.ruleName}` : f.ruleId;
     const ruleId = useColors
-      ? colorize(f.ruleId, ANSI.dim)
-      : f.ruleId;
+      ? colorize(ruleLabel, ANSI.dim)
+      : ruleLabel;
     lines.push(`  ${sevLabel} ${ruleId}: ${f.message}`);
 
     const loc = `${f.location.file}:${f.location.line}:${f.location.column}`;
@@ -223,6 +227,9 @@ export function formatJson(
         message: f.message,
         location: { ...f.location },
       };
+      if (f.ruleName !== undefined) {
+        entry.ruleName = f.ruleName;
+      }
       if (f.suggestion !== undefined) {
         entry.suggestion = f.suggestion;
       }
@@ -252,9 +259,10 @@ export function formatGithubAnnotations(findings: readonly Finding[]): string {
   for (const f of findings) {
     const level = ghAnnotationLevel(f.severity);
     const loc = `file=${f.location.file},line=${f.location.line},col=${f.location.column}`;
+    const ruleLabel = f.ruleName ? `${f.ruleId}/${f.ruleName}` : f.ruleId;
     const msg = f.suggestion
-      ? `${f.ruleId}: ${f.message} — ${f.suggestion}`
-      : `${f.ruleId}: ${f.message}`;
+      ? `${ruleLabel}: ${f.message} — ${f.suggestion}`
+      : `${ruleLabel}: ${f.message}`;
     lines.push(`::${level} ${loc}::${msg}`);
   }
   return lines.join("\n") + (lines.length > 0 ? "\n" : "");

--- a/src/analysis/rules/SA001.ts
+++ b/src/analysis/rules/SA001.ts
@@ -17,6 +17,7 @@ import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA001: Rule = {
   id: "SA001",
+  name: "add-column-not-null",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA002.ts
+++ b/src/analysis/rules/SA002.ts
@@ -20,6 +20,7 @@ import { containsVolatileFunction, forEachAlterTableCmd } from "../ast-helpers.j
 
 export const SA002: Rule = {
   id: "SA002",
+  name: "add-column-volatile-default",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA002b.ts
+++ b/src/analysis/rules/SA002b.ts
@@ -18,6 +18,7 @@ import { containsVolatileFunction, forEachAlterTableCmd } from "../ast-helpers.j
 
 export const SA002b: Rule = {
   id: "SA002b",
+  name: "add-column-default-pre-11",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA003.ts
+++ b/src/analysis/rules/SA003.ts
@@ -48,6 +48,7 @@ function isSafeCast(_targetTypeName: TypeName | Record<string, unknown> | undefi
 
 export const SA003: Rule = {
   id: "SA003",
+  name: "alter-column-type",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA004.ts
+++ b/src/analysis/rules/SA004.ts
@@ -14,6 +14,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA004: Rule = {
   id: "SA004",
+  name: "create-index-not-concurrently",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA005.ts
+++ b/src/analysis/rules/SA005.ts
@@ -14,6 +14,7 @@ import { extractDropObjectNames } from "../ast-helpers.js";
 
 export const SA005: Rule = {
   id: "SA005",
+  name: "drop-index-not-concurrently",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA006.ts
+++ b/src/analysis/rules/SA006.ts
@@ -16,6 +16,7 @@ import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA006: Rule = {
   id: "SA006",
+  name: "drop-column",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA007.ts
+++ b/src/analysis/rules/SA007.ts
@@ -16,6 +16,7 @@ import { extractDropObjectNames } from "../ast-helpers.js";
 
 export const SA007: Rule = {
   id: "SA007",
+  name: "drop-table",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA008.ts
+++ b/src/analysis/rules/SA008.ts
@@ -18,6 +18,7 @@ import { offsetToLocation, node, nodes } from "../types.js";
 
 export const SA008: Rule = {
   id: "SA008",
+  name: "truncate",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA009.ts
+++ b/src/analysis/rules/SA009.ts
@@ -24,6 +24,7 @@ import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA009: Rule = {
   id: "SA009",
+  name: "add-foreign-key-not-valid",
   severity: "warn",
   type: "hybrid",
 

--- a/src/analysis/rules/SA010.ts
+++ b/src/analysis/rules/SA010.ts
@@ -18,6 +18,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA010: Rule = {
   id: "SA010",
+  name: "dml-without-where",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA011.ts
+++ b/src/analysis/rules/SA011.ts
@@ -20,6 +20,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA011: Rule = {
   id: "SA011",
+  name: "dml-on-large-table",
   severity: "warn",
   type: "connected",
 

--- a/src/analysis/rules/SA012.ts
+++ b/src/analysis/rules/SA012.ts
@@ -15,6 +15,7 @@ import { offsetToLocation, node, nodes } from "../types.js";
 
 export const SA012: Rule = {
   id: "SA012",
+  name: "alter-sequence-restart",
   severity: "info",
   type: "static",
 

--- a/src/analysis/rules/SA013.ts
+++ b/src/analysis/rules/SA013.ts
@@ -99,6 +99,7 @@ function isRiskyDDL(stmt: Record<string, unknown>): { risky: boolean; descriptio
 
 export const SA013: Rule = {
   id: "SA013",
+  name: "missing-lock-timeout",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA014.ts
+++ b/src/analysis/rules/SA014.ts
@@ -16,6 +16,7 @@ import { offsetToLocation, node, nodes } from "../types.js";
 
 export const SA014: Rule = {
   id: "SA014",
+  name: "vacuum-full-or-cluster",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA015.ts
+++ b/src/analysis/rules/SA015.ts
@@ -15,6 +15,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA015: Rule = {
   id: "SA015",
+  name: "alter-table-rename",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA016.ts
+++ b/src/analysis/rules/SA016.ts
@@ -19,6 +19,7 @@ import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA016: Rule = {
   id: "SA016",
+  name: "add-check-not-valid",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA017.ts
+++ b/src/analysis/rules/SA017.ts
@@ -25,6 +25,7 @@ import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA017: Rule = {
   id: "SA017",
+  name: "set-not-null",
   severity: "warn",
   type: "hybrid",
 

--- a/src/analysis/rules/SA018.ts
+++ b/src/analysis/rules/SA018.ts
@@ -22,6 +22,7 @@ import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA018: Rule = {
   id: "SA018",
+  name: "add-primary-key-without-index",
   severity: "warn",
   type: "hybrid",
 

--- a/src/analysis/rules/SA019.ts
+++ b/src/analysis/rules/SA019.ts
@@ -14,6 +14,7 @@ import { offsetToLocation, node, nodes } from "../types.js";
 
 export const SA019: Rule = {
   id: "SA019",
+  name: "reindex-not-concurrently",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA020.ts
+++ b/src/analysis/rules/SA020.ts
@@ -52,6 +52,7 @@ function hasExplicitBegin(ast: ParseResult): boolean {
 
 export const SA020: Rule = {
   id: "SA020",
+  name: "concurrently-in-transaction",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA021.ts
+++ b/src/analysis/rules/SA021.ts
@@ -41,6 +41,7 @@ function lockModeName(mode: number): string {
 
 export const SA021: Rule = {
   id: "SA021",
+  name: "lock-table",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA022.ts
+++ b/src/analysis/rules/SA022.ts
@@ -35,6 +35,7 @@ function extractSchemaNames(
 
 export const SA022: Rule = {
   id: "SA022",
+  name: "drop-schema",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA023.ts
+++ b/src/analysis/rules/SA023.ts
@@ -15,6 +15,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA023: Rule = {
   id: "SA023",
+  name: "drop-database",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA024.ts
+++ b/src/analysis/rules/SA024.ts
@@ -18,6 +18,7 @@ import { offsetToLocation, node, nodes } from "../types.js";
 
 export const SA024: Rule = {
   id: "SA024",
+  name: "drop-cascade",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA025.ts
+++ b/src/analysis/rules/SA025.ts
@@ -17,6 +17,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA025: Rule = {
   id: "SA025",
+  name: "nested-begin",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA026.ts
+++ b/src/analysis/rules/SA026.ts
@@ -78,6 +78,7 @@ function isLongRunningDML(
 
 export const SA026: Rule = {
   id: "SA026",
+  name: "missing-statement-timeout",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA027.ts
+++ b/src/analysis/rules/SA027.ts
@@ -15,6 +15,7 @@ import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA027: Rule = {
   id: "SA027",
+  name: "drop-not-null",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA028.ts
+++ b/src/analysis/rules/SA028.ts
@@ -19,6 +19,7 @@ import { offsetToLocation, node, nodes } from "../types.js";
 
 export const SA028: Rule = {
   id: "SA028",
+  name: "truncate-cascade",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA029.ts
+++ b/src/analysis/rules/SA029.ts
@@ -26,6 +26,7 @@ const SERIAL_TYPES: ReadonlySet<string> = new Set([
 
 export const SA029: Rule = {
   id: "SA029",
+  name: "create-table-serial",
   severity: "info",
   type: "static",
   defaultOff: true,

--- a/src/analysis/rules/SA030.ts
+++ b/src/analysis/rules/SA030.ts
@@ -19,6 +19,7 @@ import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA030: Rule = {
   id: "SA030",
+  name: "add-unique-constraint",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA031.ts
+++ b/src/analysis/rules/SA031.ts
@@ -17,6 +17,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA031: Rule = {
   id: "SA031",
+  name: "alter-type-add-value-in-transaction",
   severity: "error",
   type: "static",
 

--- a/src/analysis/rules/SA032.ts
+++ b/src/analysis/rules/SA032.ts
@@ -14,6 +14,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA032: Rule = {
   id: "SA032",
+  name: "begin-without-commit",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA033.ts
+++ b/src/analysis/rules/SA033.ts
@@ -20,6 +20,7 @@ import { forEachAlterTableCmd } from "../ast-helpers.js";
 
 export const SA033: Rule = {
   id: "SA033",
+  name: "missing-fk-index",
   severity: "info",
   type: "connected",
 

--- a/src/analysis/rules/SA034.ts
+++ b/src/analysis/rules/SA034.ts
@@ -18,6 +18,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA034: Rule = {
   id: "SA034",
+  name: "concurrently-index-validity",
   severity: "info",
   type: "static",
 

--- a/src/analysis/rules/SA035.ts
+++ b/src/analysis/rules/SA035.ts
@@ -33,6 +33,7 @@ function isPkConstraintName(name: string): boolean {
 
 export const SA035: Rule = {
   id: "SA035",
+  name: "drop-primary-key",
   severity: "warn",
   type: "static",
 

--- a/src/analysis/rules/SA036.ts
+++ b/src/analysis/rules/SA036.ts
@@ -24,6 +24,7 @@ import { offsetToLocation, node } from "../types.js";
 
 export const SA036: Rule = {
   id: "SA036",
+  name: "large-dml-without-batching",
   severity: "warn",
   type: "connected",
 

--- a/src/analysis/rules/SA037.ts
+++ b/src/analysis/rules/SA037.ts
@@ -27,6 +27,7 @@ const INT4_TYPES = new Set(["int4", "integer", "int", "serial"]);
 
 export const SA037: Rule = {
   id: "SA037",
+  name: "int-pk-capacity",
   severity: "info",
   type: "static",
 

--- a/src/analysis/rules/SA038.ts
+++ b/src/analysis/rules/SA038.ts
@@ -28,6 +28,7 @@ function getColName(colDef: Record<string, unknown>): string {
 
 export const SA038: Rule = {
   id: "SA038",
+  name: "prefer-text-over-varchar",
   severity: "info",
   type: "static",
 

--- a/src/analysis/rules/SA039.ts
+++ b/src/analysis/rules/SA039.ts
@@ -32,6 +32,7 @@ function hasPrimaryKey(constraints: Record<string, unknown>[]): boolean {
 
 export const SA039: Rule = {
   id: "SA039",
+  name: "prefer-bigint-pk",
   severity: "info",
   type: "static",
 

--- a/src/analysis/rules/SA040.ts
+++ b/src/analysis/rules/SA040.ts
@@ -32,6 +32,7 @@ function isSerialType(typeName: Record<string, unknown>): string | null {
 
 export const SA040: Rule = {
   id: "SA040",
+  name: "prefer-identity-over-serial",
   severity: "info",
   type: "static",
 

--- a/src/analysis/rules/SA041.ts
+++ b/src/analysis/rules/SA041.ts
@@ -39,6 +39,7 @@ function isTimestampWithoutTz(typeName: Record<string, unknown>): boolean {
 
 export const SA041: Rule = {
   id: "SA041",
+  name: "prefer-timestamptz",
   severity: "info",
   type: "static",
 

--- a/src/analysis/rules/SA042.ts
+++ b/src/analysis/rules/SA042.ts
@@ -15,6 +15,7 @@ import type { StringNode } from "../types.js";
 
 export const SA042: Rule = {
   id: "SA042",
+  name: "prefer-if-not-exists",
   severity: "info",
   type: "static",
 

--- a/src/analysis/suppression.ts
+++ b/src/analysis/suppression.ts
@@ -11,9 +11,10 @@
 //   UPDATE users SET tier = 'free'; -- sqlever:disable SA010
 //
 // Rules:
-// - Comma-separated rule IDs: -- sqlever:disable SA010,SA011
+// - Comma-separated rule IDs or names: -- sqlever:disable SA010,dml-without-where
+// - Human-readable kebab-case names are resolved to rule IDs
 // - "all" keyword is NOT supported (too dangerous)
-// - Unknown rule IDs produce warnings
+// - Unknown rule IDs/names produce warnings
 // - Unclosed blocks extend to EOF and produce a warning
 // - Unused suppressions produce warnings
 
@@ -52,11 +53,12 @@ export interface SuppressionRange {
 /**
  * Regex for suppression comments.
  * Matches: -- sqlever:disable SA001,SA002
+ *          -- sqlever:disable add-column-not-null
  *          -- sqlever:enable SA001
- * Captures: [1] = "disable" | "enable", [2] = comma-separated rule IDs
+ * Captures: [1] = "disable" | "enable", [2] = comma-separated rule IDs or names
  */
 const SUPPRESSION_RE =
-  /--\s*sqlever:(disable|enable)\s+([\w,\s]+)/;
+  /--\s*sqlever:(disable|enable)\s+([\w\-,\s]+)/;
 
 /**
  * Parse all suppression directives from the raw SQL text.
@@ -117,6 +119,9 @@ function isSingleLineDirective(
 /**
  * Resolve suppression directives into line ranges.
  *
+ * Accepts both numeric rule IDs (SA001) and human-readable names
+ * (add-column-not-null). Names are resolved to IDs via the nameToId map.
+ *
  * Returns:
  * - An array of SuppressionRange objects
  * - An array of warning findings for issues like unknown rules, unclosed blocks
@@ -127,28 +132,38 @@ export function resolveSuppressionRanges(
   totalLines: number,
   knownRuleIds: Set<string>,
   filePath: string,
+  nameToId?: Map<string, string>,
 ): { ranges: SuppressionRange[]; warnings: Finding[] } {
   const ranges: SuppressionRange[] = [];
   const warnings: Finding[] = [];
+  const resolvedNameToId = nameToId ?? new Map<string, string>();
 
   // Track open blocks per rule ID: ruleId -> opening directive
   const openBlocks = new Map<string, SuppressionDirective>();
 
   for (const directive of directives) {
-    // Warn about unknown rule IDs
-    for (const ruleId of directive.ruleIds) {
-      if (!knownRuleIds.has(ruleId)) {
+    // Resolve names to IDs in the directive's ruleIds
+    const resolvedIds = directive.ruleIds.map((idOrName) => {
+      const resolved = resolvedNameToId.get(idOrName);
+      return resolved ?? idOrName;
+    });
+
+    // Warn about unknown rule IDs/names
+    for (let i = 0; i < directive.ruleIds.length; i++) {
+      const resolved = resolvedIds[i]!;
+      const original = directive.ruleIds[i]!;
+      if (!knownRuleIds.has(resolved)) {
         warnings.push({
           ruleId: "suppression",
           severity: "warn",
-          message: `Unknown rule ID "${ruleId}" in suppression comment.`,
+          message: `Unknown rule ID "${original}" in suppression comment.`,
           location: { file: filePath, line: directive.line, column: 1 },
         });
       }
     }
 
     // Warn about "all" keyword
-    if (directive.ruleIds.includes("all")) {
+    if (resolvedIds.includes("all")) {
       warnings.push({
         ruleId: "suppression",
         severity: "warn",
@@ -160,7 +175,7 @@ export function resolveSuppressionRanges(
 
     if (isSingleLineDirective(directive, sqlLines)) {
       // Single-line form: suppresses findings on THIS line only
-      for (const ruleId of directive.ruleIds) {
+      for (const ruleId of resolvedIds) {
         ranges.push({
           ruleId,
           startLine: directive.line,
@@ -171,12 +186,12 @@ export function resolveSuppressionRanges(
       }
     } else if (directive.action === "disable") {
       // Block form: open a suppression block
-      for (const ruleId of directive.ruleIds) {
+      for (const ruleId of resolvedIds) {
         openBlocks.set(ruleId, directive);
       }
     } else {
       // enable: close any matching open blocks
-      for (const ruleId of directive.ruleIds) {
+      for (const ruleId of resolvedIds) {
         const openDirective = openBlocks.get(ruleId);
         if (openDirective) {
           ranges.push({

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -103,6 +103,8 @@ export type Location = FindingLocation;
 /** A single finding produced by a rule. */
 export interface Finding {
   ruleId: string;
+  /** Human-readable rule name, attached by the analyzer after rule execution. */
+  ruleName?: string;
   severity: Severity;
   message: string;
   location: FindingLocation;
@@ -197,6 +199,8 @@ export type RuleType = "static" | "connected" | "hybrid";
 export interface Rule {
   /** Unique rule identifier, e.g., "SA001". */
   id: string;
+  /** Human-readable kebab-case name, e.g., "add-column-not-null". */
+  name: string;
   /** Default severity level. */
   severity: Severity;
   /** Whether this rule is static, connected, or hybrid. */

--- a/tests/unit/analysis-index.test.ts
+++ b/tests/unit/analysis-index.test.ts
@@ -27,6 +27,7 @@ const TMP_DIR = join(import.meta.dir, "..", ".tmp-analysis-tests");
 function selectRule(): Rule {
   return {
     id: "TEST001",
+    name: "test-select",
     severity: "warn",
     type: "static",
     check(ctx: AnalysisContext): Finding[] {
@@ -62,6 +63,7 @@ function selectRule(): Rule {
 function createTableRule(): Rule {
   return {
     id: "TEST002",
+    name: "test-create-table",
     severity: "error",
     type: "static",
     check(ctx: AnalysisContext): Finding[] {
@@ -91,6 +93,7 @@ function createTableRule(): Rule {
 function connectedRule(): Rule {
   return {
     id: "TEST003",
+    name: "test-connected",
     severity: "warn",
     type: "connected",
     check(ctx: AnalysisContext): Finding[] {
@@ -300,6 +303,7 @@ describe("Analyzer", () => {
     test("handles rule that throws an error gracefully", () => {
       const throwingRule: Rule = {
         id: "THROW001",
+        name: "test-throw",
         severity: "error",
         type: "static",
         check(): Finding[] {
@@ -330,6 +334,7 @@ describe("Analyzer", () => {
       let capturedVersion = 0;
       const versionRule: Rule = {
         id: "VERSION001",
+        name: "test-version",
         severity: "info",
         type: "static",
         check(ctx: AnalysisContext): Finding[] {
@@ -346,6 +351,7 @@ describe("Analyzer", () => {
       let capturedVersion = 0;
       const versionRule: Rule = {
         id: "VERSION001",
+        name: "test-version",
         severity: "info",
         type: "static",
         check(ctx: AnalysisContext): Finding[] {

--- a/tests/unit/analysis-registry.test.ts
+++ b/tests/unit/analysis-registry.test.ts
@@ -9,6 +9,7 @@ import type { Rule, Finding, AnalysisContext } from "../../src/analysis/types";
 function makeRule(id: string, type: "static" | "connected" | "hybrid" = "static"): Rule {
   return {
     id,
+    name: `test-${id.toLowerCase()}`,
     severity: "warn",
     type,
     check(_ctx: AnalysisContext): Finding[] {

--- a/tests/unit/analysis-suppression.test.ts
+++ b/tests/unit/analysis-suppression.test.ts
@@ -346,3 +346,185 @@ describe("filterFindings", () => {
     expect(warnings[0]!.message).toContain("Unknown rule ID");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Name-based suppression
+// ---------------------------------------------------------------------------
+
+describe("name-based suppression", () => {
+  const knownRules = new Set(["SA001", "SA010", "SA011"]);
+  const nameToId = new Map([
+    ["add-column-not-null", "SA001"],
+    ["dml-without-where", "SA010"],
+    ["dml-on-large-table", "SA011"],
+  ]);
+
+  describe("parseSuppressions with rule names", () => {
+    test("parses a disable directive using a rule name", () => {
+      const sql = "-- sqlever:disable add-column-not-null\nSELECT 1;";
+      const directives = parseSuppressions(sql);
+      expect(directives).toHaveLength(1);
+      expect(directives[0]!.action).toBe("disable");
+      expect(directives[0]!.ruleIds).toEqual(["add-column-not-null"]);
+    });
+
+    test("parses mixed IDs and names", () => {
+      const sql = "-- sqlever:disable SA010,add-column-not-null";
+      const directives = parseSuppressions(sql);
+      expect(directives).toHaveLength(1);
+      expect(directives[0]!.ruleIds).toEqual(["SA010", "add-column-not-null"]);
+    });
+
+    test("parses enable directive with a rule name", () => {
+      const sql = "SELECT 1;\n-- sqlever:enable dml-without-where";
+      const directives = parseSuppressions(sql);
+      expect(directives).toHaveLength(1);
+      expect(directives[0]!.action).toBe("enable");
+      expect(directives[0]!.ruleIds).toEqual(["dml-without-where"]);
+    });
+  });
+
+  describe("resolveSuppressionRanges with rule names", () => {
+    test("resolves block form using rule name", () => {
+      const sql = [
+        "-- sqlever:disable dml-without-where",
+        "UPDATE users SET tier = 'free';",
+        "-- sqlever:enable dml-without-where",
+      ].join("\n");
+
+      const directives = parseSuppressions(sql);
+      const sqlLines = sql.split("\n");
+      const { ranges, warnings } = resolveSuppressionRanges(
+        directives,
+        sqlLines,
+        sqlLines.length,
+        knownRules,
+        FILE,
+        nameToId,
+      );
+
+      expect(ranges).toHaveLength(1);
+      expect(ranges[0]!.ruleId).toBe("SA010");
+      expect(ranges[0]!.startLine).toBe(1);
+      expect(ranges[0]!.endLine).toBe(3);
+      expect(warnings).toHaveLength(0);
+    });
+
+    test("resolves single-line form using rule name", () => {
+      const sql =
+        "UPDATE users SET tier = 'free'; -- sqlever:disable dml-without-where";
+      const directives = parseSuppressions(sql);
+      const sqlLines = sql.split("\n");
+      const { ranges } = resolveSuppressionRanges(
+        directives,
+        sqlLines,
+        sqlLines.length,
+        knownRules,
+        FILE,
+        nameToId,
+      );
+
+      expect(ranges).toHaveLength(1);
+      expect(ranges[0]!.ruleId).toBe("SA010");
+      expect(ranges[0]!.startLine).toBe(1);
+      expect(ranges[0]!.endLine).toBe(1);
+    });
+
+    test("resolves mixed IDs and names in same directive", () => {
+      const sql = [
+        "-- sqlever:disable SA011,dml-without-where",
+        "UPDATE users SET tier = 'free';",
+        "-- sqlever:enable SA011,dml-without-where",
+      ].join("\n");
+
+      const directives = parseSuppressions(sql);
+      const sqlLines = sql.split("\n");
+      const { ranges, warnings } = resolveSuppressionRanges(
+        directives,
+        sqlLines,
+        sqlLines.length,
+        knownRules,
+        FILE,
+        nameToId,
+      );
+
+      expect(ranges).toHaveLength(2);
+      const ruleIds = ranges.map((r) => r.ruleId).sort();
+      expect(ruleIds).toEqual(["SA010", "SA011"]);
+      expect(warnings).toHaveLength(0);
+    });
+
+    test("warns on unknown rule name", () => {
+      const sql = "-- sqlever:disable unknown-rule-name\nSELECT 1;";
+      const directives = parseSuppressions(sql);
+      const sqlLines = sql.split("\n");
+      const { warnings } = resolveSuppressionRanges(
+        directives,
+        sqlLines,
+        sqlLines.length,
+        knownRules,
+        FILE,
+        nameToId,
+      );
+
+      const unknownWarnings = warnings.filter((w) =>
+        w.message.includes("Unknown rule ID"),
+      );
+      expect(unknownWarnings.length).toBeGreaterThan(0);
+      expect(unknownWarnings[0]!.message).toContain("unknown-rule-name");
+    });
+
+    test("name-based suppression filters findings correctly", () => {
+      const sql = [
+        "-- sqlever:disable dml-without-where",
+        "UPDATE users SET tier = 'free';",
+        "-- sqlever:enable dml-without-where",
+      ].join("\n");
+
+      const directives = parseSuppressions(sql);
+      const sqlLines = sql.split("\n");
+      const { ranges, warnings: directiveWarnings } =
+        resolveSuppressionRanges(
+          directives,
+          sqlLines,
+          sqlLines.length,
+          knownRules,
+          FILE,
+          nameToId,
+        );
+
+      const findings = [makeFinding("SA010", 2)];
+      const { filtered, suppressed } = filterFindings(
+        findings,
+        ranges,
+        directiveWarnings,
+      );
+
+      expect(filtered).toHaveLength(0);
+      expect(suppressed).toHaveLength(1);
+      expect(suppressed[0]!.ruleId).toBe("SA010");
+    });
+
+    test("works without nameToId map (backward compatible)", () => {
+      const sql = [
+        "-- sqlever:disable SA010",
+        "UPDATE users SET tier = 'free';",
+        "-- sqlever:enable SA010",
+      ].join("\n");
+
+      const directives = parseSuppressions(sql);
+      const sqlLines = sql.split("\n");
+      const { ranges, warnings } = resolveSuppressionRanges(
+        directives,
+        sqlLines,
+        sqlLines.length,
+        knownRules,
+        FILE,
+      );
+
+      expect(ranges).toHaveLength(1);
+      expect(ranges[0]!.ruleId).toBe("SA010");
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/analysis-types.test.ts
+++ b/tests/unit/analysis-types.test.ts
@@ -54,6 +54,7 @@ describe("analysis types", () => {
   test("Rule interface can be implemented", () => {
     const rule: Rule = {
       id: "SA999",
+      name: "test-rule",
       severity: "warn",
       type: "static",
       check(_context: AnalysisContext): Finding[] {


### PR DESCRIPTION
## Summary

- Add a `name` field (kebab-case) to the Rule interface so users can write `-- sqlever:disable add-column-not-null` instead of remembering numeric IDs like `SA001`
- Both ID and name forms are accepted in suppression comments and can be mixed (e.g. `-- sqlever:disable SA010,add-column-not-null`)
- Reporter now shows names alongside IDs in all output formats (text, JSON, GitHub annotations)

### Rule name mapping

| ID | Name |
|---|---|
| SA001 | add-column-not-null |
| SA002 | add-column-volatile-default |
| SA002b | add-column-default-pre-11 |
| SA003 | alter-column-type |
| SA004 | create-index-not-concurrently |
| SA005 | drop-index-not-concurrently |
| SA006 | drop-column |
| SA007 | drop-table |
| SA008 | truncate |
| SA009 | add-foreign-key-not-valid |
| SA010 | dml-without-where |
| SA011 | dml-on-large-table |
| SA012 | alter-sequence-restart |
| SA013 | missing-lock-timeout |
| SA014 | vacuum-full-or-cluster |
| SA015 | alter-table-rename |
| SA016 | add-check-not-valid |
| SA017 | set-not-null |
| SA018 | add-primary-key-without-index |
| SA019 | reindex-not-concurrently |
| SA020 | concurrently-in-transaction |
| SA021 | lock-table |
| SA022 | drop-schema |
| SA023 | drop-database |
| SA024 | drop-cascade |
| SA025 | nested-begin |
| SA026 | missing-statement-timeout |
| SA027 | drop-not-null |
| SA028 | truncate-cascade |
| SA029 | create-table-serial |
| SA030 | add-unique-constraint |
| SA031 | alter-type-add-value-in-transaction |
| SA032 | begin-without-commit |
| SA033 | missing-fk-index |
| SA034 | concurrently-index-validity |
| SA035 | drop-primary-key |
| SA036 | large-dml-without-batching |
| SA037 | int-pk-capacity |
| SA038 | prefer-text-over-varchar |
| SA039 | prefer-bigint-pk |
| SA040 | prefer-identity-over-serial |
| SA041 | prefer-timestamptz |
| SA042 | prefer-if-not-exists |

## Test plan

- [x] All 3,043 existing unit tests pass
- [x] 9 new tests for name-based suppression (parsing, resolution, filtering, backward compatibility)
- [x] No new TypeScript errors in source files
- [ ] CI passes on all PG versions

Closes #175