### PR TITLE
fix(test): git branch merge test CI compatibility

### DIFF
--- a/tests/unit/git-correlated-includes.test.ts
+++ b/tests/unit/git-correlated-includes.test.ts
@@ -33,7 +33,7 @@ function makeTempDir(): string {
 
 function initGitRepo(): string {
   const dir = makeTempDir();
-  execSync("git init", { cwd: dir, stdio: "ignore" });
+  execSync("git init -b main", { cwd: dir, stdio: "ignore" });
   execSync('git config user.email "test@sqlever.dev"', {
     cwd: dir,
     stdio: "ignore",


### PR DESCRIPTION
## Summary

- Use `git init -b main` instead of `git init` in the `initGitRepo()` helper in `git-correlated-includes.test.ts`
- Without this, CI environments where git's `init.defaultBranch` is unset default to `master`, causing the "handles file on a branch merged back to main" test to fail when it runs `git checkout main`
- The test creates its own temporary git repo and later does `git checkout main` after branching, which requires the initial branch to actually be named `main`

## Test plan

- [x] Verified the failing test now passes locally: `bun test tests/unit/git-correlated-includes.test.ts`
- [x] Full unit test suite passes: 3314 tests, 0 failures
- [x] Type-check passes for the modified file (pre-existing errors in other files are unrelated)
- [ ] CI should pass on this PR (the fix targets the CI failure root cause)

Generated with [Claude Code](https://claude.com/claude-code)