### PR TITLE
fix: spec minor issues + red tests for schema diff (5.12)

### DIFF
--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -831,14 +831,15 @@ Unsafe:
 ```sql
 ALTER TABLE users ADD COLUMN tier text NOT NULL DEFAULT 'free';
 ```
-Safe rewrite — 3 steps, 3 separate transactions:
+Safe rewrite — 4 steps, 4 separate transactions:
 ```sql
 -- Step 1: add nullable column (fast, no rewrite)
 ALTER TABLE users ADD COLUMN tier text;
 -- Step 2: backfill (batched DML, see 5.5; not inline)
 UPDATE users SET tier = 'free' WHERE tier IS NULL;
--- Step 3: set constraint after backfill complete
+-- Step 3: set NOT NULL after backfill complete (acquires AccessExclusiveLock, but fast post-backfill)
 ALTER TABLE users ALTER COLUMN tier SET NOT NULL;
+-- Step 4: set default (metadata-only, safe to run after NOT NULL is confirmed)
 ALTER TABLE users ALTER COLUMN tier SET DEFAULT 'free';
 ```
 Note: PG 11+ with an immutable default is safe as a single step. Version-aware.
@@ -917,9 +918,9 @@ See `pg_cast` catalog for the full list of implicit/assignment casts.
 
 Everything else produces an error with instructions:
 ```
-ERROR ST007: ALTER COLUMN TYPE for users.score (int → bigint) requires a full table rewrite.
+ERROR ST007: ALTER COLUMN TYPE for orders.amount (numeric → int) requires a full table rewrite with USING clause.
 Safe approach: add new column, backfill, swap with expand/contract.
-Use: sqlever scaffold type-change users score int bigint
+Use: sqlever scaffold type-change orders amount numeric int
 ```
 
 ---

--- a/tests/unit/schema-diff.test.ts
+++ b/tests/unit/schema-diff.test.ts
@@ -1,0 +1,85 @@
+// tests/unit/schema-diff.test.ts
+// RED tests for 5.12 offline schema diff
+// These tests define the expected behavior and WILL FAIL until implemented.
+
+import { describe, it, expect } from "bun:test";
+
+// These imports will fail until the module exists — that's expected (RED)
+// import { schemaDiff } from "../../src/commands/schema-diff";
+
+describe("schema diff — offline two-file comparison", () => {
+  it("detects new table", () => {
+    // Given before has no users table, after has it
+    const before = ``;
+    const after = `CREATE TABLE users (id bigint PRIMARY KEY, email text NOT NULL);`;
+    // When we diff
+    // const result = schemaDiff(before, after);
+    // Then output contains CREATE TABLE
+    // expect(result.sql).toContain("CREATE TABLE users");
+    expect(true).toBe(false); // RED: not implemented
+  });
+
+  it("detects dropped table (requires --confirm-destructive)", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("detects new column", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("detects column type change", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("detects new index", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("detects new foreign key", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("detects column nullability change", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("handles column rename hint --rename table.old:new", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("topologically orders output (FKs after tables)", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("applies --safe by default (CREATE INDEX becomes CONCURRENTLY)", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("parses pg_dump --schema-only output", () => {
+    expect(true).toBe(false); // RED
+  });
+});
+
+describe("schema diff — enum handling", () => {
+  it("generates ADD VALUE for new enum values", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("requires --allow-enum-removal for dropped enum values", () => {
+    expect(true).toBe(false); // RED
+  });
+});
+
+describe("schema diff CLI", () => {
+  it("sqlever schema diff <before.sql> <after.sql> exits 0 with diff output", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("sqlever schema diff --out writes to file", () => {
+    expect(true).toBe(false); // RED
+  });
+
+  it("sqlever schema diff --unsafe skips safe rewrites", () => {
+    expect(true).toBe(false); // RED
+  });
+});


### PR DESCRIPTION
Sprint 2 start:
- Fix ST001: split step 3 into SET NOT NULL + SET DEFAULT (separate transactions)
- Fix ST007: error example used safe cast (int→bigint); replace with unsafe (numeric→int)
- Add RED test stubs for 5.12 schema diff — all failing, defines the API surface

These red tests are the TDD anchor for implementing sqlever schema diff.